### PR TITLE
projection status IDLE is for situation when projection awaits for new events

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -93,7 +93,7 @@
         "jms/serializer": "^3.17",
         "laminas/laminas-zendframework-bridge": "^1.0.0",
         "laravel/framework": "^9.0",
-        "prooph/pdo-event-store": "^1.15.0",
+        "prooph/pdo-event-store": "^1.15.1",
         "psr/log": "^2.0|^3.0",
         "queue-interop/queue-interop": "^0.8",
         "ramsey/uuid": "^4.0",

--- a/packages/PdoEventSourcing/composer.json
+++ b/packages/PdoEventSourcing/composer.json
@@ -27,7 +27,7 @@
     },
     "require": {
         "ecotone/dbal": "^1.57",
-        "prooph/pdo-event-store": "^1.15.0"
+        "prooph/pdo-event-store": "^1.15.1"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5",

--- a/packages/PdoEventSourcing/src/ProjectionStatus.php
+++ b/packages/PdoEventSourcing/src/ProjectionStatus.php
@@ -7,6 +7,7 @@ final class ProjectionStatus
     public const RUNNING = 'running';
     public const DELETING = 'deleting';
     public const REBUILDING = 'rebuilding';
+    public const IDLE = 'idle';
 
     public function __construct(
         private string $type
@@ -31,5 +32,10 @@ final class ProjectionStatus
     public static function REBUILDING(): self
     {
         return new self(self::REBUILDING);
+    }
+
+    public static function IDLE(): self
+    {
+        return new self(self::IDLE);
     }
 }

--- a/packages/PdoEventSourcing/src/Prooph/LazyProophProjectionManager.php
+++ b/packages/PdoEventSourcing/src/Prooph/LazyProophProjectionManager.php
@@ -116,8 +116,9 @@ class LazyProophProjectionManager implements ProjectionManager
 
         return match ($this->getProjectionManager()->fetchProjectionStatus($name)->getValue()) {
             ProjectionStatus::DELETING, ProjectionStatus::DELETING_INCL_EMITTED_EVENTS => \Ecotone\EventSourcing\ProjectionStatus::DELETING(),
-            ProjectionStatus::STOPPING, ProjectionStatus::IDLE, ProjectionStatus::RUNNING => \Ecotone\EventSourcing\ProjectionStatus::RUNNING(),
-            ProjectionStatus::RESETTING => \Ecotone\EventSourcing\ProjectionStatus::REBUILDING()
+            ProjectionStatus::STOPPING, ProjectionStatus::RUNNING => \Ecotone\EventSourcing\ProjectionStatus::RUNNING(),
+            ProjectionStatus::RESETTING => \Ecotone\EventSourcing\ProjectionStatus::REBUILDING(),
+            ProjectionStatus::IDLE => \Ecotone\EventSourcing\ProjectionStatus::IDLE(),
         };
     }
 

--- a/packages/PdoEventSourcing/tests/Behat/features/event-sourcing.feature
+++ b/packages/PdoEventSourcing/tests/Behat/features/event-sourcing.feature
@@ -54,17 +54,33 @@ Feature: activating as aggregate order entity
         | Test\Ecotone\EventSourcing\Fixture\Ticket                      |
         | Test\Ecotone\EventSourcing\Fixture\TicketWithPollingProjection |
     When I register "alert" ticket 123 with assignation to "Johny"
+    When I register "alert" ticket 124 with assignation to "Johny"
+    When I register "alert" ticket 125 with assignation to "Johny"
+    When I register "alert" ticket 126 with assignation to "Johny"
+    When I register "alert" ticket 127 with assignation to "Johny"
     When I run endpoint with name "inProgressTicketList"
     Then I should see tickets in progress:
       | ticket_id  | ticket_type    |
       | 123        | alert          |
+      | 124        | alert          |
+      | 125        | alert          |
+      | 126        | alert          |
+      | 127        | alert          |
     When I close ticket with id 123
     Then I should see tickets in progress:
       | ticket_id  | ticket_type    |
       | 123        | alert          |
+      | 124        | alert          |
+      | 125        | alert          |
+      | 126        | alert          |
+      | 127        | alert          |
     And I run endpoint with name "inProgressTicketList"
     Then I should see tickets in progress:
       | ticket_id  | ticket_type    |
+      | 124        | alert          |
+      | 125        | alert          |
+      | 126        | alert          |
+      | 127        | alert          |
 
   Scenario: I verify building asynchronous event driven projection
     Given I active messaging for namespaces
@@ -150,16 +166,23 @@ Feature: activating as aggregate order entity
     Given I active messaging for namespaces
       | Test\Ecotone\EventSourcing\Fixture\Ticket                      |
       | Test\Ecotone\EventSourcing\Fixture\TicketWithSynchronousEventDrivenProjection                      |
-      | Test\Ecotone\EventSourcing\Fixture\TicketWithLimitedLoad                      |
     When I register "alert" ticket 1234 with assignation to "Marcus"
     And I register "alert" ticket 1235 with assignation to "Andrew"
     And I register "alert" ticket 1236 with assignation to "Andrew"
+    And I register "info" ticket 1237 with assignation to "Thomas"
+    And I register "info" ticket 1238 with assignation to "Peter"
+    And I register "info" ticket 1239 with assignation to "Maik"
+    And I register "warning" ticket 1240 with assignation to "Jack"
     When I reset the projection for in progress tickets
     Then I should see tickets in progress:
-      | ticket_id  | ticket_type    |
-      | 1234       | alert          |
-      | 1235      | alert          |
-      | 1236      | alert          |
+      | ticket_id | ticket_type |
+      | 1234      | alert       |
+      | 1235      | alert       |
+      | 1236      | alert       |
+      | 1237      | info        |
+      | 1238      | info        |
+      | 1239      | info        |
+      | 1240      | warning     |
 
   Scenario: Catching up events after reset the asynchronous event-driven projection
     Given I active messaging for namespaces
@@ -169,6 +192,10 @@ Feature: activating as aggregate order entity
     When I register "alert" ticket 1234 with assignation to "Marcus"
     And I register "alert" ticket 1235 with assignation to "Andrew"
     And I register "alert" ticket 1236 with assignation to "Andrew"
+    And I register "info" ticket 1237 with assignation to "Thomas"
+    And I register "info" ticket 1238 with assignation to "Peter"
+    And I register "info" ticket 1239 with assignation to "Maik"
+    And I register "warning" ticket 1240 with assignation to "Jack"
     And I run endpoint with name "asynchronous_projections"
     And I reset the projection for in progress tickets
     And I run endpoint with name "asynchronous_projections"
@@ -177,6 +204,10 @@ Feature: activating as aggregate order entity
       | 1234       | alert          |
       | 1235      | alert          |
       | 1236      | alert          |
+      | 1237      | info          |
+      | 1238      | info          |
+      | 1239      | info          |
+      | 1240      | warning          |
 
   Scenario: I verify building projection from event sourced aggregate using custom stream name and simple arrays in projections
     Given I active messaging for namespaces

--- a/packages/PdoEventSourcing/tests/Behat/features/event-sourcing.feature
+++ b/packages/PdoEventSourcing/tests/Behat/features/event-sourcing.feature
@@ -164,8 +164,9 @@ Feature: activating as aggregate order entity
 
   Scenario: Catching up events after reset the synchronous event-driven projection
     Given I active messaging for namespaces
-      | Test\Ecotone\EventSourcing\Fixture\Ticket                      |
-      | Test\Ecotone\EventSourcing\Fixture\TicketWithSynchronousEventDrivenProjection                      |
+      | Test\Ecotone\EventSourcing\Fixture\Ticket                                     |
+      | Test\Ecotone\EventSourcing\Fixture\TicketWithSynchronousEventDrivenProjection |
+      | Test\Ecotone\EventSourcing\Fixture\TicketWithLimitedLoad                      |
     When I register "alert" ticket 1234 with assignation to "Marcus"
     And I register "alert" ticket 1235 with assignation to "Andrew"
     And I register "alert" ticket 1236 with assignation to "Andrew"


### PR DESCRIPTION
without being handled separately resetting projection will stop after second run if load limit is set