### PR TITLE
reliable symfony transport

### DIFF
--- a/packages/Symfony/SymfonyBundle/Messenger/SymfonyAcknowledgementCallback.php
+++ b/packages/Symfony/SymfonyBundle/Messenger/SymfonyAcknowledgementCallback.php
@@ -8,6 +8,7 @@ use Ecotone\Enqueue\EnqueueAcknowledgementCallback;
 use Ecotone\Messaging\Endpoint\AcknowledgementCallback;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Transport\Receiver\ReceiverInterface;
+use Symfony\Component\Messenger\Transport\TransportInterface;
 
 /**
  * Class EnqueueAcknowledgementCallback
@@ -20,17 +21,21 @@ class SymfonyAcknowledgementCallback implements AcknowledgementCallback
     public const MANUAL_ACK = 'manual';
     public const NONE = 'none';
 
-    private function __construct(private bool $isAutoAck, private ReceiverInterface $symfonyReceiver, private Envelope $envelope)
+    private function __construct(
+        private bool $isAutoAck, 
+        private TransportInterface $symfonyTransport,
+        private Envelope $envelope
+    )
     {
 
     }
 
-    public static function createWithAutoAck(ReceiverInterface $symfonyTransport, Envelope $envelope): self
+    public static function createWithAutoAck(TransportInterface $symfonyTransport, Envelope $envelope): self
     {
         return new self(true, $symfonyTransport, $envelope);
     }
 
-    public static function createWithManualAck(ReceiverInterface $symfonyTransport, Envelope $envelope): self
+    public static function createWithManualAck(TransportInterface $symfonyTransport, Envelope $envelope): self
     {
         return new self(false, $symfonyTransport, $envelope);
     }
@@ -56,7 +61,7 @@ class SymfonyAcknowledgementCallback implements AcknowledgementCallback
      */
     public function accept(): void
     {
-        $this->symfonyReceiver->ack($this->envelope);
+        $this->symfonyTransport->ack($this->envelope);
     }
 
     /**
@@ -64,7 +69,7 @@ class SymfonyAcknowledgementCallback implements AcknowledgementCallback
      */
     public function reject(): void
     {
-        $this->symfonyReceiver->reject($this->envelope);
+        $this->symfonyTransport->reject($this->envelope);
     }
 
     /**
@@ -72,7 +77,7 @@ class SymfonyAcknowledgementCallback implements AcknowledgementCallback
      */
     public function requeue(): void
     {
-        /** Symfony receiver does not support reject with requeue */
-        $this->symfonyReceiver->reject($this->envelope);
+        $this->symfonyTransport->send($this->envelope);
+        $this->symfonyTransport->reject($this->envelope);
     }
 }

--- a/packages/Symfony/SymfonyBundle/Messenger/SymfonyMessageConverter.php
+++ b/packages/Symfony/SymfonyBundle/Messenger/SymfonyMessageConverter.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ecotone\SymfonyBundle\Messenger;
+
+use Ecotone\Messaging\Conversion\ConversionService;
+use Ecotone\Messaging\Conversion\MediaType;
+use Ecotone\Messaging\Handler\TypeDescriptor;
+use Ecotone\Messaging\Message;
+use Ecotone\Messaging\MessageConverter\HeaderMapper;
+use Ecotone\Messaging\MessageHeaders;
+use Ecotone\Messaging\Support\Assert;
+use Ecotone\Messaging\Support\MessageBuilder;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Stamp\DelayStamp;
+use Symfony\Component\Messenger\Transport\TransportInterface;
+
+final class SymfonyMessageConverter
+{
+    public const ECOTONE_SYMFONY_ACKNOWLEDGE_HEADER = 'ecotone.symfony.acknowledge';
+
+    public function __construct(
+        private HeaderMapper $headerMapper,
+        private string $acknowledgeMode,
+        private ConversionService $conversionService
+    ) {
+
+    }
+
+    public function convertToSymfonyMessage(Message $message, bool $withDelay): Envelope
+    {
+        $payload = $message->getPayload();
+        $headers = MessageHeaders::unsetEnqueueMetadata($message->getHeaders()->headers());
+        $headers = $this->headerMapper->mapFromMessageHeaders($headers, $this->conversionService);
+
+        $type = TypeDescriptor::createFromVariable($payload);
+        $contentType = MediaType::createApplicationXPHPWithTypeParameter($type->toString());
+        if (! TypeDescriptor::createFromVariable($payload)->isClassOrInterface()) {
+            $payload = new WrappedPayload($payload);
+            if ($message->getHeaders()->hasContentType()) {
+                $contentType = $message->getHeaders()->getContentType();
+            }
+        } else {
+            $headers[MessageHeaders::TYPE_ID] = $type->toString();
+        }
+
+        $headers[MessageHeaders::CONTENT_TYPE] = $contentType->toString();
+        $envelopeToSend = new Envelope($payload, [new MetadataStamp($headers)]);
+
+        if ($message->getHeaders()->containsKey(MessageHeaders::DELIVERY_DELAY) && $withDelay) {
+            $envelopeToSend = $envelopeToSend->with(new DelayStamp($message->getHeaders()->get(MessageHeaders::DELIVERY_DELAY)));
+        }
+
+        return $envelopeToSend;
+    }
+
+    public function convertFromSymfonyMessage(Envelope $symfonyEnvelope, TransportInterface $symfonyTransport): Message
+    {
+        $headers = $symfonyEnvelope->last(MetadataStamp::class)->getMetadata();
+
+        $payload = $symfonyEnvelope->getMessage();
+        if ($payload instanceof WrappedPayload) {
+            $payload = $payload->getPayload();
+        }
+        $messageBuilder = MessageBuilder::withPayload($payload)
+            ->setMultipleHeaders($this->headerMapper->mapToMessageHeaders($headers, $this->conversionService));
+
+        if (array_key_exists(MessageHeaders::CONTENT_TYPE, $headers)) {
+            $messageBuilder = $messageBuilder
+                ->setContentType(MediaType::parseMediaType($headers[MessageHeaders::CONTENT_TYPE]));
+        }
+
+        if (in_array($this->acknowledgeMode, [SymfonyAcknowledgementCallback::AUTO_ACK, SymfonyAcknowledgementCallback::MANUAL_ACK])) {
+            if ($this->acknowledgeMode == SymfonyAcknowledgementCallback::AUTO_ACK) {
+                $amqpAcknowledgeCallback = SymfonyAcknowledgementCallback::createWithAutoAck(
+                    $symfonyTransport,
+                    $symfonyEnvelope
+                );
+            } else {
+                $amqpAcknowledgeCallback = SymfonyAcknowledgementCallback::createWithManualAck(
+                    $symfonyTransport,
+                    $symfonyEnvelope
+                );
+            }
+
+            $messageBuilder = $messageBuilder
+                ->setHeader(MessageHeaders::CONSUMER_ACK_HEADER_LOCATION, self::ECOTONE_SYMFONY_ACKNOWLEDGE_HEADER)
+                ->setHeader(self::ECOTONE_SYMFONY_ACKNOWLEDGE_HEADER, $amqpAcknowledgeCallback);
+        }
+
+        return $messageBuilder->build();
+    }
+}

--- a/packages/Symfony/SymfonyBundle/Messenger/SymfonyMessengerMessageChannel.php
+++ b/packages/Symfony/SymfonyBundle/Messenger/SymfonyMessengerMessageChannel.php
@@ -19,42 +19,18 @@ use Symfony\Component\Messenger\Transport\TransportInterface;
 
 final class SymfonyMessengerMessageChannel implements PollableChannel
 {
-    public const ECOTONE_SYMFONY_ACKNOWLEDGE_HEADER = 'ecotone.symfony.acknowledge';
-
     public function __construct(
         private TransportInterface $symfonyTransport,
-        private HeaderMapper $headerMapper,
-        private string $acknowledgeMode,
-        private ConversionService $conversionService
+        private SymfonyMessageConverter $symfonyMessageConverter
     ) {
 
     }
 
     public function send(Message $message): void
     {
-        $payload = $message->getPayload();
-        $headers = MessageHeaders::unsetEnqueueMetadata($message->getHeaders()->headers());
-        $headers = $this->headerMapper->mapFromMessageHeaders($headers, $this->conversionService);
-
-        $type = TypeDescriptor::createFromVariable($payload);
-        $contentType = MediaType::createApplicationXPHPWithTypeParameter($type->toString());
-        if (! TypeDescriptor::createFromVariable($payload)->isClassOrInterface()) {
-            $payload = new WrappedPayload($payload);
-            if ($message->getHeaders()->hasContentType()) {
-                $contentType = $message->getHeaders()->getContentType();
-            }
-        } else {
-            $headers[MessageHeaders::TYPE_ID] = $type->toString();
-        }
-
-        $headers[MessageHeaders::CONTENT_TYPE] = $contentType->toString();
-        $envelopeToSend = new Envelope($payload, [new MetadataStamp($headers)]);
-
-        if ($message->getHeaders()->containsKey(MessageHeaders::DELIVERY_DELAY)) {
-            $envelopeToSend = $envelopeToSend->with(new DelayStamp($message->getHeaders()->get(MessageHeaders::DELIVERY_DELAY)));
-        }
-
-        $this->symfonyTransport->send($envelopeToSend);
+        $this->symfonyTransport->send(
+            $this->symfonyMessageConverter->convertToSymfonyMessage($message, true)
+        );
     }
 
     public function receive(): ?Message
@@ -67,41 +43,11 @@ final class SymfonyMessengerMessageChannel implements PollableChannel
         }
 
         Assert::isTrue(count($symfonyEnvelope) === 1, 'Symfony messenger transport should be configured to return only one message at a time');
-        $symfonyEnvelope = $symfonyEnvelope[0];
 
-        $headers = $symfonyEnvelope->last(MetadataStamp::class)->getMetadata();
-
-        $payload = $symfonyEnvelope->getMessage();
-        if ($payload instanceof WrappedPayload) {
-            $payload = $payload->getPayload();
-        }
-        $messageBuilder = MessageBuilder::withPayload($payload)
-            ->setMultipleHeaders($this->headerMapper->mapToMessageHeaders($headers, $this->conversionService));
-
-        if (array_key_exists(MessageHeaders::CONTENT_TYPE, $headers)) {
-            $messageBuilder = $messageBuilder
-                ->setContentType(MediaType::parseMediaType($headers[MessageHeaders::CONTENT_TYPE]));
-        }
-
-        if (in_array($this->acknowledgeMode, [SymfonyAcknowledgementCallback::AUTO_ACK, SymfonyAcknowledgementCallback::MANUAL_ACK])) {
-            if ($this->acknowledgeMode == SymfonyAcknowledgementCallback::AUTO_ACK) {
-                $amqpAcknowledgeCallback = SymfonyAcknowledgementCallback::createWithAutoAck(
-                    $this->symfonyTransport,
-                    $symfonyEnvelope
-                );
-            } else {
-                $amqpAcknowledgeCallback = SymfonyAcknowledgementCallback::createWithManualAck(
-                    $this->symfonyTransport,
-                    $symfonyEnvelope
-                );
-            }
-
-            $messageBuilder = $messageBuilder
-                ->setHeader(MessageHeaders::CONSUMER_ACK_HEADER_LOCATION, self::ECOTONE_SYMFONY_ACKNOWLEDGE_HEADER)
-                ->setHeader(self::ECOTONE_SYMFONY_ACKNOWLEDGE_HEADER, $amqpAcknowledgeCallback);
-        }
-
-        return $messageBuilder->build();
+        return $this->symfonyMessageConverter->convertFromSymfonyMessage(
+            $symfonyEnvelope[0],
+            $this->symfonyTransport
+        );
     }
 
     public function receiveWithTimeout(int $timeoutInMilliseconds): ?Message

--- a/packages/Symfony/SymfonyBundle/Messenger/SymfonyMessengerMessageChannelBuilder.php
+++ b/packages/Symfony/SymfonyBundle/Messenger/SymfonyMessengerMessageChannelBuilder.php
@@ -60,9 +60,11 @@ final class SymfonyMessengerMessageChannelBuilder implements MessageChannelBuild
 
         return new SymfonyMessengerMessageChannel(
             $transport,
-            DefaultHeaderMapper::createWith($this->headerMapper, $this->headerMapper),
-            $this->acknowledgeMode,
-            $conversionService
+            new SymfonyMessageConverter(
+                DefaultHeaderMapper::createWith($this->headerMapper, $this->headerMapper),
+                $this->acknowledgeMode,
+                $conversionService
+            )
         );
     }
 

--- a/packages/Symfony/tests/phpunit/MessengerIntegrationTest.php
+++ b/packages/Symfony/tests/phpunit/MessengerIntegrationTest.php
@@ -109,8 +109,7 @@ final class MessengerIntegrationTest extends WebTestCase
 
         $this->assertCount(1, $messaging->sendQueryWithRouting('consumer.getMessages'));
     }
-
-    /** Rejecting instead of requeuing due to lack of support */
+    
     public function test_rejecting_message_when_fails()
     {
         $channelName = 'messenger_async';
@@ -130,7 +129,7 @@ final class MessengerIntegrationTest extends WebTestCase
         $this->assertCount(1, $messaging->sendQueryWithRouting('consumer.getMessages'));
 
         $messaging->run($channelName, ExecutionPollingMetadata::createWithTestingSetup(failAtError: false));
-        $this->assertCount(1, $messaging->sendQueryWithRouting('consumer.getMessages'));
+        $this->assertCount(0, $messaging->sendQueryWithRouting('consumer.getMessages'));
     }
 
     public function test_sending_via_routing_without_payload()

--- a/packages/Symfony/tests/phpunit/MessengerIntegrationTest.php
+++ b/packages/Symfony/tests/phpunit/MessengerIntegrationTest.php
@@ -110,7 +110,7 @@ final class MessengerIntegrationTest extends WebTestCase
         $this->assertCount(1, $messaging->sendQueryWithRouting('consumer.getMessages'));
     }
     
-    public function test_rejecting_message_when_fails()
+    public function test_requeing_message_when_fails()
     {
         $channelName = 'messenger_async';
         $messagePayload = new ExampleCommand(Uuid::uuid4()->toString());
@@ -129,7 +129,7 @@ final class MessengerIntegrationTest extends WebTestCase
         $this->assertCount(1, $messaging->sendQueryWithRouting('consumer.getMessages'));
 
         $messaging->run($channelName, ExecutionPollingMetadata::createWithTestingSetup(failAtError: false));
-        $this->assertCount(0, $messaging->sendQueryWithRouting('consumer.getMessages'));
+        $this->assertCount(2, $messaging->sendQueryWithRouting('consumer.getMessages'));
     }
 
     public function test_sending_via_routing_without_payload()


### PR DESCRIPTION
Symfony Messenger when Message can't be sent to failed transport [will lose the Message.](https://github.com/symfony/symfony/issues/36870)
This is not the case when using Ecotone with Messenger Transport. Ecotone will requeue the message in that case.

To ensure all Message duduplications are handled correctly install [Dbal Module](https://github.com/o/-M-DmcwekWzN78BCsTLK/s/-LmAUnBnyZgZuLF2eWLn/~/changes/681/modules/dbal-support).