### PR TITLE
Reconnecting when connection to message channel fails

### DIFF
--- a/packages/Amqp/src/AmqpInboundChannelAdapter.php
+++ b/packages/Amqp/src/AmqpInboundChannelAdapter.php
@@ -10,6 +10,7 @@ use Ecotone\Enqueue\InboundMessageConverter;
 use Ecotone\Messaging\Channel\QueueChannel;
 use Ecotone\Messaging\Conversion\MediaType;
 use Ecotone\Messaging\Endpoint\InboundChannelAdapterEntrypoint;
+use Ecotone\Messaging\Endpoint\PollingConsumer\ConnectionException;
 use Ecotone\Messaging\Message;
 use Ecotone\Messaging\Support\MessageBuilder;
 use Interop\Amqp\AmqpMessage;
@@ -65,26 +66,35 @@ class AmqpInboundChannelAdapter extends EnqueueInboundChannelAdapter
 
     public function receiveMessage(int $timeout = 0): ?Message
     {
-        if ($this->declareOnStartup && $this->initialized === false) {
-            $this->initialize();
+        try {
+            if ($this->declareOnStartup && $this->initialized === false) {
+                $this->initialize();
 
-            $this->initialized = true;
+                $this->initialized = true;
+            }
+
+            /** @var AmqpReconnectableConnectionFactory $connectionFactory */
+            $connectionFactory = $this->connectionFactory->getInnerConnectionFactory();
+            $queueChannel = $this->queueChannel;
+            $subscriptionConsumer = $connectionFactory->getSubscriptionConsumer($this->queueName, function (EnqueueMessage $receivedMessage, Consumer $consumer) use ($queueChannel) {
+                $message = $this->inboundMessageConverter->toMessage($receivedMessage, $consumer);
+                $message = $this->enrichMessage($receivedMessage, $message);
+
+                $queueChannel->send($message->build());
+
+                return false;
+            });
+
+            $subscriptionConsumer->consume($timeout ?: $this->receiveTimeoutInMilliseconds);
+
+            return $this->queueChannel->receive();
+        }catch (\AMQPConnectionException $exception) {
+            throw new ConnectionException("Failed to connect to AMQP broker", 0, $exception);
         }
+    }
 
-        /** @var AmqpReconnectableConnectionFactory $connectionFactory */
-        $connectionFactory = $this->connectionFactory->getInnerConnectionFactory();
-        $queueChannel = $this->queueChannel;
-        $subscriptionConsumer = $connectionFactory->getSubscriptionConsumer($this->queueName, function (EnqueueMessage $receivedMessage, Consumer $consumer) use ($queueChannel) {
-            $message = $this->inboundMessageConverter->toMessage($receivedMessage, $consumer);
-            $message = $this->enrichMessage($receivedMessage, $message);
-
-            $queueChannel->send($message->build());
-
-            return false;
-        });
-
-        $subscriptionConsumer->consume($timeout ?: $this->receiveTimeoutInMilliseconds);
-
-        return $this->queueChannel->receive();
+    public function connectionException(): string
+    {
+        return \AMQPConnectionException::class;
     }
 }

--- a/packages/Amqp/tests/Fixture/Support/Logger/LoggerExample.php
+++ b/packages/Amqp/tests/Fixture/Support/Logger/LoggerExample.php
@@ -1,0 +1,177 @@
+<?php
+
+namespace Test\Ecotone\Amqp\Fixture\Support\Logger;
+
+use Psr\Log\LoggerInterface;
+use Stringable;
+
+/**
+ * Class LoggerExample
+ * @package Test\Ecotone\Messaging\Unit\Handler\Logger
+ * @author Dariusz Gafka <dgafka.mail@gmail.com>
+ */
+class LoggerExample implements LoggerInterface
+{
+    private array $emergency = [];
+    private array $alert = [];
+    private array $critical = [];
+    private array $error = [];
+    private array $warning = [];
+    private array $notice = [];
+    private array $info = [];
+    private array $debug = [];
+    private array $log = [];
+
+    private function __construct()
+    {
+    }
+
+    public static function create(): self
+    {
+        return new self();
+    }
+
+    /**
+     * @return array
+     */
+    public function getEmergency(): array
+    {
+        return $this->emergency;
+    }
+
+    /**
+     * @return array
+     */
+    public function getAlert(): array
+    {
+        return $this->alert;
+    }
+
+    /**
+     * @return array
+     */
+    public function getCritical(): array
+    {
+        return $this->critical;
+    }
+
+    /**
+     * @return array
+     */
+    public function getError(): array
+    {
+        return $this->error;
+    }
+
+    /**
+     * @return array
+     */
+    public function getWarning(): array
+    {
+        return $this->warning;
+    }
+
+    /**
+     * @return array
+     */
+    public function getNotice(): array
+    {
+        return $this->notice;
+    }
+
+    /**
+     * @return array
+     */
+    public function getInfo(): array
+    {
+        return $this->info;
+    }
+
+    /**
+     * @return array
+     */
+    public function getDebug(): array
+    {
+        return $this->debug;
+    }
+
+    /**
+     * @return array
+     */
+    public function getLog(): array
+    {
+        return $this->log;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function emergency(string|Stringable $message, array $context = []): void
+    {
+        $this->emergency[] = $message;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function alert(string|Stringable $message, array $context = []): void
+    {
+        $this->alert[] = $message;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function critical(string|Stringable $message, array $context = []): void
+    {
+        $this->critical[] = $message;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function error(string|Stringable $message, array $context = []): void
+    {
+        $this->error[] = $message;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function warning(string|Stringable $message, array $context = []): void
+    {
+        $this->warning[] = $message;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function notice(string|Stringable $message, array $context = []): void
+    {
+        $this->notice[] = $message;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function info(string|Stringable $message, array $context = []): void
+    {
+        $this->info[] = $message;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function debug(string|Stringable $message, array $context = []): void
+    {
+        $this->debug[] = $message;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function log($level, string|Stringable $message, array $context = []): void
+    {
+        $this->log[] = $level;
+    }
+}

--- a/packages/Dbal/src/DbalInboundChannelAdapter.php
+++ b/packages/Dbal/src/DbalInboundChannelAdapter.php
@@ -2,6 +2,7 @@
 
 namespace Ecotone\Dbal;
 
+use Doctrine\DBAL\Exception\ConnectionException;
 use Ecotone\Enqueue\EnqueueInboundChannelAdapter;
 use Enqueue\Dbal\DbalContext;
 
@@ -13,5 +14,10 @@ class DbalInboundChannelAdapter extends EnqueueInboundChannelAdapter
         $context = $this->connectionFactory->createContext();
 
         $context->createDataBaseTable();
+    }
+
+    public function connectionException(): string
+    {
+        return ConnectionException::class;
     }
 }

--- a/packages/Dbal/tests/Fixture/AsynchronousHandler/OrderService.php
+++ b/packages/Dbal/tests/Fixture/AsynchronousHandler/OrderService.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Test\Ecotone\Dbal\Fixture\AsynchronousHandler;
+
+use Ecotone\Messaging\Attribute\Asynchronous;
+use Ecotone\Messaging\Attribute\ServiceActivator;
+use Ecotone\Modelling\Attribute\CommandHandler;
+use Ecotone\Modelling\Attribute\QueryHandler;
+use InvalidArgumentException;
+
+class OrderService
+{
+    private int $placedOrders = 0;
+
+    #[Asynchronous("async")]
+    #[CommandHandler('order.register', 'orderService')]
+    public function order(string $orderName): void
+    {
+        $this->placedOrders[] = $orderName;
+    }
+
+    #[QueryHandler('getOrders')]
+    public function getOrder(): int
+    {
+        return $this->placedOrders;
+    }
+}

--- a/packages/Dbal/tests/Integration/DbalBackedMessageChannelTest.php
+++ b/packages/Dbal/tests/Integration/DbalBackedMessageChannelTest.php
@@ -2,19 +2,24 @@
 
 namespace Test\Ecotone\Dbal\Integration;
 
+use Doctrine\DBAL\Exception\TableNotFoundException;
+use Ecotone\Amqp\AmqpBackedMessageChannelBuilder;
 use Ecotone\Dbal\DbalBackedMessageChannelBuilder;
 use Ecotone\Lite\EcotoneLite;
 use Ecotone\Messaging\Config\ModulePackageList;
 use Ecotone\Messaging\Config\ServiceConfiguration;
 use Ecotone\Messaging\Endpoint\PollingConsumer\ConnectionException;
 use Ecotone\Messaging\Handler\InMemoryReferenceSearchService;
+use Ecotone\Messaging\Handler\Recoverability\RetryTemplateBuilder;
 use Ecotone\Messaging\MessageHeaders;
 use Ecotone\Messaging\PollableChannel;
 use Ecotone\Messaging\Support\MessageBuilder;
 use Enqueue\Dbal\DbalConnectionFactory;
 use Enqueue\Dbal\DbalContext;
 use Ramsey\Uuid\Uuid;
+use Test\Ecotone\Amqp\Fixture\Support\Logger\LoggerExample;
 use Test\Ecotone\Dbal\DbalMessagingTest;
+use Test\Ecotone\Dbal\Fixture\AsynchronousHandler\OrderService;
 
 /**
  * @internal
@@ -187,7 +192,7 @@ class DbalBackedMessageChannelTest extends DbalMessagingTest
         $this->assertNull($messageChannel->receiveWithTimeout(1));
     }
 
-    public function test_failing_to_receive_message_when_not_declared()
+    public function test_failing_to_receive_message_when_not_declared_and_auto_declare_off()
     {
         $queueName = Uuid::uuid4()->toString();
 
@@ -206,9 +211,46 @@ class DbalBackedMessageChannelTest extends DbalMessagingTest
         /** @var PollableChannel $messageChannel */
         $messageChannel = $ecotoneLite->getMessageChannelByName($queueName);
 
-        /** Dbal handle not declared queues as long as database table is created first */
-        $this->expectException(ConnectionException::class);
+        $this->expectException(TableNotFoundException::class);
 
         $messageChannel->receiveWithTimeout(1);
+    }
+
+    public function test_failing_to_consume_due_to_connection_failure()
+    {
+        $loggerExample = LoggerExample::create();
+        $ecotoneLite = EcotoneLite::bootstrapForTesting(
+            [OrderService::class],
+            containerOrAvailableServices: [
+                new OrderService(),
+                DbalConnectionFactory::class => new DbalConnectionFactory(['dsn' => 'pgsql://ecotone:secret@localhost:1000/ecotone']),
+                'logger' => $loggerExample
+            ],
+            configuration: ServiceConfiguration::createWithDefaults()
+                ->withSkippedModulePackageNames(ModulePackageList::allPackagesExcept([ModulePackageList::DBAL_PACKAGE, ModulePackageList::ASYNCHRONOUS_PACKAGE]))
+                ->withConnectionRetryTemplate(
+                    RetryTemplateBuilder::exponentialBackoff(1, 3)->maxRetryAttempts(3)
+                )
+                ->withExtensionObjects([
+                    DbalBackedMessageChannelBuilder::create('async')
+                ])
+        );
+
+        $wasFinallyRethrown = false;
+        try {
+            $ecotoneLite->run('async');
+        } catch (\Doctrine\DBAL\Exception\ConnectionException) {
+            $wasFinallyRethrown = true;
+        }
+
+        $this->assertTrue($wasFinallyRethrown, 'Connection exception was not propagated');
+        $this->assertEquals(
+            [
+                ConnectionException::connectionRetryMessage(1, 1),
+                ConnectionException::connectionRetryMessage(2, 3),
+                ConnectionException::connectionRetryMessage(3, 9),
+            ],
+            $loggerExample->getInfo()
+        );
     }
 }

--- a/packages/Ecotone/src/Messaging/Endpoint/Interceptor/ConnectionExceptionRetryInterceptor.php
+++ b/packages/Ecotone/src/Messaging/Endpoint/Interceptor/ConnectionExceptionRetryInterceptor.php
@@ -48,11 +48,15 @@ class ConnectionExceptionRetryInterceptor implements ConsumerInterceptor
 
         $this->currentNumberOfRetries++;
         if (! $this->retryTemplate || ! $this->retryTemplate->canBeCalledNextTime($this->currentNumberOfRetries)) {
+            $this->logger->critical("Connection retry to Message Channel was exceed.", ['exception' => $exception]);
             return true;
         }
 
         $retryConnectionIn = $this->retryTemplate->calculateNextDelay($this->currentNumberOfRetries);
-        $this->logger->info("Retrying to connect to the Message Channel. Current number of retries: {$this->currentNumberOfRetries}, Message Consumer will try to reconnect in {$retryConnectionIn}ms. Exception: {$exception->getMessage()}");
+        $this->logger->info(
+            ConnectionException::connectionRetryMessage($this->currentNumberOfRetries, $retryConnectionIn),
+            ['exception' => $exception]
+        );
         return false;
     }
 

--- a/packages/Ecotone/src/Messaging/Endpoint/PollingConsumer/ConnectionException.php
+++ b/packages/Ecotone/src/Messaging/Endpoint/PollingConsumer/ConnectionException.php
@@ -6,4 +6,8 @@ use RuntimeException;
 
 class ConnectionException extends RuntimeException
 {
+    public static function connectionRetryMessage(int $retryCount, int $delayTimeMs): self
+    {
+        return new self("Retrying to connect to the Message Channel. Current number of retries: {$retryCount}, Message Consumer will try to reconnect in {$delayTimeMs}ms.",);
+    }
 }

--- a/packages/Redis/src/RedisInboundChannelAdapter.php
+++ b/packages/Redis/src/RedisInboundChannelAdapter.php
@@ -6,6 +6,7 @@ namespace Ecotone\Redis;
 
 use Ecotone\Enqueue\EnqueueInboundChannelAdapter;
 use Enqueue\Redis\RedisContext;
+use Predis\Connection\ConnectionException;
 
 final class RedisInboundChannelAdapter extends EnqueueInboundChannelAdapter
 {
@@ -14,5 +15,10 @@ final class RedisInboundChannelAdapter extends EnqueueInboundChannelAdapter
         /** @var RedisContext $context */
         $context = $this->connectionFactory->createContext();
         $context->createQueue($this->queueName);
+    }
+
+    public function connectionException(): string
+    {
+        return ConnectionException::class;
     }
 }

--- a/packages/Redis/tests/Fixture/AsynchronousHandler/OrderService.php
+++ b/packages/Redis/tests/Fixture/AsynchronousHandler/OrderService.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Test\Ecotone\Redis\Fixture\AsynchronousHandler;
+
+use Ecotone\Messaging\Attribute\Asynchronous;
+use Ecotone\Messaging\Attribute\ServiceActivator;
+use Ecotone\Modelling\Attribute\CommandHandler;
+use Ecotone\Modelling\Attribute\QueryHandler;
+use InvalidArgumentException;
+
+class OrderService
+{
+    private int $placedOrders = 0;
+
+    #[Asynchronous("async")]
+    #[CommandHandler('order.register', 'orderService')]
+    public function order(string $orderName): void
+    {
+        $this->placedOrders[] = $orderName;
+    }
+
+    #[QueryHandler('getOrders')]
+    public function getOrder(): int
+    {
+        return $this->placedOrders;
+    }
+}

--- a/packages/Redis/tests/Integration/RedisBackedMessageChannelTest.php
+++ b/packages/Redis/tests/Integration/RedisBackedMessageChannelTest.php
@@ -4,16 +4,21 @@ declare(strict_types=1);
 
 namespace Test\Ecotone\Redis\Integration;
 
+use Ecotone\Dbal\DbalBackedMessageChannelBuilder;
 use Ecotone\Lite\EcotoneLite;
 use Ecotone\Messaging\Config\ModulePackageList;
 use Ecotone\Messaging\Config\ServiceConfiguration;
 use Ecotone\Messaging\Endpoint\ExecutionPollingMetadata;
+use Ecotone\Messaging\Endpoint\PollingConsumer\ConnectionException;
+use Ecotone\Messaging\Handler\Recoverability\RetryTemplateBuilder;
 use Ecotone\Messaging\PollableChannel;
 use Ecotone\Messaging\Support\MessageBuilder;
 use Ecotone\Redis\RedisBackedMessageChannelBuilder;
 use Enqueue\Redis\RedisConnectionFactory;
 use Enqueue\Redis\RedisDestination;
 use Ramsey\Uuid\Uuid;
+use Test\Ecotone\Amqp\Fixture\Support\Logger\LoggerExample;
+use Test\Ecotone\Redis\Fixture\AsynchronousHandler\OrderService;
 use Test\Ecotone\Redis\AbstractConnectionTest;
 use Test\Ecotone\Redis\Fixture\RedisConsumer\RedisAsyncConsumerExample;
 
@@ -84,5 +89,43 @@ final class RedisBackedMessageChannelTest extends AbstractConnectionTest
 
         $ecotoneLite->run('redis', $executionPollingMetadata);
         $this->assertEquals([$messagePayload], $ecotoneLite->getQueryBus()->sendWithRouting('consumer.getMessagePayloads'));
+    }
+
+    public function test_failing_to_consume_due_to_connection_failure()
+    {
+        $loggerExample = LoggerExample::create();
+        $ecotoneLite = EcotoneLite::bootstrapForTesting(
+            [OrderService::class],
+            containerOrAvailableServices: [
+                new OrderService(),
+                RedisConnectionFactory::class => new RedisConnectionFactory('redis://localhost:1000'),
+                'logger' => $loggerExample
+            ],
+            configuration: ServiceConfiguration::createWithDefaults()
+                ->withSkippedModulePackageNames(ModulePackageList::allPackagesExcept([ModulePackageList::REDIS_PACKAGE, ModulePackageList::ASYNCHRONOUS_PACKAGE]))
+                ->withConnectionRetryTemplate(
+                    RetryTemplateBuilder::exponentialBackoff(1, 3)->maxRetryAttempts(3)
+                )
+                ->withExtensionObjects([
+                    RedisBackedMessageChannelBuilder::create('async')
+                ])
+        );
+
+        $wasFinallyRethrown = false;
+        try {
+            $ecotoneLite->run('async');
+        } catch (\Predis\Connection\ConnectionException) {
+            $wasFinallyRethrown = true;
+        }
+
+        $this->assertTrue($wasFinallyRethrown, 'Connection exception was not propagated');
+        $this->assertEquals(
+            [
+                ConnectionException::connectionRetryMessage(1, 1),
+                ConnectionException::connectionRetryMessage(2, 3),
+                ConnectionException::connectionRetryMessage(3, 9),
+            ],
+            $loggerExample->getInfo()
+        );
     }
 }

--- a/packages/Sqs/src/SqsInboundChannelAdapter.php
+++ b/packages/Sqs/src/SqsInboundChannelAdapter.php
@@ -6,6 +6,7 @@ namespace Ecotone\Sqs;
 
 use Ecotone\Enqueue\EnqueueInboundChannelAdapter;
 use Enqueue\Sqs\SqsContext;
+use GuzzleHttp\Exception\ConnectException;
 
 final class SqsInboundChannelAdapter extends EnqueueInboundChannelAdapter
 {
@@ -15,5 +16,10 @@ final class SqsInboundChannelAdapter extends EnqueueInboundChannelAdapter
         $context = $this->connectionFactory->createContext();
 
         $context->declareQueue($context->createQueue($this->queueName));
+    }
+
+    public function connectionException(): string
+    {
+        return ConnectException::class;
     }
 }

--- a/packages/Sqs/tests/Fixture/AsynchronousHandler/OrderService.php
+++ b/packages/Sqs/tests/Fixture/AsynchronousHandler/OrderService.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Test\Ecotone\Sqs\Fixture\AsynchronousHandler;
+
+use Ecotone\Messaging\Attribute\Asynchronous;
+use Ecotone\Messaging\Attribute\ServiceActivator;
+use Ecotone\Modelling\Attribute\CommandHandler;
+use Ecotone\Modelling\Attribute\QueryHandler;
+use InvalidArgumentException;
+
+class OrderService
+{
+    private int $placedOrders = 0;
+
+    #[Asynchronous("async")]
+    #[CommandHandler('order.register', 'orderService')]
+    public function order(string $orderName): void
+    {
+        $this->placedOrders[] = $orderName;
+    }
+
+    #[QueryHandler('getOrders')]
+    public function getOrder(): int
+    {
+        return $this->placedOrders;
+    }
+}

--- a/packages/Sqs/tests/Integration/SqsBackedMessageChannelTest.php
+++ b/packages/Sqs/tests/Integration/SqsBackedMessageChannelTest.php
@@ -4,15 +4,22 @@ declare(strict_types=1);
 
 namespace Test\Ecotone\Sqs\Integration;
 
+use Aws\Sqs\Exception\SqsException;
 use Ecotone\Lite\EcotoneLite;
 use Ecotone\Messaging\Config\ModulePackageList;
 use Ecotone\Messaging\Config\ServiceConfiguration;
 use Ecotone\Messaging\Endpoint\ExecutionPollingMetadata;
+use Ecotone\Messaging\Endpoint\PollingConsumer\ConnectionException;
+use Ecotone\Messaging\Handler\Recoverability\RetryTemplateBuilder;
 use Ecotone\Messaging\PollableChannel;
 use Ecotone\Messaging\Support\MessageBuilder;
+use Ecotone\Redis\RedisBackedMessageChannelBuilder;
 use Ecotone\Sqs\SqsBackedMessageChannelBuilder;
 use Enqueue\Sqs\SqsConnectionFactory;
+use GuzzleHttp\Exception\ConnectException;
 use Ramsey\Uuid\Uuid;
+use Test\Ecotone\Amqp\Fixture\Support\Logger\LoggerExample;
+use Test\Ecotone\Sqs\Fixture\AsynchronousHandler\OrderService;
 use Test\Ecotone\Sqs\AbstractConnectionTest;
 use Test\Ecotone\Sqs\Fixture\SqsConsumer\SqsAsyncConsumerExample;
 
@@ -81,5 +88,43 @@ final class SqsBackedMessageChannelTest extends AbstractConnectionTest
 
         $ecotoneLite->run('sqs', $executionPollingMetadata);
         $this->assertEquals([$messagePayload], $ecotoneLite->getQueryBus()->sendWithRouting('consumer.getMessagePayloads'));
+    }
+
+    public function test_failing_to_consume_due_to_connection_failure()
+    {
+        $loggerExample = LoggerExample::create();
+        $ecotoneLite = EcotoneLite::bootstrapForTesting(
+            [OrderService::class],
+            containerOrAvailableServices: [
+                new OrderService(),
+                SqsConnectionFactory::class => new SqsConnectionFactory('sqs:?key=key&secret=secret&region=us-east-1&endpoint=http://localhost:1000&version=latest'),
+                'logger' => $loggerExample
+            ],
+            configuration: ServiceConfiguration::createWithDefaults()
+                ->withSkippedModulePackageNames(ModulePackageList::allPackagesExcept([ModulePackageList::SQS_PACKAGE, ModulePackageList::ASYNCHRONOUS_PACKAGE]))
+                ->withConnectionRetryTemplate(
+                    RetryTemplateBuilder::exponentialBackoff(1, 3)->maxRetryAttempts(3)
+                )
+                ->withExtensionObjects([
+                    SqsBackedMessageChannelBuilder::create('async')
+                ])
+        );
+
+        $wasFinallyRethrown = false;
+        try {
+            $ecotoneLite->run('async');
+        } catch (SqsException) {
+            $wasFinallyRethrown = true;
+        }
+
+        $this->assertTrue($wasFinallyRethrown, 'Connection exception was not propagated');
+        $this->assertEquals(
+            [
+                ConnectionException::connectionRetryMessage(1, 1),
+                ConnectionException::connectionRetryMessage(2, 3),
+                ConnectionException::connectionRetryMessage(3, 9),
+            ],
+            $loggerExample->getInfo()
+        );
     }
 }


### PR DESCRIPTION
This provides possibility to self-heal in case consumer lost/can't connect to message channel.
This is especially useful on startup of consumers, or when connection becomes idle.