### PR TITLE
fix: allow property attributes on constructor arguments

### DIFF
--- a/packages/Ecotone/src/Messaging/Handler/TypeResolver.php
+++ b/packages/Ecotone/src/Messaging/Handler/TypeResolver.php
@@ -68,7 +68,11 @@ class TypeResolver
 
             $parameterAttributes = [];
             foreach ($parameter->getAttributes() as $attribute) {
-                $parameterAttributes[] = $attribute->newInstance();
+                try {
+                    $parameterAttributes[] = $attribute->newInstance();
+                } catch (\Error $e) {
+                    // ignore errors (e.g. when attribute target property and we are retrieving constructor parameters)
+                }
             }
 
             $parameters[] = InterfaceParameter::create(

--- a/packages/Ecotone/tests/Messaging/Fixture/Handler/ObjectWithConstructorProperties.php
+++ b/packages/Ecotone/tests/Messaging/Fixture/Handler/ObjectWithConstructorProperties.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Test\Ecotone\Messaging\Fixture\Handler;
+
+use Attribute;
+use Ecotone\Modelling\Attribute\AggregateIdentifier;
+
+class ObjectWithConstructorProperties
+{
+    public function __construct(
+        #[ExampleAttribute, AggregateIdentifier] public string $id
+    ) {
+    }
+}
+
+#[Attribute(Attribute::TARGET_PROPERTY)]
+class ExampleAttribute
+{
+}

--- a/packages/Ecotone/tests/Messaging/Unit/Handler/InterfaceToCallTest.php
+++ b/packages/Ecotone/tests/Messaging/Unit/Handler/InterfaceToCallTest.php
@@ -30,6 +30,7 @@ use Test\Ecotone\Messaging\Fixture\Conversion\SuperAdmin;
 use Test\Ecotone\Messaging\Fixture\Conversion\TwoStepPassword;
 use Test\Ecotone\Messaging\Fixture\Conversion\User;
 use Test\Ecotone\Messaging\Fixture\Dto\MethodWithCallable;
+use Test\Ecotone\Messaging\Fixture\Handler\ObjectWithConstructorProperties;
 
 /**
  * Class InterfaceToCallTest
@@ -612,5 +613,12 @@ class InterfaceToCallTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
 
         $interfaceToCall->getClassAnnotation(TypeDescriptor::create(Asynchronous::class));
+    }
+
+    public function test_not_throwing_exception_when_retrieving_constructor_parameter_attributes()
+    {
+        $interfaceToCall = InterfaceToCall::create(ObjectWithConstructorProperties::class, '__construct');
+
+        $this->assertCount(1, $interfaceToCall->getFirstParameter()->getAnnotations());
     }
 }


### PR DESCRIPTION
This PR will allow to have attributes targeting property on constructor property parameters.

For example with Doctrine, this will throw an error, because `Column` attribute is targeting property:

```php
#[Entity]
#[Aggregate]
class Mission
{
    public function __construct(
        #[Column, Id, AggregateIdentifier] public Uuid $id,
    ) {
    }
}
``` 