### PR TITLE
perf(Ecotone): avoid unnecessary work on boot when cache is available

### DIFF
--- a/packages/Ecotone/src/Messaging/Config/MessagingSystemConfiguration.php
+++ b/packages/Ecotone/src/Messaging/Config/MessagingSystemConfiguration.php
@@ -714,6 +714,14 @@ final class MessagingSystemConfiguration implements Configuration
 
     public static function prepare(string $rootPathToSearchConfigurationFor, ConfigurationVariableService $configurationVariableService, ServiceConfiguration $serviceConfiguration, bool $useCachedVersion, array $userLandClassesToRegister = [], bool $enableTestPackage = false): Configuration
     {
+        if ($useCachedVersion) {
+            Assert::isTrue((bool)$serviceConfiguration->getCacheDirectoryPath(), "Can't make use of cached version of messaging if no cache path is defined");
+            $cachedVersion = self::getCachedVersion($serviceConfiguration->getCacheDirectoryPath());
+            if ($cachedVersion) {
+                return $cachedVersion;
+            }
+        }
+
         $requiredModules = [ModulePackageList::CORE_PACKAGE];
         if ($enableTestPackage) {
             $requiredModules[] = ModulePackageList::TEST_PACKAGE;
@@ -737,8 +745,7 @@ final class MessagingSystemConfiguration implements Configuration
                 $enableTestPackage
             ),
             $configurationVariableService,
-            $serviceConfiguration,
-            $useCachedVersion
+            $serviceConfiguration
         );
     }
 
@@ -750,16 +757,8 @@ final class MessagingSystemConfiguration implements Configuration
         return $cachedVersion;
     }
 
-    public static function prepareWithAnnotationFinder(AnnotationFinder $annotationFinder, ConfigurationVariableService $configurationVariableService, ServiceConfiguration $serviceConfiguration, bool $useCachedVersion): Configuration
+    public static function prepareWithAnnotationFinder(AnnotationFinder $annotationFinder, ConfigurationVariableService $configurationVariableService, ServiceConfiguration $serviceConfiguration): Configuration
     {
-        if ($useCachedVersion) {
-            Assert::isTrue((bool)$serviceConfiguration->getCacheDirectoryPath(), "Can't make use of cached version of messaging if no cache path is defined");
-            $cachedVersion = self::getCachedVersion($serviceConfiguration->getCacheDirectoryPath());
-            if ($cachedVersion) {
-                return $cachedVersion;
-            }
-        }
-
         $preparationInterfaceRegistry = InterfaceToCallRegistry::createWith($annotationFinder);
 
         return self::prepareWithModuleRetrievingService(


### PR DESCRIPTION
Early return if cached configuration is available.

The impact of this PR can be huge on large codebase, as it avoids loading the attributes from catalog when cache is available.

Example with `package/Ecotone/src` as a catalog I got these results for boostraping Ecotone:
```
    before.........................I4 - Mo163.687ms (±4.31%)
    after..........................I4 - Mo14.700ms (±2.71%)
```

Now booting Ecotone from cache will be stable (14ms in my case) whatever the size of codebase.