### PR TITLE
message ID should not be overwritten.

### DIFF
--- a/packages/Ecotone/src/Modelling/Event.php
+++ b/packages/Ecotone/src/Modelling/Event.php
@@ -19,10 +19,8 @@ class Event
         $this->eventType = $eventType;
         $this->payload = $payload;
 
-        $metadata[MessageHeaders::MESSAGE_ID] = Uuid::uuid4()->toString();
-        if (! array_key_exists(MessageHeaders::TIMESTAMP, $metadata)) {
-            $metadata[MessageHeaders::TIMESTAMP] = (int)round(microtime(true));
-        }
+        $metadata[MessageHeaders::MESSAGE_ID] = $metadata[MessageHeaders::MESSAGE_ID] ?? Uuid::uuid4()->toString();
+        $metadata[MessageHeaders::TIMESTAMP] = $metadata[MessageHeaders::TIMESTAMP] ?? (int)round(microtime(true));
 
         $this->metadata = $metadata;
     }

--- a/packages/Ecotone/tests/Modelling/Unit/EventTest.php
+++ b/packages/Ecotone/tests/Modelling/Unit/EventTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Ecotone\Modelling\Unit;
+
+use Ecotone\Messaging\MessageHeaders;
+use Ecotone\Modelling\Event;
+use PHPUnit\Framework\TestCase;
+use function PHPUnit\Framework\assertEquals;
+
+/**
+ * @internal
+ */
+final class EventTest extends TestCase
+{
+    public function test_constructor_wont_overwrite_already_set_metadata(): void
+    {
+        $metadata = [
+            MessageHeaders::MESSAGE_ID => 'uuid',
+            MessageHeaders::TIMESTAMP => 123,
+        ];
+
+        assertEquals($metadata, (Event::createWithType('type', [], $metadata))->getMetadata());
+        assertEquals($metadata, (Event::create(new \stdClass(), $metadata))->getMetadata());
+    }
+}


### PR DESCRIPTION
this happens when Event is loaded from existing stream and sent to projection