### PR TITLE
Making use of Event (with metadata)

### DIFF
--- a/packages/Ecotone/src/Lite/Test/Configuration/MessageCollectorHandler.php
+++ b/packages/Ecotone/src/Lite/Test/Configuration/MessageCollectorHandler.php
@@ -19,17 +19,17 @@ final class MessageCollectorHandler
 
     public function recordEvent(Message $event): void
     {
-        $this->publishedEvents[] = $event;
+        $this->publishedEvents[$event->getHeaders()->getMessageId()] = $event;
     }
 
-    public function recordCommand(Message $event): void
+    public function recordCommand(Message $command): void
     {
-        $this->sentCommands[] = $event;
+        $this->sentCommands[] = $command;
     }
 
-    public function recordQuery(Message $event): void
+    public function recordQuery(Message $query): void
     {
-        $this->sentQueries[] = $event;
+        $this->sentQueries[] = $query;
     }
 
     public function getRecordedEvents(): array
@@ -39,7 +39,7 @@ final class MessageCollectorHandler
 
     public function getRecordedEventMessages(): array
     {
-        $events = $this->publishedEvents;
+        $events = array_values($this->publishedEvents);
         $this->publishedEvents = [];
 
         return $events;
@@ -52,7 +52,7 @@ final class MessageCollectorHandler
 
     public function getRecordedCommandMessages(): array
     {
-        $commands = $this->sentCommands;
+        $commands = array_values($this->sentCommands);
         $this->sentCommands = [];
 
         return $commands;
@@ -93,7 +93,7 @@ final class MessageCollectorHandler
             return [];
         }
 
-        $messages = $this->spiedChannelsMessages[$channelName];
+        $messages = array_values($this->spiedChannelsMessages[$channelName]);
         unset($this->spiedChannelsMessages[$channelName]);
 
         return $messages;

--- a/packages/Ecotone/src/Modelling/InMemoryEventSourcedRepository.php
+++ b/packages/Ecotone/src/Modelling/InMemoryEventSourcedRepository.php
@@ -35,6 +35,8 @@ class InMemoryEventSourcedRepository implements EventSourcedRepository
     {
         $self = static::createEmpty();
 
+        $events = array_map(static fn($event) => Event::create($event), $events);
+
         $self->save($identifiers, $aggregateClassName, $events, [], count($events));
 
         return $self;
@@ -75,6 +77,8 @@ class InMemoryEventSourcedRepository implements EventSourcedRepository
     public function save(array $identifiers, string $aggregateClassName, array $events, array $metadata, int $versionBeforeHandling): void
     {
         $key = $this->getKey($identifiers);
+
+        $events = array_map(static fn(Event $event) => $event->getPayload(), $events);
 
         if (! isset($this->eventsPerAggregate[$aggregateClassName][$key])) {
             $this->eventsPerAggregate[$aggregateClassName][$key] = $events;

--- a/packages/PdoEventSourcing/tests/Integration/EventSourcingRepositoryBuilderTest.php
+++ b/packages/PdoEventSourcing/tests/Integration/EventSourcingRepositoryBuilderTest.php
@@ -13,6 +13,7 @@ use Ecotone\Messaging\Conversion\InMemoryConversionService;
 use Ecotone\Messaging\MessageHeaders;
 use Ecotone\Messaging\Store\Document\DocumentStore;
 use Ecotone\Messaging\Store\Document\InMemoryDocumentStore;
+use Ecotone\Modelling\Event;
 use Ecotone\Modelling\SaveAggregateService;
 use Ecotone\Modelling\SnapshotEvent;
 use Ramsey\Uuid\Uuid;
@@ -50,7 +51,7 @@ class EventSourcingRepositoryBuilderTest extends EventSourcingMessagingTest
                 ->registerInPHPConversion($ticketWasRegisteredEventAsArray, $ticketWasRegisteredEvent),
         ]));
 
-        $repository->save(['ticketId'=> $ticketId], Ticket::class, [$ticketWasRegisteredEvent], [
+        $repository->save(['ticketId'=> $ticketId], Ticket::class, [Event::create($ticketWasRegisteredEvent)], [
             MessageHeaders::MESSAGE_ID => Uuid::uuid4()->toString(),
             MessageHeaders::TIMESTAMP => 1610285647,
         ], 0);
@@ -97,7 +98,7 @@ class EventSourcingRepositoryBuilderTest extends EventSourcingMessagingTest
             DocumentStore::class => $documentStore,
         ]));
 
-        $repository->save(['ticketId'=> $ticketId], Ticket::class, [$ticketWasRegistered, $workerWasAssigned], [
+        $repository->save(['ticketId'=> $ticketId], Ticket::class, [Event::create($ticketWasRegistered), Event::create($workerWasAssigned)], [
             MessageHeaders::TIMESTAMP => 1610285647,
         ], 0);
 
@@ -143,7 +144,7 @@ class EventSourcingRepositoryBuilderTest extends EventSourcingMessagingTest
             DocumentStore::class => $documentStore,
         ]));
 
-        $repository->save(['ticketId'=> $ticketId], Ticket::class, [$ticketWasRegistered, $workerWasAssigned], [
+        $repository->save(['ticketId'=> $ticketId], Ticket::class, [Event::create($ticketWasRegistered), Event::create($workerWasAssigned)], [
             MessageHeaders::TIMESTAMP => 1610285647,
         ], 0);
 
@@ -185,12 +186,12 @@ class EventSourcingRepositoryBuilderTest extends EventSourcingMessagingTest
                 ->registerInPHPConversion($secondTicketWasRegisteredEventAsArray, $secondTicketWasRegisteredEvent),
         ]));
 
-        $repository->save(['ticketId'=> $firstTicketAggregate], Ticket::class, [$firstTicketWasRegisteredEvent], [
+        $repository->save(['ticketId'=> $firstTicketAggregate], Ticket::class, [Event::create($firstTicketWasRegisteredEvent)], [
             MessageHeaders::MESSAGE_ID => Uuid::uuid4()->toString(),
             MessageHeaders::TIMESTAMP => 1610285647,
         ], 0);
 
-        $repository->save(['ticketId'=> $secondTicketAggregate], Ticket::class, [$secondTicketWasRegisteredEvent], [
+        $repository->save(['ticketId'=> $secondTicketAggregate], Ticket::class, [Event::create($secondTicketWasRegisteredEvent)], [
             MessageHeaders::MESSAGE_ID => Uuid::uuid4()->toString(),
             MessageHeaders::TIMESTAMP => 1610285647,
         ], 0);
@@ -237,12 +238,12 @@ class EventSourcingRepositoryBuilderTest extends EventSourcingMessagingTest
                 ->registerInPHPConversion($secondTicketWasRegisteredEventAsArray, $secondTicketWasRegisteredEvent),
         ]));
 
-        $repository->save(['ticketId'=> $firstTicketAggregate], Ticket::class, [$firstTicketWasRegisteredEvent], [
+        $repository->save(['ticketId'=> $firstTicketAggregate], Ticket::class, [Event::create($firstTicketWasRegisteredEvent)], [
             MessageHeaders::MESSAGE_ID => Uuid::uuid4()->toString(),
             MessageHeaders::TIMESTAMP => 1610285647,
         ], 0);
 
-        $repository->save(['ticketId'=> $secondTicketAggregate], Ticket::class, [$secondTicketWasRegisteredEvent], [
+        $repository->save(['ticketId'=> $secondTicketAggregate], Ticket::class, [Event::create($secondTicketWasRegisteredEvent)], [
             MessageHeaders::MESSAGE_ID => Uuid::uuid4()->toString(),
             MessageHeaders::TIMESTAMP => 1610285647,
         ], 0);
@@ -280,7 +281,7 @@ class EventSourcingRepositoryBuilderTest extends EventSourcingMessagingTest
                 ->registerInPHPConversion($ticketWasRegisteredEventAsArray, $ticketWasRegisteredEvent),
         ], true));
 
-        $repository->save(['ticketId'=> $ticketId], Ticket::class, [$ticketWasRegisteredEvent], [
+        $repository->save(['ticketId'=> $ticketId], Ticket::class, [Event::create($ticketWasRegisteredEvent)], [
             MessageHeaders::MESSAGE_ID => Uuid::uuid4()->toString(),
             MessageHeaders::TIMESTAMP => 1610285647,
         ], 0);


### PR DESCRIPTION
- wrapping aggregate events with Event resolves issue with MessageId where saved events had different MessageId than one published and in case of having multiple events published, they all had the same MessageId