### PR TITLE
lock aws sdk version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -133,7 +133,8 @@
         "phpunit/phpunit": "^9.5",
         "predis/predis": "^1.1.10",
         "symfony/expression-language": "^6.0",
-        "symplify/monorepo-builder": "11.1.21"
+        "symplify/monorepo-builder": "11.1.21",
+        "aws/aws-sdk-php": "<=3.269.5"
     },
     "extra": {
         "laravel": {

--- a/packages/Sqs/composer.json
+++ b/packages/Sqs/composer.json
@@ -31,7 +31,8 @@
     },
     "require": {
         "ecotone/enqueue": "^1.81",
-        "enqueue/sqs": "^0.10.15"
+        "enqueue/sqs": "^0.10.15",
+        "aws/aws-sdk-php": "<=3.269.5"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5",


### PR DESCRIPTION
Newest version of aws sdk fails on creating sqs queues. Due to that we need to lock on lower version