### PR TITLE
Poll consumer while there are messages to consume

### DIFF
--- a/packages/Ecotone/src/Messaging/Config/Annotation/ModuleConfiguration/MessagingCommands/MessagingBaseCommand.php
+++ b/packages/Ecotone/src/Messaging/Config/Annotation/ModuleConfiguration/MessagingCommands/MessagingBaseCommand.php
@@ -14,7 +14,7 @@ class MessagingBaseCommand
         return $configuredMessagingSystem->runConsoleCommand($commandName, $parameters);
     }
 
-    public function runAsynchronousEndpointCommand(string $consumerName, ConfiguredMessagingSystem $configuredMessagingSystem, #[ConsoleParameterOption] ?string $handledMessageLimit = null, #[ConsoleParameterOption] ?int $executionTimeLimit = null, #[ConsoleParameterOption] ?int $memoryLimit = null, #[ConsoleParameterOption] ?string $cron = null, #[ConsoleParameterOption] bool $stopOnFailure = false): void
+    public function runAsynchronousEndpointCommand(string $consumerName, ConfiguredMessagingSystem $configuredMessagingSystem, #[ConsoleParameterOption] ?string $handledMessageLimit = null, #[ConsoleParameterOption] ?int $executionTimeLimit = null, #[ConsoleParameterOption] ?int $memoryLimit = null, #[ConsoleParameterOption] ?string $cron = null, #[ConsoleParameterOption] bool $stopOnFailure = false, #[ConsoleParameterOption] bool $finishWhenNoMessages = false): void
     {
         $pollingMetadata = ExecutionPollingMetadata::createWithDefaults();
         if ($stopOnFailure) {
@@ -31,6 +31,9 @@ class MessagingBaseCommand
         }
         if ($cron) {
             $pollingMetadata = $pollingMetadata->withCron($cron);
+        }
+        if ($finishWhenNoMessages) {
+            $pollingMetadata = $pollingMetadata->withFinishWhenNoMessages(true);
         }
 
 

--- a/packages/Ecotone/src/Messaging/Endpoint/ExecutionPollingMetadata.php
+++ b/packages/Ecotone/src/Messaging/Endpoint/ExecutionPollingMetadata.php
@@ -9,6 +9,7 @@ final class ExecutionPollingMetadata
     private ?int $memoryLimitInMegabytes = null;
     private ?string $cron = null;
     private ?bool $stopOnError = null;
+    private ?bool $finishWhenNoMessages = null;
 
     private function __construct()
     {
@@ -82,6 +83,14 @@ final class ExecutionPollingMetadata
         return $self;
     }
 
+    public function withFinishWhenNoMessages(bool $finishWhenNoMessages): ExecutionPollingMetadata
+    {
+        $self = clone $this;
+        $self->finishWhenNoMessages = $finishWhenNoMessages;
+
+        return $self;
+    }
+
     public function getCron(): ?string
     {
         return $this->cron;
@@ -105,5 +114,10 @@ final class ExecutionPollingMetadata
     public function getStopOnError(): ?bool
     {
         return $this->stopOnError;
+    }
+
+    public function getFinishWhenNoMessages(): ?bool
+    {
+        return $this->finishWhenNoMessages;
     }
 }

--- a/packages/Ecotone/src/Messaging/Endpoint/InterceptedConsumer.php
+++ b/packages/Ecotone/src/Messaging/Endpoint/InterceptedConsumer.php
@@ -3,6 +3,7 @@
 namespace Ecotone\Messaging\Endpoint;
 
 use Ecotone\Messaging\Endpoint\Interceptor\ConnectionExceptionRetryInterceptor;
+use Ecotone\Messaging\Endpoint\Interceptor\FinishWhenNoMessagesInterceptor;
 use Ecotone\Messaging\Endpoint\Interceptor\LimitConsumedMessagesInterceptor;
 use Ecotone\Messaging\Endpoint\Interceptor\LimitExecutionAmountInterceptor;
 use Ecotone\Messaging\Endpoint\Interceptor\LimitMemoryUsageInterceptor;
@@ -95,6 +96,9 @@ class InterceptedConsumer implements ConsumerLifecycle
         }
         if ($pollingMetadata->getExecutionTimeLimitInMilliseconds() > 0) {
             $interceptors[] = new TimeLimitInterceptor($pollingMetadata->getExecutionTimeLimitInMilliseconds());
+        }
+        if ($pollingMetadata->finishWhenNoMessages()) {
+            $interceptors[] = new FinishWhenNoMessagesInterceptor();
         }
         $interceptors[] = new ConnectionExceptionRetryInterceptor($referenceSearchService->get(LoggingHandlerBuilder::LOGGER_REFERENCE), $pollingMetadata->getConnectionRetryTemplate(), $pollingMetadata->isStoppedOnError());
 

--- a/packages/Ecotone/src/Messaging/Endpoint/InterceptedConsumer.php
+++ b/packages/Ecotone/src/Messaging/Endpoint/InterceptedConsumer.php
@@ -74,8 +74,6 @@ class InterceptedConsumer implements ConsumerLifecycle
     }
 
     /**
-     * @param PollingMetadata $pollingMetadata
-     * @param array $interceptor
      * @return ConsumerInterceptor[]
      * @throws \Ecotone\Messaging\MessagingException
      */

--- a/packages/Ecotone/src/Messaging/Endpoint/Interceptor/FinishWhenNoMessagesInterceptor.php
+++ b/packages/Ecotone/src/Messaging/Endpoint/Interceptor/FinishWhenNoMessagesInterceptor.php
@@ -8,11 +8,6 @@ use Ecotone\Messaging\Endpoint\ConsumerInterceptor;
 use Ecotone\Messaging\Handler\Processor\MethodInvoker\MethodInvocation;
 use Throwable;
 
-/**
- * Class LimitConsumedMessagesExtension
- * @package Ecotone\Messaging\Endpoint\Extension
- * @author Dariusz Gafka <dgafka.mail@gmail.com>
- */
 class FinishWhenNoMessagesInterceptor implements ConsumerInterceptor
 {
     private bool $shouldBeStopped = false;

--- a/packages/Ecotone/src/Messaging/Endpoint/Interceptor/FinishWhenNoMessagesInterceptor.php
+++ b/packages/Ecotone/src/Messaging/Endpoint/Interceptor/FinishWhenNoMessagesInterceptor.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ecotone\Messaging\Endpoint\Interceptor;
+
+use Ecotone\Messaging\Endpoint\ConsumerInterceptor;
+use Ecotone\Messaging\Handler\Processor\MethodInvoker\MethodInvocation;
+use Throwable;
+
+/**
+ * Class LimitConsumedMessagesExtension
+ * @package Ecotone\Messaging\Endpoint\Extension
+ * @author Dariusz Gafka <dgafka.mail@gmail.com>
+ */
+class FinishWhenNoMessagesInterceptor implements ConsumerInterceptor
+{
+    private bool $shouldBeStopped = false;
+
+    /**
+     * @inheritDoc
+     */
+    public function onStartup(): void
+    {
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function preRun(): void
+    {
+        $this->shouldBeStopped = true;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function shouldBeThrown(Throwable $exception): bool
+    {
+        return false;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function shouldBeStopped(): bool
+    {
+        return $this->shouldBeStopped;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function postRun(): void
+    {
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function postSend(MethodInvocation $methodInvocation): mixed
+    {
+        $this->shouldBeStopped = false;
+
+        return $methodInvocation->proceed();
+    }
+
+    public function isInterestedInPostSend(): bool
+    {
+        return true;
+    }
+}

--- a/packages/Ecotone/src/Messaging/Endpoint/PollingMetadata.php
+++ b/packages/Ecotone/src/Messaging/Endpoint/PollingMetadata.php
@@ -18,6 +18,7 @@ final class PollingMetadata
     public const DEFAULT_EXECUTION_LIMIT = 0;
     public const DEFAULT_EXECUTION_TIME_LIMIT_IN_MILLISECONDS = 0;
     public const DEFAULT_STOP_ON_ERROR = false;
+    public const DEFAULT_FINISH_WHEN_NO_MESSAGES = false;
 
     private string $endpointId;
     private string $cron = '';
@@ -41,6 +42,8 @@ final class PollingMetadata
     private string $triggerReferenceName = '';
     private string $taskExecutorName = '';
     private bool $stopOnError = self::DEFAULT_STOP_ON_ERROR;
+    private bool $finishWhenNoMessages = self::DEFAULT_FINISH_WHEN_NO_MESSAGES;
+
     /**
      * PollingMetadata constructor.
      * @param string $endpointId
@@ -147,6 +150,9 @@ final class PollingMetadata
         }
         if (! is_null($executionPollingMetadata->getCron())) {
             $copy = $copy->setCron($executionPollingMetadata->getCron());
+        }
+        if (! is_null($executionPollingMetadata->getFinishWhenNoMessages())) {
+            $copy = $copy->setFinishWhenNoMessages($executionPollingMetadata->getFinishWhenNoMessages());
         }
 
         return $copy;
@@ -306,6 +312,14 @@ final class PollingMetadata
         return $copy;
     }
 
+    public function setFinishWhenNoMessages(bool $finishWhenNoMessages): PollingMetadata
+    {
+        $copy = $this->createCopy();
+        $copy->finishWhenNoMessages = $finishWhenNoMessages;
+
+        return $copy;
+    }
+
     /**1
      * @return int
      */
@@ -400,6 +414,11 @@ final class PollingMetadata
     public function getHandledMessageLimit(): int
     {
         return $this->handledMessageLimit;
+    }
+
+    public function finishWhenNoMessages(): bool
+    {
+        return $this->finishWhenNoMessages;
     }
 
     /**

--- a/packages/Ecotone/tests/Messaging/Unit/Endpoint/Poller/PollingConsumerBuilderTest.php
+++ b/packages/Ecotone/tests/Messaging/Unit/Endpoint/Poller/PollingConsumerBuilderTest.php
@@ -398,29 +398,7 @@ class PollingConsumerBuilderTest extends MessagingTest
     public function test_finish_when_no_messages(): void
     {
         $inputChannelName = 'inputChannel';
-        $inputChannel = new class implements PollableChannel {
-            private array $queue = [];
-
-            public function receive(): ?Message
-            {
-                return array_shift($this->queue);
-            }
-
-            public function send(Message $message): void
-            {
-                $this->queue[] = $message;
-            }
-
-            public function receiveWithTimeout(int $timeoutInMilliseconds): ?Message
-            {
-                return $this->receive();
-            }
-
-            public function queueSize(): int
-            {
-                return count($this->queue);
-            }
-        };
+        $inputChannel = QueueChannel::create();
         $objectToInvokeOn = new class {
             public array $receivedMessages = [];
             public function handle(Message $message): void
@@ -445,7 +423,7 @@ class PollingConsumerBuilderTest extends MessagingTest
         $inputChannel->send(MessageBuilder::withPayload('some')->build());
         $pollingConsumer->run();
 
-        $this->assertSame(0, $inputChannel->queueSize());
+        $this->assertNull($inputChannel->receive());
         $this->assertCount(2, $objectToInvokeOn->receivedMessages);
     }
 


### PR DESCRIPTION
Add `--finishWhenNoMessages` option when running asynchronous endpoints. The execution will be stopped when there are no messages to handle