### PR TITLE
Count failure handling as message consumption

### DIFF
--- a/config_ci.json
+++ b/config_ci.json
@@ -2,39 +2,39 @@
     "repositories": [
       {
         "type": "path",
-        "url": "../../packages/Amqp"
+        "url": "packages/Amqp"
       },
       {
         "type": "path",
-        "url": "../../packages/Ecotone"
+        "url": "packages/Ecotone"
       },
       {
         "type": "path",
-        "url": "../../packages/Dbal"
+        "url": "packages/Dbal"
       },
       {
         "type": "path",
-        "url": "../../packages/Enqueue"
+        "url": "packages/Enqueue"
       },
       {
         "type": "path",
-        "url": "../../packages/PdoEventSourcing"
+        "url": "packages/PdoEventSourcing"
       },
       {
         "type": "path",
-        "url": "../../packages/JmsConverter"
+        "url": "packages/JmsConverter"
       },
       {
         "type": "path",
-        "url": "../../packages/Laravel"
+        "url": "packages/Laravel"
       },
       {
         "type": "path",
-        "url": "../../packages/Symfony"
+        "url": "packages/Symfony"
       },
       {
         "type": "path",
-        "url": "../../packages/LiteApplication"
+        "url": "packages/LiteApplication"
       }
     ]
 }

--- a/config_ci.json
+++ b/config_ci.json
@@ -2,39 +2,39 @@
     "repositories": [
       {
         "type": "path",
-        "url": "packages/Amqp"
+        "url": "../../packages/Amqp"
       },
       {
         "type": "path",
-        "url": "packages/Ecotone"
+        "url": "../../packages/Ecotone"
       },
       {
         "type": "path",
-        "url": "packages/Dbal"
+        "url": "../../packages/Dbal"
       },
       {
         "type": "path",
-        "url": "packages/Enqueue"
+        "url": "../../packages/Enqueue"
       },
       {
         "type": "path",
-        "url": "packages/PdoEventSourcing"
+        "url": "../../packages/PdoEventSourcing"
       },
       {
         "type": "path",
-        "url": "packages/JmsConverter"
+        "url": "../../packages/JmsConverter"
       },
       {
         "type": "path",
-        "url": "packages/Laravel"
+        "url": "../../packages/Laravel"
       },
       {
         "type": "path",
-        "url": "packages/Symfony"
+        "url": "../../packages/Symfony"
       },
       {
         "type": "path",
-        "url": "packages/LiteApplication"
+        "url": "../../packages/LiteApplication"
       }
     ]
 }

--- a/packages/Amqp/tests/Behat/Bootstrap/DomainContext.php
+++ b/packages/Amqp/tests/Behat/Bootstrap/DomainContext.php
@@ -194,6 +194,8 @@ class DomainContext extends AmqpMessagingTest implements Context
                 false
             );
         }
+
+        $this->queueCleanUp();
     }
 
     /**
@@ -371,6 +373,7 @@ class DomainContext extends AmqpMessagingTest implements Context
 
     /**
      * @When using :serviceName process ticket with failure
+     * @When using :serviceName set up distributed consumer
      */
     public function usingProcessTicketWithFailure(string $serviceName)
     {

--- a/packages/Amqp/tests/Behat/features/modelling.feature
+++ b/packages/Amqp/tests/Behat/features/modelling.feature
@@ -66,6 +66,7 @@ Feature: activating as aggregate order entity
       | name            | namespace |
       | user_service    | Test\Ecotone\Amqp\Fixture\DistributedCommandBus\Publisher |
       | ticket_service  | Test\Ecotone\Amqp\Fixture\DistributedCommandBus\Receiver  |
+    And using "ticket_service" set up distributed consumer
     When using "ticket_service" I should have 0 remaining ticket
     And using "user_service" I change billing details
     Then using "ticket_service" I should have 1 remaining ticket
@@ -75,6 +76,7 @@ Feature: activating as aggregate order entity
       | name            | namespace |
       | user_service    | Test\Ecotone\Amqp\Fixture\DistributedEventBus\Publisher |
       | ticket_service  | Test\Ecotone\Amqp\Fixture\DistributedEventBus\Receiver  |
+    And using "ticket_service" set up distributed consumer
     When using "ticket_service" I should have 0 remaining ticket
     And using "user_service" I change billing details
     Then using "ticket_service" I should have 1 remaining ticket
@@ -84,6 +86,7 @@ Feature: activating as aggregate order entity
       | name            | namespace |
       | user_service    | Test\Ecotone\Amqp\Fixture\DistributedCommandBus\Publisher |
       | ticket_service  | Test\Ecotone\Amqp\Fixture\DistributedCommandBus\Receiver  |
+    And using "ticket_service" set up distributed consumer
     When using "ticket_service" I should have 0 remaining ticket
     And using "user_service" I change billing details
     Then using "ticket_service" I should have 1 remaining ticket
@@ -93,6 +96,7 @@ Feature: activating as aggregate order entity
       | name            | namespace |
       | user_service    | Test\Ecotone\Amqp\Fixture\DistributedDeadLetter\Publisher |
       | ticket_service  | Test\Ecotone\Amqp\Fixture\DistributedDeadLetter\Receiver  |
+    And using "ticket_service" set up distributed consumer
     When using "ticket_service" there are 0 error tickets
     And using "user_service" I change billing details
     And using "ticket_service" process ticket with failure
@@ -105,6 +109,7 @@ Feature: activating as aggregate order entity
       | name            | namespace |
       | user_service    | Test\Ecotone\Amqp\Fixture\DistributedMessage\Publisher |
       | ticket_service  | Test\Ecotone\Amqp\Fixture\DistributedMessage\Receiver  |
+    And using "ticket_service" set up distributed consumer
     When using "ticket_service" I should have 0 remaining ticket
     And using "user_service" I change billing details
     Then using "ticket_service" I should have 1 remaining ticket

--- a/packages/Amqp/tests/Fixture/DistributedDeadLetter/Receiver/TicketServiceMessagingConfiguration.php
+++ b/packages/Amqp/tests/Fixture/DistributedDeadLetter/Receiver/TicketServiceMessagingConfiguration.php
@@ -27,11 +27,11 @@ class TicketServiceMessagingConfiguration
     }
 
     #[ServiceContext]
-    public function errorConfiguration()
+    public function errorConfiguration(): ErrorHandlerConfiguration
     {
         return ErrorHandlerConfiguration::createWithDeadLetterChannel(
             self::ERROR_CHANNEL,
-            RetryTemplateBuilder::exponentialBackoff(1, 1)
+            RetryTemplateBuilder::fixedBackOff(1)
                 ->maxRetryAttempts(1),
             self::DEAD_LETTER_CHANNEL
         );

--- a/packages/Ecotone/src/Messaging/Endpoint/ConsumerInterceptor.php
+++ b/packages/Ecotone/src/Messaging/Endpoint/ConsumerInterceptor.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Ecotone\Messaging\Endpoint;
 
+use Ecotone\Messaging\Handler\Processor\MethodInvoker\MethodInvocation;
 use Throwable;
 
 /**
@@ -40,6 +41,8 @@ interface ConsumerInterceptor
 
     /**
      * Called after each sending message to request channel
+     *
+     * @return mixed result of method invocation
      */
-    public function postSend(): void;
+    public function postSend(MethodInvocation $methodInvocation): mixed;
 }

--- a/packages/Ecotone/src/Messaging/Endpoint/Interceptor/ConnectionExceptionRetryInterceptor.php
+++ b/packages/Ecotone/src/Messaging/Endpoint/Interceptor/ConnectionExceptionRetryInterceptor.php
@@ -6,6 +6,7 @@ namespace Ecotone\Messaging\Endpoint\Interceptor;
 
 use Ecotone\Messaging\Endpoint\ConsumerInterceptor;
 use Ecotone\Messaging\Endpoint\PollingConsumer\ConnectionException;
+use Ecotone\Messaging\Handler\Processor\MethodInvoker\MethodInvocation;
 use Ecotone\Messaging\Handler\Recoverability\RetryTemplateBuilder;
 use Throwable;
 
@@ -77,7 +78,8 @@ class ConnectionExceptionRetryInterceptor implements ConsumerInterceptor
     /**
      * @inheritDoc
      */
-    public function postSend(): void
+    public function postSend(MethodInvocation $methodInvocation): mixed
     {
+        return $methodInvocation->proceed();
     }
 }

--- a/packages/Ecotone/src/Messaging/Endpoint/Interceptor/LimitConsumedMessagesInterceptor.php
+++ b/packages/Ecotone/src/Messaging/Endpoint/Interceptor/LimitConsumedMessagesInterceptor.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Ecotone\Messaging\Endpoint\Interceptor;
 
 use Ecotone\Messaging\Endpoint\ConsumerInterceptor;
+use Ecotone\Messaging\Handler\Processor\MethodInvoker\MethodInvocation;
 use Throwable;
 
 /**
@@ -71,10 +72,11 @@ class LimitConsumedMessagesInterceptor implements ConsumerInterceptor
     /**
      * @inheritDoc
      */
-    public function postSend(): void
+    public function postSend(MethodInvocation $methodInvocation): mixed
     {
         $this->currentSentMessages++;
-
         $this->shouldBeStopped = $this->currentSentMessages >= $this->messageLimit;
+
+        return $methodInvocation->proceed();
     }
 }

--- a/packages/Ecotone/src/Messaging/Endpoint/Interceptor/LimitExecutionAmountInterceptor.php
+++ b/packages/Ecotone/src/Messaging/Endpoint/Interceptor/LimitExecutionAmountInterceptor.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Ecotone\Messaging\Endpoint\Interceptor;
 
 use Ecotone\Messaging\Endpoint\ConsumerInterceptor;
+use Ecotone\Messaging\Handler\Processor\MethodInvoker\MethodInvocation;
 use Throwable;
 
 /**
@@ -73,7 +74,8 @@ class LimitExecutionAmountInterceptor implements ConsumerInterceptor
     /**
      * @inheritDoc
      */
-    public function postSend(): void
+    public function postSend(MethodInvocation $methodInvocation): mixed
     {
+        return $methodInvocation->proceed();
     }
 }

--- a/packages/Ecotone/src/Messaging/Endpoint/Interceptor/LimitMemoryUsageInterceptor.php
+++ b/packages/Ecotone/src/Messaging/Endpoint/Interceptor/LimitMemoryUsageInterceptor.php
@@ -6,6 +6,7 @@ namespace Ecotone\Messaging\Endpoint\Interceptor;
 
 use Ecotone\Messaging\Config\ConfigurationException;
 use Ecotone\Messaging\Endpoint\ConsumerInterceptor;
+use Ecotone\Messaging\Handler\Processor\MethodInvoker\MethodInvocation;
 use Throwable;
 
 /**
@@ -75,7 +76,8 @@ class LimitMemoryUsageInterceptor implements ConsumerInterceptor
     /**
      * @inheritDoc
      */
-    public function postSend(): void
+    public function postSend(MethodInvocation $methodInvocation): mixed
     {
+        return $methodInvocation->proceed();
     }
 }

--- a/packages/Ecotone/src/Messaging/Endpoint/Interceptor/SignalInterceptor.php
+++ b/packages/Ecotone/src/Messaging/Endpoint/Interceptor/SignalInterceptor.php
@@ -6,6 +6,7 @@ namespace Ecotone\Messaging\Endpoint\Interceptor;
 
 use Ecotone\Messaging\Config\ConfigurationException;
 use Ecotone\Messaging\Endpoint\ConsumerInterceptor;
+use Ecotone\Messaging\Handler\Processor\MethodInvoker\MethodInvocation;
 use Throwable;
 
 /**
@@ -73,8 +74,9 @@ class SignalInterceptor implements ConsumerInterceptor
     /**
      * @inheritDoc
      */
-    public function postSend(): void
+    public function postSend(MethodInvocation $methodInvocation): mixed
     {
+        return $methodInvocation->proceed();
     }
 
     /**

--- a/packages/Ecotone/src/Messaging/Endpoint/Interceptor/TimeLimitInterceptor.php
+++ b/packages/Ecotone/src/Messaging/Endpoint/Interceptor/TimeLimitInterceptor.php
@@ -6,6 +6,7 @@ namespace Ecotone\Messaging\Endpoint\Interceptor;
 
 use Ecotone\Messaging\Config\ConfigurationException;
 use Ecotone\Messaging\Endpoint\ConsumerInterceptor;
+use Ecotone\Messaging\Handler\Processor\MethodInvoker\MethodInvocation;
 use Throwable;
 
 /**
@@ -78,7 +79,8 @@ class TimeLimitInterceptor implements ConsumerInterceptor
     /**
      * @inheritDoc
      */
-    public function postSend(): void
+    public function postSend(MethodInvocation $methodInvocation): mixed
     {
+        return $methodInvocation->proceed();
     }
 }

--- a/packages/config.json
+++ b/packages/config.json
@@ -2,39 +2,39 @@
     "repositories": [
       {
         "type": "path",
-        "url": "../Amqp"
+        "url": "Amqp"
       },
       {
         "type": "path",
-        "url": "../Ecotone"
+        "url": "Ecotone"
       },
       {
         "type": "path",
-        "url": "../Dbal"
+        "url": "Dbal"
       },
       {
         "type": "path",
-        "url": "../Enqueue"
+        "url": "Enqueue"
       },
       {
         "type": "path",
-        "url": "../PdoEventSourcing"
+        "url": "PdoEventSourcing"
       },
       {
         "type": "path",
-        "url": "../JmsConverter"
+        "url": "JmsConverter"
       },
       {
         "type": "path",
-        "url": "../Laravel"
+        "url": "Laravel"
       },
       {
         "type": "path",
-        "url": "../Symfony"
+        "url": "Symfony"
       },
       {
         "type": "path",
-        "url": "../LiteApplication"
+        "url": "LiteApplication"
       }
     ]
 }


### PR DESCRIPTION
Currently if message was handled with failure it was not counted as handled message, which caused to ignore message consumption limit for the message consumer.