### PR TITLE
Combined Message Channels

### DIFF
--- a/packages/Ecotone/src/Messaging/Channel/CombinedMessageChannel.php
+++ b/packages/Ecotone/src/Messaging/Channel/CombinedMessageChannel.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ecotone\Messaging\Channel;
+
+use Ecotone\Messaging\Support\Assert;
+
+final class CombinedMessageChannel
+{
+    private function __construct(private string $referenceName, private array $combinedChannels)
+    {
+        Assert::notNull($referenceName, 'Reference name can not be null');
+        Assert::notNullAndEmpty($this->combinedChannels, 'Combined channels can not be empty');
+    }
+
+    public static function create(string $referenceName, array $combinedChannels): self
+    {
+        return new self($referenceName, $combinedChannels);
+    }
+
+    public function getReferenceName(): string
+    {
+        return $this->referenceName;
+    }
+
+    public function getCombinedChannels(): array
+    {
+        return $this->combinedChannels;
+    }
+}

--- a/packages/Ecotone/tests/Modelling/Fixture/Outbox/OutboxWithMultipleChannels.php
+++ b/packages/Ecotone/tests/Modelling/Fixture/Outbox/OutboxWithMultipleChannels.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Ecotone\Modelling\Fixture\Outbox;
+
+use Ecotone\Messaging\Attribute\Asynchronous;
+use Ecotone\Messaging\Attribute\ServiceContext;
+use Ecotone\Messaging\Channel\SimpleMessageChannelBuilder;
+use Ecotone\Messaging\Endpoint\PollingMetadata;
+use Ecotone\Modelling\Attribute\CommandHandler;
+use Ecotone\Modelling\Attribute\QueryHandler;
+
+final class OutboxWithMultipleChannels
+{
+    private int $amount = 0;
+
+    #[Asynchronous(['outbox', 'rabbitMQ'])]
+    #[CommandHandler('outboxWithMultipleChannels', endpointId: 'outboxMultipleChannels')]
+    public function handle(int $amount): void
+    {
+        $this->amount = $amount;
+    }
+
+    #[QueryHandler('getResult')]
+    public function getResult(): int
+    {
+        return $this->amount;
+    }
+
+    #[ServiceContext]
+    public function getChannels()
+    {
+        /** faking asynchronous message channels */
+        return [
+            SimpleMessageChannelBuilder::createQueueChannel("outbox"),
+            PollingMetadata::create('outbox')->withTestingSetup(),
+            SimpleMessageChannelBuilder::createQueueChannel("rabbitMQ"),
+            PollingMetadata::create('rabbitMQ')->withTestingSetup(),
+        ];
+    }
+}

--- a/packages/Ecotone/tests/Modelling/Fixture/Outbox/OutboxWithMultipleChannels.php
+++ b/packages/Ecotone/tests/Modelling/Fixture/Outbox/OutboxWithMultipleChannels.php
@@ -6,6 +6,7 @@ namespace Test\Ecotone\Modelling\Fixture\Outbox;
 
 use Ecotone\Messaging\Attribute\Asynchronous;
 use Ecotone\Messaging\Attribute\ServiceContext;
+use Ecotone\Messaging\Channel\CombinedMessageChannel;
 use Ecotone\Messaging\Channel\SimpleMessageChannelBuilder;
 use Ecotone\Messaging\Endpoint\PollingMetadata;
 use Ecotone\Modelling\Attribute\CommandHandler;
@@ -16,8 +17,15 @@ final class OutboxWithMultipleChannels
     private int $amount = 0;
 
     #[Asynchronous(['outbox', 'rabbitMQ'])]
-    #[CommandHandler('outboxWithMultipleChannels', endpointId: 'outboxMultipleChannels')]
+    #[CommandHandler('outboxWithMultipleChannels', endpointId: 'outboxMultipleChannelsId')]
     public function handle(int $amount): void
+    {
+        $this->amount = $amount;
+    }
+
+    #[Asynchronous(['outbox_rabbit'])]
+    #[CommandHandler('outboxWithCombinedChannels', endpointId: 'outboxCombinedMessageChannelsId')]
+    public function handleWithCombinedMessageChannel(int $amount): void
     {
         $this->amount = $amount;
     }
@@ -38,5 +46,14 @@ final class OutboxWithMultipleChannels
             SimpleMessageChannelBuilder::createQueueChannel("rabbitMQ"),
             PollingMetadata::create('rabbitMQ')->withTestingSetup(),
         ];
+    }
+
+    #[ServiceContext]
+    public function combinedMessageChannel(): CombinedMessageChannel
+    {
+        return CombinedMessageChannel::create(
+            'outbox_rabbit',
+            ['outbox', 'rabbitMQ'],
+        );
     }
 }

--- a/packages/Ecotone/tests/Modelling/Unit/ModellingEcotoneLiteTest.php
+++ b/packages/Ecotone/tests/Modelling/Unit/ModellingEcotoneLiteTest.php
@@ -59,7 +59,7 @@ final class ModellingEcotoneLiteTest extends TestCase
         );
     }
 
-    public function test_calling_asynchronous_command_handler_with_two_message_channels()
+    public function test_calling_asynchronous_command_handler_with_pass_through_message_channels()
     {
         $ecotoneLite = EcotoneLite::bootstrapFlowTesting(
             [OutboxWithMultipleChannels::class],
@@ -70,6 +70,35 @@ final class ModellingEcotoneLiteTest extends TestCase
         );
 
         $ecotoneLite->sendCommandWithRoutingKey('outboxWithMultipleChannels', 1);
+        $this->assertEquals(
+            0,
+            $ecotoneLite->sendQueryWithRouting('getResult')
+        );
+
+        $ecotoneLite->run('outbox');
+        $this->assertEquals(
+            0,
+            $ecotoneLite->sendQueryWithRouting('getResult')
+        );
+
+        $ecotoneLite->run('rabbitMQ');
+        $this->assertEquals(
+            1,
+            $ecotoneLite->sendQueryWithRouting('getResult')
+        );
+    }
+
+    public function test_calling_asynchronous_command_handler_with_combined_message_channel()
+    {
+        $ecotoneLite = EcotoneLite::bootstrapFlowTesting(
+            [OutboxWithMultipleChannels::class],
+            [
+                new OutboxWithMultipleChannels(),
+            ],
+            ServiceConfiguration::createWithAsynchronicityOnly()
+        );
+
+        $ecotoneLite->sendCommandWithRoutingKey('outboxWithCombinedChannels', 1);
         $this->assertEquals(
             0,
             $ecotoneLite->sendQueryWithRouting('getResult')


### PR DESCRIPTION
In order to provide possibility to pass through message from database channel providing outbox to a different channel like RabbitMQ, or SQS this PR provides combined Message Channels.

[Read more](https://docs.ecotone.tech/modelling/error-handling/outbox-pattern)