### PR TITLE
Do not lookup abstract classes

### DIFF
--- a/packages/Ecotone/src/Messaging/Attribute/IsAbstract.php
+++ b/packages/Ecotone/src/Messaging/Attribute/IsAbstract.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ecotone\Messaging\Attribute;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_CLASS)]
+final class IsAbstract
+{
+
+}

--- a/packages/Ecotone/tests/AnnotationFinder/Fixture/Usage/Attribute/AbstractClass/TestAbstractHandler.php
+++ b/packages/Ecotone/tests/AnnotationFinder/Fixture/Usage/Attribute/AbstractClass/TestAbstractHandler.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Ecotone\AnnotationFinder\Fixture\Usage\Attribute\AbstractClass;
+
+use Test\Ecotone\AnnotationFinder\Fixture\Usage\Attribute\Annotation\MessageEndpoint;
+use Test\Ecotone\AnnotationFinder\Fixture\Usage\Attribute\Annotation\SomeHandlerAnnotation;
+use Test\Ecotone\Modelling\Fixture\HandlerWithAbstractClass\TestCommand;
+
+abstract class TestAbstractHandler
+{
+    #[SomeHandlerAnnotation]
+    public function execute(TestCommand $command): int
+    {
+        return $command->amount;
+    }
+}

--- a/packages/Ecotone/tests/AnnotationFinder/Fixture/Usage/Attribute/AbstractClass/TestHandler.php
+++ b/packages/Ecotone/tests/AnnotationFinder/Fixture/Usage/Attribute/AbstractClass/TestHandler.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Ecotone\AnnotationFinder\Fixture\Usage\Attribute\AbstractClass;
+
+use Test\Ecotone\AnnotationFinder\Fixture\Usage\Attribute\Annotation\MessageEndpoint;
+
+final class TestHandler extends TestAbstractHandler
+{
+
+}

--- a/packages/Ecotone/tests/AnnotationFinder/Unit/FileSystemAttributeAnnotationFinderTest.php
+++ b/packages/Ecotone/tests/AnnotationFinder/Unit/FileSystemAttributeAnnotationFinderTest.php
@@ -10,9 +10,12 @@ use Ecotone\AnnotationFinder\Attribute\Environment;
 use Ecotone\AnnotationFinder\ConfigurationException;
 use Ecotone\AnnotationFinder\FileSystem\AutoloadFileNamespaceParser;
 use Ecotone\AnnotationFinder\FileSystem\FileSystemAnnotationFinder;
+use Ecotone\Messaging\Attribute\IsAbstract;
 use Ecotone\Messaging\Support\InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 use ReflectionException;
+use Test\Ecotone\AnnotationFinder\Fixture\Usage\Attribute\AbstractClass\TestAbstractHandler;
+use Test\Ecotone\AnnotationFinder\Fixture\Usage\Attribute\AbstractClass\TestHandler;
 use Test\Ecotone\AnnotationFinder\Fixture\Usage\Attribute\Annotation\EndpointAnnotationExample;
 use Test\Ecotone\AnnotationFinder\Fixture\Usage\Attribute\Annotation\Extension;
 use Test\Ecotone\AnnotationFinder\Fixture\Usage\Attribute\Annotation\MessageEndpoint;
@@ -325,6 +328,46 @@ class FileSystemAttributeAnnotationFinderTest extends TestCase
                 ),
             ],
             $fileSystemAnnotationRegistrationService->findAnnotatedMethods(SomeHandlerAnnotation::class)
+        );
+    }
+
+    public function test_ignoring_abstract_class_while_fetching_annotated_classes()
+    {
+        $annotation = new SomeHandlerAnnotation();
+
+        $fileSystemAnnotationRegistrationService = $this->createAnnotationRegistrationService($this->getAnnotationNamespacePrefix() . '\\AbstractClass', 'prod');
+
+        $this->assertEquals(
+            [
+                AnnotatedMethod::create(
+                    $annotation,
+                    TestHandler::class,
+                    'execute',
+                    [],
+                    [$annotation]
+                ),
+            ],
+            $fileSystemAnnotationRegistrationService->findAnnotatedMethods(SomeHandlerAnnotation::class)
+        );
+    }
+
+    public function test_interfaces_should_be_found_and_not_treat_as_abstracts()
+    {
+        $annotation = new SomeGatewayExample();
+
+        $fileSystemAnnotationRegistrationService = $this->createAnnotationRegistrationService($this->getAnnotationNamespacePrefix() . '\\MessageEndpoint\\Gateway\\FileSystem', 'prod');
+
+        $this->assertEquals(
+            [
+                AnnotatedMethod::create(
+                    $annotation,
+                    GatewayWithReplyChannelExample::class,
+                    'buy',
+                    [new MessageEndpoint()],
+                    [$annotation]
+                ),
+            ],
+            $fileSystemAnnotationRegistrationService->findAnnotatedMethods(SomeGatewayExample::class)
         );
     }
 

--- a/packages/Ecotone/tests/Modelling/Fixture/HandlerWithAbstractClass/TestAbstractHandler.php
+++ b/packages/Ecotone/tests/Modelling/Fixture/HandlerWithAbstractClass/TestAbstractHandler.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Ecotone\Modelling\Fixture\HandlerWithAbstractClass;
+
+use Ecotone\Modelling\Attribute\CommandHandler;
+
+abstract class TestAbstractHandler
+{
+    #[CommandHandler]
+    public function execute(TestCommand $command): int
+    {
+        return $command->amount;
+    }
+}

--- a/packages/Ecotone/tests/Modelling/Fixture/HandlerWithAbstractClass/TestCommand.php
+++ b/packages/Ecotone/tests/Modelling/Fixture/HandlerWithAbstractClass/TestCommand.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Ecotone\Modelling\Fixture\HandlerWithAbstractClass;
+
+final class TestCommand
+{
+    public function __construct(public int $amount)
+    {
+
+    }
+}

--- a/packages/Ecotone/tests/Modelling/Fixture/HandlerWithAbstractClass/TestHandler.php
+++ b/packages/Ecotone/tests/Modelling/Fixture/HandlerWithAbstractClass/TestHandler.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Ecotone\Modelling\Fixture\HandlerWithAbstractClass;
+
+final class TestHandler extends TestAbstractHandler
+{
+
+}

--- a/packages/Ecotone/tests/Modelling/Unit/ModellingEcotoneLiteTest.php
+++ b/packages/Ecotone/tests/Modelling/Unit/ModellingEcotoneLiteTest.php
@@ -12,6 +12,9 @@ use Test\Ecotone\Modelling\Fixture\CommandEventFlow\CreateMerchant;
 use Test\Ecotone\Modelling\Fixture\CommandEventFlow\Merchant;
 use Test\Ecotone\Modelling\Fixture\CommandEventFlow\MerchantSubscriber;
 use Test\Ecotone\Modelling\Fixture\CommandEventFlow\User;
+use Test\Ecotone\Modelling\Fixture\HandlerWithAbstractClass\TestAbstractHandler;
+use Test\Ecotone\Modelling\Fixture\HandlerWithAbstractClass\TestCommand;
+use Test\Ecotone\Modelling\Fixture\HandlerWithAbstractClass\TestHandler;
 
 /**
  * @internal
@@ -35,6 +38,23 @@ final class ModellingEcotoneLiteTest extends TestCase
             $ecotoneTestSupport
                 ->sendCommand(new CreateMerchant($merchantId))
                 ->sendQueryWithRouting('user.get', metadata: ['aggregate.id' => $merchantId])
+        );
+    }
+
+    public function test_calling_command_handler_with_abstract_class()
+    {
+        $ecotoneLite = EcotoneLite::bootstrapForTesting(
+            [TestHandler::class, TestAbstractHandler::class],
+            [
+                new TestHandler()
+            ],
+            ServiceConfiguration::createWithDefaults()
+                ->withSkippedModulePackageNames(ModulePackageList::allPackages())
+        );
+
+        $this->assertEquals(
+            1,
+            $ecotoneLite->getCommandBus()->send(new TestCommand(1))
         );
     }
 }


### PR DESCRIPTION
In case annotation is put on abstract classes, it's looked up like any other class. 
As abstract classes can't be initialized on their own, they should be skipped, as they're meaningful only in case other class extends them.

This related to #89