### PR TITLE
Expression evaluation service always available

### DIFF
--- a/packages/Ecotone/src/Lite/PsrContainerReferenceSearchService.php
+++ b/packages/Ecotone/src/Lite/PsrContainerReferenceSearchService.php
@@ -6,8 +6,10 @@ namespace Ecotone\Lite;
 
 use Ecotone\Messaging\Config\ConfiguredMessagingSystem;
 use Ecotone\Messaging\Config\LazyConfiguredMessagingSystem;
+use Ecotone\Messaging\Handler\ExpressionEvaluationService;
 use Ecotone\Messaging\Handler\ReferenceNotFoundException;
 use Ecotone\Messaging\Handler\ReferenceSearchService;
+use Ecotone\Messaging\Handler\SymfonyExpressionEvaluationAdapter;
 use Psr\Container\ContainerInterface;
 
 class PsrContainerReferenceSearchService implements ReferenceSearchService
@@ -16,12 +18,14 @@ class PsrContainerReferenceSearchService implements ReferenceSearchService
     private array $defaults;
 
     private LazyConfiguredMessagingSystem $lazyConfiguredMessagingSystem;
+    private ExpressionEvaluationService $symfonyExpressionEvaluationAdapter;
 
     public function __construct(ContainerInterface $container, array $defaults = [])
     {
         $this->container = $container;
         $this->defaults = $defaults;
         $this->lazyConfiguredMessagingSystem = new LazyConfiguredMessagingSystem();
+        $this->symfonyExpressionEvaluationAdapter = SymfonyExpressionEvaluationAdapter::create();
     }
 
     /**
@@ -32,6 +36,10 @@ class PsrContainerReferenceSearchService implements ReferenceSearchService
         if ($reference === ConfiguredMessagingSystem::class) {
             return $this->lazyConfiguredMessagingSystem;
         }
+        if ($reference === ExpressionEvaluationService::REFERENCE) {
+            return $this->symfonyExpressionEvaluationAdapter;
+        }
+
         if (! $this->container->has($reference)) {
             if (array_key_exists($reference, $this->defaults)) {
                 return $this->defaults[$reference];

--- a/packages/Ecotone/src/Messaging/Config/Annotation/ModuleConfiguration/BasicMessagingModule.php
+++ b/packages/Ecotone/src/Messaging/Config/Annotation/ModuleConfiguration/BasicMessagingModule.php
@@ -235,7 +235,6 @@ class BasicMessagingModule extends NoExternalConfigurationModule implements Anno
     public function getRelatedReferences(): array
     {
         return [
-            RequiredReference::create(ExpressionEvaluationService::REFERENCE),
             RequiredReference::create(InterfaceToCallRegistry::REFERENCE_NAME),
         ];
     }

--- a/packages/Laravel/src/EcotoneProvider.php
+++ b/packages/Laravel/src/EcotoneProvider.php
@@ -169,13 +169,6 @@ class EcotoneProvider extends ServiceProvider
             }
         }
 
-        if (class_exists(ExpressionLanguage::class)) {
-            $this->app->singleton(
-                ExpressionEvaluationService::REFERENCE,
-                fn () => SymfonyExpressionEvaluationAdapter::create()
-            );
-        }
-
         $this->app->singleton(
             ConfiguredMessagingSystem::class,
             function () use ($configuration) {

--- a/packages/Symfony/DepedencyInjection/Compiler/EcotoneCompilerPass.php
+++ b/packages/Symfony/DepedencyInjection/Compiler/EcotoneCompilerPass.php
@@ -181,24 +181,5 @@ class EcotoneCompilerPass implements CompilerPassInterface
         $definition->setPublic(true);
         $definition->setFactory(new Reference(MessagingSystemFactory::class));
         $container->setDefinition(ConfiguredMessagingSystem::class, $definition);
-
-        $this->setUpExpressionLanguage($container);
-    }
-
-    /**
-     * @param ContainerBuilder $container
-     * @return void
-     */
-    private function setUpExpressionLanguage(ContainerBuilder $container): void
-    {
-        if (! class_exists(ExpressionLanguage::class)) {
-            return;
-        }
-
-        $definition = new Definition();
-        $definition->setClass(SymfonyExpressionEvaluationAdapter::class);
-        $definition->setFactory([SymfonyExpressionEvaluationAdapter::class, 'create']);
-        $definition->setPublic(true);
-        $container->setDefinition(ExpressionEvaluationService::REFERENCE, $definition);
     }
 }


### PR DESCRIPTION
Fix for https://github.com/ecotoneframework/ecotone-dev/issues/128

It will make Expression Evaluation Service always available. In case class is missing, it will use stub.