### PR TITLE
Handle exception during first handling

### DIFF
--- a/packages/Dbal/src/Deduplication/DeduplicationInterceptor.php
+++ b/packages/Dbal/src/Deduplication/DeduplicationInterceptor.php
@@ -72,8 +72,14 @@ class DeduplicationInterceptor
             return;
         }
 
-        $result = $methodInvocation->proceed();
-        $this->insertHandledMessage($connectionFactory, $messageId, $consumerEndpointId, $routingSlip);
+        try {
+            $result = $methodInvocation->proceed();
+            $this->insertHandledMessage($connectionFactory, $messageId, $consumerEndpointId, $routingSlip);
+        }catch (\Throwable $exception) {
+            $this->isInitialized = false;
+
+            throw $exception;
+        }
 
         return $result;
     }

--- a/packages/Dbal/tests/DbalMessagingTest.php
+++ b/packages/Dbal/tests/DbalMessagingTest.php
@@ -45,19 +45,19 @@ abstract class DbalMessagingTest extends TestCase
     {
         $connection = $this->getConnectionFactory()->createContext()->getDbalConnection();
 
-        $this->deleteFromTableExists('enqueue', $connection);
-        $this->deleteFromTableExists(OrderService::ORDER_TABLE, $connection);
-        $this->deleteFromTableExists(DbalDeadLetter::DEFAULT_DEAD_LETTER_TABLE, $connection);
-        $this->deleteFromTableExists(DbalDocumentStore::ECOTONE_DOCUMENT_STORE, $connection);
-        $this->deleteFromTableExists(DeduplicationInterceptor::DEFAULT_DEDUPLICATION_TABLE, $connection);
+        $this->deleteTable('enqueue', $connection);
+        $this->deleteTable(OrderService::ORDER_TABLE, $connection);
+        $this->deleteTable(DbalDeadLetter::DEFAULT_DEAD_LETTER_TABLE, $connection);
+        $this->deleteTable(DbalDocumentStore::ECOTONE_DOCUMENT_STORE, $connection);
+        $this->deleteTable(DeduplicationInterceptor::DEFAULT_DEDUPLICATION_TABLE, $connection);
     }
 
-    private function deleteFromTableExists(string $tableName, \Doctrine\DBAL\Connection $connection): void
+    private function deleteTable(string $tableName, \Doctrine\DBAL\Connection $connection): void
     {
         $doesExists = $this->checkIfTableExists($connection, $tableName);
 
         if ($doesExists) {
-            $connection->executeStatement('DELETE FROM ' . $tableName);
+            $connection->executeStatement('DROP TABLE ' . $tableName);
         }
     }
 

--- a/packages/Dbal/tests/Integration/DbalBackedMessageChannelTest.php
+++ b/packages/Dbal/tests/Integration/DbalBackedMessageChannelTest.php
@@ -190,7 +190,6 @@ class DbalBackedMessageChannelTest extends DbalMessagingTest
     public function test_failing_to_receive_message_when_not_declared()
     {
         $queueName = Uuid::uuid4()->toString();
-        $messagePayload = 'some';
 
         $ecotoneLite = EcotoneLite::bootstrapForTesting(
             containerOrAvailableServices: [

--- a/packages/Dbal/tests/Integration/DbalBackedMessageChannelTest.php
+++ b/packages/Dbal/tests/Integration/DbalBackedMessageChannelTest.php
@@ -6,6 +6,7 @@ use Ecotone\Dbal\DbalBackedMessageChannelBuilder;
 use Ecotone\Lite\EcotoneLite;
 use Ecotone\Messaging\Config\ModulePackageList;
 use Ecotone\Messaging\Config\ServiceConfiguration;
+use Ecotone\Messaging\Endpoint\PollingConsumer\ConnectionException;
 use Ecotone\Messaging\Handler\InMemoryReferenceSearchService;
 use Ecotone\Messaging\MessageHeaders;
 use Ecotone\Messaging\PollableChannel;
@@ -206,10 +207,9 @@ class DbalBackedMessageChannelTest extends DbalMessagingTest
         /** @var PollableChannel $messageChannel */
         $messageChannel = $ecotoneLite->getMessageChannelByName($queueName);
 
-        $messageChannel->send(MessageBuilder::withPayload($messagePayload)->build());
+        /** Dbal handle not declared queues as long as database table is created first */
+        $this->expectException(ConnectionException::class);
 
-        /** Dbal handle handle not declared queues as long as database table is created first */
-
-        $this->assertNotNull($messageChannel->receiveWithTimeout(1));
+        $messageChannel->receiveWithTimeout(1);
     }
 }

--- a/packages/Dbal/tests/Integration/Deduplication/DbalDeduplicationModuleTest.php
+++ b/packages/Dbal/tests/Integration/Deduplication/DbalDeduplicationModuleTest.php
@@ -12,6 +12,7 @@ use Ecotone\Messaging\Config\ServiceConfiguration;
 use Ecotone\Messaging\Endpoint\ExecutionPollingMetadata;
 use Ecotone\Messaging\MessageHeaders;
 use Enqueue\Dbal\DbalConnectionFactory;
+use MongoDB\Driver\Exception\RuntimeException;
 use Ramsey\Uuid\Uuid;
 use Test\Ecotone\Dbal\DbalMessagingTest;
 use Test\Ecotone\Dbal\Fixture\DeduplicationCommandHandler\EmailCommandHandler;
@@ -40,6 +41,33 @@ final class DbalDeduplicationModuleTest extends DbalMessagingTest
             $ecotoneLite
                 ->sendCommandWithRoutingKey('email_event_handler.handle', metadata: [MessageHeaders::MESSAGE_ID => $messageId])
                 ->sendCommandWithRoutingKey('email_event_handler.handle', metadata: [MessageHeaders::MESSAGE_ID => $messageId])
+                ->sendQueryWithRouting('email_event_handler.getCallCount')
+        );
+    }
+
+    public function test_deduplicating_after_first_handling_was_failure_during_asynchronous_processing()
+    {
+        $ecotoneLite = EcotoneLite::bootstrapFlowTesting(
+            [EmailCommandHandler::class],
+            [
+                new EmailCommandHandler(1),
+                DbalConnectionFactory::class => $this->getConnectionFactory(true),
+            ],
+            ServiceConfiguration::createWithDefaults()
+                ->withSkippedModulePackageNames(ModulePackageList::allPackagesExcept([ModulePackageList::DBAL_PACKAGE, ModulePackageList::ASYNCHRONOUS_PACKAGE]))
+                ->withExtensionObjects([
+                    DbalBackedMessageChannelBuilder::create('email')
+                ])
+        );
+
+        $ecotoneLite->sendCommandWithRoutingKey('email_event_handler.handle', metadata: [MessageHeaders::MESSAGE_ID => Uuid::uuid4()->toString()]);
+
+        $this->assertEquals(
+            2,
+            $ecotoneLite
+                ->run('email', ExecutionPollingMetadata::createWithDefaults()->withHandledMessageLimit(1)->withExecutionTimeLimitInMilliseconds(100))
+                ->run('email', ExecutionPollingMetadata::createWithDefaults()->withHandledMessageLimit(1)->withExecutionTimeLimitInMilliseconds(100))
+                ->run('email', ExecutionPollingMetadata::createWithDefaults()->withHandledMessageLimit(1)->withExecutionTimeLimitInMilliseconds(100))
                 ->sendQueryWithRouting('email_event_handler.getCallCount')
         );
     }


### PR DESCRIPTION
When first message is failed and postgres driver is used, then rolling back creation of deduplication table creates problems with handling consecutive messages.