### PR TITLE
Fix Symfony bundle dumping absolute path in cache dir

### DIFF
--- a/packages/Symfony/SymfonyBundle/EcotoneSymfonyBundle.php
+++ b/packages/Symfony/SymfonyBundle/EcotoneSymfonyBundle.php
@@ -69,13 +69,7 @@ class EcotoneSymfonyBundle extends Bundle
 
     public function boot()
     {
-        $configuration = MessagingSystemConfiguration::prepare(
-            EcotoneCompilerPass::getRootProjectPath($this->container),
-            new SymfonyReferenceTypeResolver($this->container),
-            new SymfonyConfigurationVariableService($this->container),
-            unserialize($this->container->getParameter(self::APPLICATION_CONFIGURATION_CONTEXT)),
-            true
-        );
+        $configuration = EcotoneCompilerPass::getMassagingConfiguration($this->container, true);
 
         $messagingSystem = $configuration->buildMessagingSystemFromConfiguration($this->container->get('symfonyReferenceSearchService'));
 


### PR DESCRIPTION
The actual symfony bundle is dumping the messaging system configuration with absolute path to the cache directory.
In the context of a cache warmup in a different system than the execution system (typically while bundling lambdas), the the configuration is incorrect.

This PR fixes this issue by using Symfony parameter interpolation feature