### PR TITLE
Add return types for DbalConfiguration class methods

### DIFF
--- a/packages/Dbal/src/DbalConnection.php
+++ b/packages/Dbal/src/DbalConnection.php
@@ -5,6 +5,8 @@ namespace Ecotone\Dbal;
 use Doctrine\DBAL\Connection;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\Persistence\ManagerRegistry;
+use Doctrine\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectRepository;
 use Ecotone\Messaging\Support\InvalidArgumentException;
 use Enqueue\Dbal\DbalConnectionFactory;
 use Enqueue\Dbal\ManagerRegistryConnectionFactory;
@@ -35,64 +37,100 @@ class DbalConnection implements ManagerRegistry
         return new ManagerRegistryConnectionFactory($managerRegistry, ['connection_name' => $connectionName]);
     }
 
-    public function getDefaultConnectionName()
+    /**
+     * {@inheritdoc}
+     */
+    public function getDefaultConnectionName(): string
     {
         return 'default';
     }
 
-    public function getConnection($name = null)
+    /**
+     * {@inheritdoc}
+     */
+    public function getConnection($name = null): object
     {
         return $this->connection;
     }
 
-    public function getConnections()
+    /**
+     * {@inheritdoc}
+     */
+    public function getConnections(): array
     {
         return [$this->connection];
     }
 
-    public function getConnectionNames()
+    /**
+     * {@inheritdoc}
+     */
+    public function getConnectionNames(): array
     {
         return ['default'];
     }
 
-    public function getDefaultManagerName()
+    /**
+     * {@inheritdoc}
+     */
+    public function getDefaultManagerName(): string
     {
         return 'default';
     }
 
-    public function getManager($name = null)
+    /**
+     * {@inheritdoc}
+     */
+    public function getManager($name = null): ObjectManager
     {
         return $this->entityManager;
     }
 
-    public function getManagers()
+    /**
+     * {@inheritdoc}
+     */
+    public function getManagers(): array
     {
         return $this->entityManager ? [$this->entityManager] : [];
     }
 
-    public function resetManager($name = null)
+    /**
+     * {@inheritdoc}
+     */
+    public function resetManager($name = null): ObjectManager
     {
         $this->entityManager->getUnitOfWork()->clear();
 
         return $this->entityManager;
     }
 
-    public function getAliasNamespace($alias)
+    /**
+     * @throws InvalidArgumentException
+     */
+    public function getAliasNamespace($alias): string
     {
         throw InvalidArgumentException::create('Method not supported');
     }
 
-    public function getManagerNames()
+    /**
+     * {@inheritdoc}
+     */
+    public function getManagerNames(): array
     {
         return ['default'];
     }
 
-    public function getRepository($persistentObject, $persistentManagerName = null)
+    /**
+     * {@inheritdoc}
+     */
+    public function getRepository($persistentObject, $persistentManagerName = null): ObjectRepository
     {
         return $this->entityManager->getRepository($persistentObject);
     }
 
-    public function getManagerForClass($class)
+    /**
+     * {@inheritdoc}
+     */
+    public function getManagerForClass($class): ?ObjectManager
     {
         return $this->entityManager;
     }


### PR DESCRIPTION
Remove Symfony indirect deprecation notices in integrations tests:

1x: Method "Doctrine\Persistence\ConnectionRegistry::getDefaultConnectionName()" might add "string" as a native return type declaration in the future. Do the same in implementation "Ecotone\Dbal\DbalConnection" now to avoid errors or add an explicit @return annotation to suppress this message.

1x: Method "Doctrine\Persistence\ConnectionRegistry::getConnection()" might add "object" as a native return type declaration in the future. Do the same in implementation "Ecotone\Dbal\DbalConnection" now to avoid errors or add an explicit @return annotation to suppress this message.

1x: Method "Doctrine\Persistence\ConnectionRegistry::getConnections()" might add "array" as a native return type declaration in the future. Do the same in implementation "Ecotone\Dbal\DbalConnection" now to avoid errors or add an explicit @return annotation to suppress this message.

1x: Method "Doctrine\Persistence\ConnectionRegistry::getConnectionNames()" might add "array" as a native return type declaration in the future. Do the same in implementation "Ecotone\Dbal\DbalConnection" now to avoid errors or add an explicit @return annotation to suppress this message.

1x: Method "Doctrine\Persistence\ManagerRegistry::getDefaultManagerName()" might add "string" as a native return type declaration in the future. Do the same in implementation "Ecotone\Dbal\DbalConnection" now to avoid errors or add an explicit @return annotation to suppress this message.

1x: Method "Doctrine\Persistence\ManagerRegistry::getManager()" might add "ObjectManager" as a native return type declaration in the future. Do the same in implementation "Ecotone\Dbal\DbalConnection" now to avoid errors or add an explicit @return annotation to suppress this message.

1x: Method "Doctrine\Persistence\ManagerRegistry::getManagers()" might add "array" as a native return type declaration in the future. Do the same in implementation "Ecotone\Dbal\DbalConnection" now to avoid errors or add an explicit @return annotation to suppress this message.

1x: Method "Doctrine\Persistence\ManagerRegistry::resetManager()" might add "ObjectManager" as a native return type declaration in the future. Do the same in implementation "Ecotone\Dbal\DbalConnection" now to avoid errors or add an explicit @return annotation to suppress this message.

1x: Method "Doctrine\Persistence\ManagerRegistry::getAliasNamespace()" might add "string" as a native return type declaration in the future. Do the same in implementation "Ecotone\Dbal\DbalConnection" now to avoid errors or add an explicit @return annotation to suppress this message.

1x: Method "Doctrine\Persistence\ManagerRegistry::getManagerNames()" might add "array" as a native return type declaration in the future. Do the same in implementation "Ecotone\Dbal\DbalConnection" now to avoid errors or add an explicit @return annotation to suppress this message.

1x: Method "Doctrine\Persistence\ManagerRegistry::getRepository()" might add "ObjectRepository" as a native return type declaration in the future. Do the same in implementation "Ecotone\Dbal\DbalConnection" now to avoid errors or add an explicit @return annotation to suppress this message.

1x: Method "Doctrine\Persistence\ManagerRegistry::getManagerForClass()" might add "?ObjectManager" as a native return type declaration in the future. Do the same in implementation "Ecotone\Dbal\DbalConnection" now to avoid errors or add an explicit @return annotation to suppress this message.