### PR TITLE
Ensure all integration tests are running against production event store

### DIFF
--- a/packages/Ecotone/src/Lite/EcotoneLite.php
+++ b/packages/Ecotone/src/Lite/EcotoneLite.php
@@ -123,10 +123,11 @@ final class EcotoneLite
         ?string                  $pathToRootCatalog = null,
         bool                     $allowGatewaysToBeRegisteredInContainer = false,
         bool                     $addInMemoryStateStoredRepository = true,
+        bool                     $runForProductionEventStore = false
     ): FlowTestSupport {
         $configuration = self::prepareForFlowTesting($configuration, ModulePackageList::allPackagesExcept([ModulePackageList::EVENT_SOURCING_PACKAGE, ModulePackageList::DBAL_PACKAGE, ModulePackageList::JMS_CONVERTER_PACKAGE]), $classesToResolve, $addInMemoryStateStoredRepository);
 
-        if (! $configuration->hasExtensionObject(BaseEventSourcingConfiguration::class)) {
+        if (! $configuration->hasExtensionObject(BaseEventSourcingConfiguration::class) && !$runForProductionEventStore) {
             Assert::isTrue(class_exists(EventSourcingConfiguration::class), 'To use Flow Testing with Event Store you need to add event sourcing module.');
 
             $configuration = $configuration

--- a/packages/Ecotone/src/Lite/Test/FlowTestSupport.php
+++ b/packages/Ecotone/src/Lite/Test/FlowTestSupport.php
@@ -122,6 +122,18 @@ final class FlowTestSupport
         return $this;
     }
 
+    public function deleteEventStream(string $streamName): self
+    {
+        $gateway = $this->getGateway(EventStore::class);
+        if (!$gateway->hasStream($streamName)) {
+            return $this;
+        }
+
+        $gateway->delete($streamName);
+
+        return $this;
+    }
+
     /**
      * @param Event[]|object[]|array[] $streamEvents
      */

--- a/packages/PdoEventSourcing/tests/EventSourcingMessagingTest.php
+++ b/packages/PdoEventSourcing/tests/EventSourcingMessagingTest.php
@@ -67,34 +67,15 @@ abstract class EventSourcingMessagingTestCase extends TestCase
 
     public static function clearDataTables(Connection $connection): void
     {
-        EventSourcingMessagingTestCase::deleteFromTableExists('enqueue', $connection);
-        EventSourcingMessagingTestCase::deleteFromTableExists(DbalDeadLetterHandler::DEFAULT_DEAD_LETTER_TABLE, $connection);
-        EventSourcingMessagingTestCase::deleteFromTableExists(DbalDocumentStore::ECOTONE_DOCUMENT_STORE, $connection);
-        EventSourcingMessagingTestCase::deleteTable('in_progress_tickets', $connection);
-        EventSourcingMessagingTestCase::deleteEventStreamTables($connection);
+        foreach ($connection->createSchemaManager()->listTableNames() as $tableNames) {
+            $sql = 'DROP TABLE ' . $tableNames;
+            $connection->prepare($sql)->executeStatement();
+        }
     }
 
     public static function tableExists(Connection $connection, string $table): bool
     {
         return $connection->createSchemaManager()->tablesExist([$table]);
-    }
-
-    private static function deleteEventStreamTables(Connection $connection): void
-    {
-        if (self::tableExists($connection, 'event_streams')) {
-            $projections = $connection->createQueryBuilder()
-                ->select('*')
-                ->from('event_streams')
-                ->executeQuery()
-                ->fetchAllAssociative();
-
-            foreach ($projections as $projection) {
-                self::deleteTable($projection['stream_name'], $connection);
-            }
-        }
-
-        self::deleteTable('event_streams', $connection);
-        self::deleteTable('projections', $connection);
     }
 
     private static function deleteFromTableExists(string $tableName, Connection $connection): void

--- a/packages/PdoEventSourcing/tests/InMemory/EcotoneLiteEventSourcingTest.php
+++ b/packages/PdoEventSourcing/tests/InMemory/EcotoneLiteEventSourcingTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Test\Ecotone\EventSourcing\Integration;
+namespace Test\Ecotone\EventSourcing\InMemory;
 
 use Ecotone\EventSourcing\Config\EventSourcingModule;
 use Ecotone\EventSourcing\EventSourcingConfiguration;

--- a/packages/PdoEventSourcing/tests/InMemory/EventSourcedAggregateTestSupportFrameworkTest.php
+++ b/packages/PdoEventSourcing/tests/InMemory/EventSourcedAggregateTestSupportFrameworkTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Test\Ecotone\EventSourcing\Integration;
+namespace Test\Ecotone\EventSourcing\InMemory;
 
 use Ecotone\EventSourcing\EventSourcingConfiguration;
 use Ecotone\Lite\EcotoneLite;

--- a/packages/PdoEventSourcing/tests/InMemory/EventSourcingRepositoryBuilderTest.php
+++ b/packages/PdoEventSourcing/tests/InMemory/EventSourcingRepositoryBuilderTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Test\Ecotone\EventSourcing\Integration;
+namespace Test\Ecotone\EventSourcing\InMemory;
 
 use Ecotone\EventSourcing\AggregateStreamMapping;
 use Ecotone\EventSourcing\AggregateTypeMapping;

--- a/packages/PdoEventSourcing/tests/InMemory/ProjectionMetadataPropagationTest.php
+++ b/packages/PdoEventSourcing/tests/InMemory/ProjectionMetadataPropagationTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Test\Ecotone\EventSourcing\Integration;
+namespace Test\Ecotone\EventSourcing\InMemory;
 
 use Ecotone\Lite\EcotoneLite;
 use Ecotone\Lite\Test\FlowTestSupport;

--- a/packages/PdoEventSourcing/tests/InMemory/SynchronousEventDrivenSagaTest.php
+++ b/packages/PdoEventSourcing/tests/InMemory/SynchronousEventDrivenSagaTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Test\Ecotone\EventSourcing\Integration;
+namespace Test\Ecotone\EventSourcing\InMemory;
 
 use Ecotone\Lite\EcotoneLite;
 use Ecotone\Messaging\Config\ModulePackageList;

--- a/packages/PdoEventSourcing/tests/InMemory/ValueObjectIdentifierTest.php
+++ b/packages/PdoEventSourcing/tests/InMemory/ValueObjectIdentifierTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Test\Ecotone\EventSourcing\Integration;
+namespace Test\Ecotone\EventSourcing\InMemory;
 
 use Ecotone\Lite\EcotoneLite;
 use Ecotone\Messaging\Config\ModulePackageList;

--- a/packages/PdoEventSourcing/tests/Integration/AggregateAndProjectionTriggerTest.php
+++ b/packages/PdoEventSourcing/tests/Integration/AggregateAndProjectionTriggerTest.php
@@ -24,14 +24,14 @@ final class AggregateAndProjectionTriggerTest extends EventSourcingMessagingTest
 {
     public function test_triggering_projection_with_state_synchronously()
     {
-        $ecotoneLite = EcotoneLite::bootstrapFlowTesting(
+        $ecotoneLite = EcotoneLite::bootstrapFlowTestingWithEventStore(
             [],
             [new TicketEventConverter(), new StateAndEventConverter(), new NotificationService(), new TicketCounterProjection(), DbalConnectionFactory::class => $this->getConnectionFactory()],
             ServiceConfiguration::createWithDefaults()
                 ->withSkippedModulePackageNames(ModulePackageList::allPackagesExcept([ModulePackageList::EVENT_SOURCING_PACKAGE, ModulePackageList::DBAL_PACKAGE]))
                 ->withNamespaces(['Test\Ecotone\EventSourcing\Fixture\Ticket', 'Test\Ecotone\EventSourcing\Fixture\TicketProjectionState']),
             pathToRootCatalog: __DIR__ . '/../../',
-            addEventSourcedRepository: false
+            runForProductionEventStore: true
         );
 
         $this->assertEquals(

--- a/packages/PdoEventSourcing/tests/Integration/AsynchronousEventDrivenProjectionTest.php
+++ b/packages/PdoEventSourcing/tests/Integration/AsynchronousEventDrivenProjectionTest.php
@@ -37,6 +37,7 @@ final class AsynchronousEventDrivenProjectionTest extends EventSourcingMessaging
                     EventSourcingConfiguration::createWithDefaults(),
                 ]),
             pathToRootCatalog: __DIR__ . '/../../',
+            runForProductionEventStore: true
         );
 
         $ecotone->sendCommand(new RegisterTicket('123', 'Johnny', 'alert'));
@@ -68,6 +69,7 @@ final class AsynchronousEventDrivenProjectionTest extends EventSourcingMessaging
                     EventSourcingConfiguration::createWithDefaults(),
                 ]),
             pathToRootCatalog: __DIR__ . '/../../',
+            runForProductionEventStore: true
         );
 
         $ecotone->sendCommand(new RegisterTicket('123', 'Johnny', 'alert'));
@@ -115,6 +117,7 @@ final class AsynchronousEventDrivenProjectionTest extends EventSourcingMessaging
                         ->withOption(ProophProjectionRunningOption::OPTION_LOAD_COUNT, 2),
                 ]),
             pathToRootCatalog: __DIR__ . '/../../',
+            runForProductionEventStore: true
         );
 
         $ecotone->sendCommand(new RegisterTicket('1', 'Marcus', 'alert'));

--- a/packages/PdoEventSourcing/tests/Integration/CategoryStreamTest.php
+++ b/packages/PdoEventSourcing/tests/Integration/CategoryStreamTest.php
@@ -36,7 +36,8 @@ final class CategoryStreamTest extends EventSourcingMessagingTestCase
                     EventSourcingConfiguration::createWithDefaults()
                         ->withStreamPerAggregatePersistenceStrategy(),
                 ]),
-            pathToRootCatalog: __DIR__ . '/../../'
+            pathToRootCatalog: __DIR__ . '/../../',
+            runForProductionEventStore: true
         );
 
         $ecotone

--- a/packages/PdoEventSourcing/tests/Integration/CustomEventStreamTest.php
+++ b/packages/PdoEventSourcing/tests/Integration/CustomEventStreamTest.php
@@ -44,7 +44,8 @@ final class CustomEventStreamTest extends EventSourcingMessagingTestCase
                                 : new MySqlSingleStreamStrategy(new FromProophMessageToArrayConverter())
                         ),
                 ]),
-            pathToRootCatalog: __DIR__ . '/../../'
+            pathToRootCatalog: __DIR__ . '/../../',
+            runForProductionEventStore: true
         );
 
         $ecotone

--- a/packages/PdoEventSourcing/tests/Integration/EmittingEventsProjectionTest.php
+++ b/packages/PdoEventSourcing/tests/Integration/EmittingEventsProjectionTest.php
@@ -80,7 +80,8 @@ final class EmittingEventsProjectionTest extends EventSourcingMessagingTestCase
                     'Test\Ecotone\EventSourcing\Fixture\TicketEmittingProjection',
                 ])
                 ->withExtensionObjects(array_merge([EventSourcingConfiguration::createWithDefaults()], $extensionObjects)),
-            pathToRootCatalog: __DIR__ . '/../../'
+            pathToRootCatalog: __DIR__ . '/../../',
+            runForProductionEventStore: true
         );
     }
 

--- a/packages/PdoEventSourcing/tests/Integration/FlowTestingTest.php
+++ b/packages/PdoEventSourcing/tests/Integration/FlowTestingTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Ecotone\EventSourcing\Integration;
+
+use Ecotone\EventSourcing\EventSourcingConfiguration;
+use Ecotone\Lite\EcotoneLite;
+use Ecotone\Messaging\Config\ModulePackageList;
+use Ecotone\Messaging\Config\ServiceConfiguration;
+use Enqueue\Dbal\DbalConnectionFactory;
+use Test\Ecotone\EventSourcing\EventSourcingMessagingTestCase;
+use Test\Ecotone\EventSourcing\Fixture\Ticket\Command\CloseTicket;
+use Test\Ecotone\EventSourcing\Fixture\Ticket\Command\RegisterTicket;
+use Test\Ecotone\EventSourcing\Fixture\Ticket\Ticket;
+use Test\Ecotone\EventSourcing\Fixture\Ticket\TicketEventConverter;
+use Test\Ecotone\EventSourcing\Fixture\TicketWithSynchronousEventDrivenProjection\InProgressTicketList;
+
+final class FlowTestingTest extends EventSourcingMessagingTestCase
+{
+    public function test_resetting_projection_and_restarting_test()
+    {
+        $ecotone = EcotoneLite::bootstrapFlowTestingWithEventStore(
+            containerOrAvailableServices: [new InProgressTicketList($this->getConnection()), new TicketEventConverter(), DbalConnectionFactory::class => $this->getConnectionFactory()],
+            configuration: ServiceConfiguration::createWithDefaults()
+                ->withEnvironment('prod')
+                ->withSkippedModulePackageNames(ModulePackageList::allPackagesExcept([ModulePackageList::EVENT_SOURCING_PACKAGE]))
+                ->withNamespaces([
+                    'Test\Ecotone\EventSourcing\Fixture\Ticket',
+                    'Test\Ecotone\EventSourcing\Fixture\TicketWithSynchronousEventDrivenProjection',
+                ]),
+            pathToRootCatalog: __DIR__ . '/../../',
+            runForProductionEventStore: true
+        );
+
+        $ecotone->initializeProjection(InProgressTicketList::IN_PROGRESS_TICKET_PROJECTION);
+
+        self::assertEquals([], $ecotone->sendQueryWithRouting('getInProgressTickets'));
+
+        $ecotone->sendCommand(new RegisterTicket('123', 'Johnny', 'alert'));
+
+        self::assertEquals([['ticket_id' => '123', 'ticket_type' => 'alert']], $ecotone->sendQueryWithRouting('getInProgressTickets'));
+
+        $ecotone->deleteEventStream(Ticket::class);
+        $ecotone->resetProjection(InProgressTicketList::IN_PROGRESS_TICKET_PROJECTION);
+
+        self::assertEquals([], $ecotone->sendQueryWithRouting('getInProgressTickets'));
+    }
+}

--- a/packages/PdoEventSourcing/tests/Integration/PollingProjectionTest.php
+++ b/packages/PdoEventSourcing/tests/Integration/PollingProjectionTest.php
@@ -48,6 +48,7 @@ final class PollingProjectionTest extends EventSourcingMessagingTestCase
                     EventSourcingConfiguration::createWithDefaults(),
                 ]),
             pathToRootCatalog: __DIR__ . '/../../',
+            runForProductionEventStore: true
         );
 
         $ecotoneLite->initializeProjection(InProgressTicketList::IN_PROGRESS_TICKET_PROJECTION);

--- a/packages/PdoEventSourcing/tests/Integration/ProjectionFromMultipleStreamsTest.php
+++ b/packages/PdoEventSourcing/tests/Integration/ProjectionFromMultipleStreamsTest.php
@@ -36,7 +36,8 @@ final class ProjectionFromMultipleStreamsTest extends EventSourcingMessagingTest
                 ->withExtensionObjects([
                     EventSourcingConfiguration::createWithDefaults(),
                 ]),
-            pathToRootCatalog: __DIR__ . '/../../'
+            pathToRootCatalog: __DIR__ . '/../../',
+            runForProductionEventStore: true
         );
 
         $ecotone

--- a/packages/PdoEventSourcing/tests/Integration/ProjectionWithStateTest.php
+++ b/packages/PdoEventSourcing/tests/Integration/ProjectionWithStateTest.php
@@ -99,7 +99,8 @@ final class ProjectionWithStateTest extends EventSourcingMessagingTestCase
                     'Test\Ecotone\EventSourcing\Fixture\Ticket',
                     'Test\Ecotone\EventSourcing\Fixture\TicketProjectionState',
                 ]),
-            pathToRootCatalog: __DIR__ . '/../../'
+            pathToRootCatalog: __DIR__ . '/../../',
+            runForProductionEventStore: true
         );
     }
 }

--- a/packages/PdoEventSourcing/tests/Integration/SnapshotsTest.php
+++ b/packages/PdoEventSourcing/tests/Integration/SnapshotsTest.php
@@ -39,7 +39,8 @@ final class SnapshotsTest extends EventSourcingMessagingTestCase
                     EventSourcingConfiguration::createWithDefaults()
                         ->withSnapshots([Ticket::class, Basket::class], 1),
                 ]),
-            pathToRootCatalog: __DIR__ . '/../../'
+            pathToRootCatalog: __DIR__ . '/../../',
+            runForProductionEventStore: true
         );
 
         $ecotone

--- a/packages/PdoEventSourcing/tests/Integration/SpecificEventStreamTest.php
+++ b/packages/PdoEventSourcing/tests/Integration/SpecificEventStreamTest.php
@@ -36,7 +36,8 @@ final class SpecificEventStreamTest extends EventSourcingMessagingTestCase
                     EventSourcingConfiguration::createWithDefaults()
                         ->withStreamPerAggregatePersistenceStrategy(),
                 ]),
-            pathToRootCatalog: __DIR__ . '/../../'
+            pathToRootCatalog: __DIR__ . '/../../',
+            runForProductionEventStore: true
         );
 
         $ecotone

--- a/packages/PdoEventSourcing/tests/Integration/SynchronousEventDrivenProjectionTest.php
+++ b/packages/PdoEventSourcing/tests/Integration/SynchronousEventDrivenProjectionTest.php
@@ -42,6 +42,7 @@ final class SynchronousEventDrivenProjectionTest extends EventSourcingMessagingT
                 EventSourcingConfiguration::createWithDefaults(),
             ]),
             pathToRootCatalog: __DIR__ . '/../../',
+            runForProductionEventStore: true
         );
 
         $ecotone->initializeProjection(InProgressTicketList::IN_PROGRESS_TICKET_PROJECTION);
@@ -73,6 +74,7 @@ final class SynchronousEventDrivenProjectionTest extends EventSourcingMessagingT
                 EventSourcingConfiguration::createWithDefaults(),
             ]),
             pathToRootCatalog: __DIR__ . '/../../',
+            runForProductionEventStore: true
         );
 
         $ecotone->sendCommand(new RegisterTicket('123', 'Marcus', 'alert'));
@@ -110,6 +112,7 @@ final class SynchronousEventDrivenProjectionTest extends EventSourcingMessagingT
                         ->withSnapshots([Ticket::class, Basket::class], 1),
                 ]),
             pathToRootCatalog: __DIR__ . '/../../',
+            runForProductionEventStore: true
         );
 
         $ecotone->initializeProjection(InProgressTicketList::IN_PROGRESS_TICKET_PROJECTION);
@@ -139,6 +142,7 @@ final class SynchronousEventDrivenProjectionTest extends EventSourcingMessagingT
                     'Test\Ecotone\EventSourcing\Fixture\TicketWithSynchronousEventDrivenProjection',
                 ]),
             pathToRootCatalog: __DIR__ . '/../../',
+            runForProductionEventStore: true
         );
 
         $ecotone->initializeProjection(InProgressTicketList::IN_PROGRESS_TICKET_PROJECTION);
@@ -173,6 +177,7 @@ final class SynchronousEventDrivenProjectionTest extends EventSourcingMessagingT
                         ->withOption(ProophProjectionRunningOption::OPTION_LOAD_COUNT, 2),
                 ]),
             pathToRootCatalog: __DIR__ . '/../../',
+            runForProductionEventStore: true
         );
 
         $ecotone->sendCommand(new RegisterTicket('1', 'Marcus', 'alert'));


### PR DESCRIPTION
Some tests have not run against production Event Store, this PR fixes that. 
Plus introduce possibility to delete event stream in order to run tests against production event store easier.