### PR TITLE
fix: symfony bundle failing without symfony/expression-language

### DIFF
--- a/packages/Symfony/DepedencyInjection/Compiler/EcotoneCompilerPass.php
+++ b/packages/Symfony/DepedencyInjection/Compiler/EcotoneCompilerPass.php
@@ -142,6 +142,10 @@ class EcotoneCompilerPass implements CompilerPassInterface
                 continue;
             }
 
+            if (! $container->has($requiredReference)) {
+                continue;
+            }
+
             $alias = $container->setAlias(PsrContainerReferenceSearchService::getServiceNameWithSuffix($requiredReference), $requiredReference);
 
             if ($alias) {


### PR DESCRIPTION
Fix for #128 

Not sure it is the way to go, but `ExpressionEvaluationService::REFERENCE` is defined as a required reference so it tries to create a public alias in symfony container to a non existent service if `symfony/expression-language` is not installed.