### PR TITLE
Allow setting up Dead Letter for Messages failed during sending

### DIFF
--- a/packages/Amqp/tests/Integration/AmqpChannelAdapterTest.php
+++ b/packages/Amqp/tests/Integration/AmqpChannelAdapterTest.php
@@ -371,7 +371,7 @@ class AmqpChannelAdapterTest extends AmqpMessagingTest
         $this->assertNotNull($message, 'Message was not received from rabbit');
         $this->assertEquals(
             $message->getPayload(),
-            serialize($payload)
+            addslashes(serialize($payload))
         );
     }
 

--- a/packages/Dbal/tests/Fixture/ORM/AsynchronousEventHandler/NotificationService.php
+++ b/packages/Dbal/tests/Fixture/ORM/AsynchronousEventHandler/NotificationService.php
@@ -6,14 +6,23 @@ namespace Test\Ecotone\Dbal\Fixture\ORM\AsynchronousEventHandler;
 
 use Ecotone\Messaging\Attribute\Asynchronous;
 use Ecotone\Modelling\Attribute\EventHandler;
+use Ecotone\Modelling\Attribute\QueryHandler;
 use Test\Ecotone\Dbal\Fixture\ORM\Person\PersonRegistered;
 
 final class NotificationService
 {
+    private bool $isNotified = false;
+
     #[Asynchronous('notifications')]
     #[EventHandler(endpointId: 'personNotifierPersonRegistered')]
     public function handle(PersonRegistered $event): void
     {
-        // do something
+        $this->isNotified = true;
+    }
+
+    #[QueryHandler("notification.isNotified")]
+    public function isNotified(): bool
+    {
+        return $this->isNotified;
     }
 }

--- a/packages/Dbal/tests/Integration/CollectorModuleTest.php
+++ b/packages/Dbal/tests/Integration/CollectorModuleTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Test\Ecotone\Dbal\Integration;
 
 use Ecotone\Dbal\Configuration\DbalConfiguration;
+use Ecotone\Dbal\Recoverability\DeadLetterGateway;
 use Ecotone\Lite\EcotoneLite;
 use Ecotone\Lite\Test\FlowTestSupport;
 use Ecotone\Messaging\Channel\Collector\Config\CollectorConfiguration;
@@ -14,8 +15,11 @@ use Ecotone\Messaging\Channel\PollableChannel\PollableChannelConfiguration;
 use Ecotone\Messaging\Channel\SimpleMessageChannelBuilder;
 use Ecotone\Messaging\Config\ModulePackageList;
 use Ecotone\Messaging\Config\ServiceConfiguration;
+use Ecotone\Messaging\Endpoint\ExecutionPollingMetadata;
+use Ecotone\Messaging\MessageHeaders;
 use Ecotone\Modelling\AggregateNotFoundException;
 use Enqueue\Dbal\DbalConnectionFactory;
+use Ramsey\Uuid\Uuid;
 use Test\Ecotone\Dbal\DbalMessagingTestCase;
 use Test\Ecotone\Dbal\Fixture\ORM\AsynchronousEventHandler\NotificationService;
 use Test\Ecotone\Dbal\Fixture\ORM\Person\Person;
@@ -71,6 +75,62 @@ final class CollectorModuleTest extends DbalMessagingTestCase
         $this->expectException(AggregateNotFoundException::class);
 
         $ecotoneLite->sendQueryWithRouting('person.getName', metadata: ['aggregate.id' => 100]);
+    }
+
+    public function test_sending_to_dead_letter_should_not_rollback_transaction()
+    {
+        $ecotoneLite = $this->bootstrapEcotone(
+            [Person::class, NotificationService::class],
+            [new NotificationService(), DbalConnectionFactory::class => $this->getORMConnectionFactory([__DIR__.'/../Fixture/ORM/Person'])],
+            [
+                SimpleMessageChannelBuilder::createQueueChannel('orders'),
+                ExceptionalQueueChannel::createWithExceptionOnSend('notifications'),
+            ],
+            [
+                PollableChannelConfiguration::neverRetry('notifications')
+                    ->withDeadLetterChannel('dbal_dead_letter')
+                    ->withCollector(true),
+            ]
+        );
+
+        $ecotoneLite->sendCommand(new RegisterPerson(100, 'Johny'));
+
+        $this->assertNotNull(
+            $ecotoneLite->sendQueryWithRouting('person.getName', metadata: ['aggregate.id' => 100])
+        );
+    }
+
+    public function test_replaying_message_sent_error_message_from_dead_letter()
+    {
+        $ecotoneLite = $this->bootstrapEcotone(
+            [Person::class, NotificationService::class],
+            [new NotificationService(), DbalConnectionFactory::class => $this->getORMConnectionFactory([__DIR__.'/../Fixture/ORM/Person'])],
+            [
+                SimpleMessageChannelBuilder::createQueueChannel('orders'),
+                ExceptionalQueueChannel::createWithExceptionOnSend('notifications', stopFailingAfterAttempt: 1),
+            ],
+            [
+                PollableChannelConfiguration::neverRetry('notifications')
+                    ->withDeadLetterChannel('dbal_dead_letter')
+                    ->withCollector(true),
+            ]
+        );
+
+        $messageId = Uuid::uuid4()->toString();
+        $ecotoneLite->sendCommand(new RegisterPerson(100, 'Johny'));
+
+        $ecotoneLite->run('notifications', ExecutionPollingMetadata::createWithTestingSetup());
+        $this->assertFalse($ecotoneLite->sendQueryWithRouting('notification.isNotified'));
+
+        /** @var DeadLetterGateway $deadLetterGateway */
+        $deadLetterGateway = $ecotoneLite->getGateway(DeadLetterGateway::class);
+        foreach ($deadLetterGateway->list(1, 0) as $errorContext) {
+            $deadLetterGateway->reply($errorContext->getMessageId());
+        }
+        $this->assertFalse($ecotoneLite->sendQueryWithRouting('notification.isNotified'));
+
+        $ecotoneLite->run('notifications', ExecutionPollingMetadata::createWithTestingSetup());
+        $this->assertTrue($ecotoneLite->sendQueryWithRouting('notification.isNotified'));
     }
 
     /**

--- a/packages/Dbal/tests/Integration/CollectorModuleTest.php
+++ b/packages/Dbal/tests/Integration/CollectorModuleTest.php
@@ -88,7 +88,7 @@ final class CollectorModuleTest extends DbalMessagingTestCase
             ],
             [
                 PollableChannelConfiguration::neverRetry('notifications')
-                    ->withDeadLetterChannel('dbal_dead_letter')
+                    ->withErrorChannel('dbal_dead_letter')
                     ->withCollector(true),
             ]
         );
@@ -111,7 +111,7 @@ final class CollectorModuleTest extends DbalMessagingTestCase
             ],
             [
                 PollableChannelConfiguration::neverRetry('notifications')
-                    ->withDeadLetterChannel('dbal_dead_letter')
+                    ->withErrorChannel('dbal_dead_letter')
                     ->withCollector(true),
             ]
         );

--- a/packages/Ecotone/src/Messaging/Channel/ExceptionalQueueChannel.php
+++ b/packages/Ecotone/src/Messaging/Channel/ExceptionalQueueChannel.php
@@ -4,32 +4,35 @@ declare(strict_types=1);
 
 namespace Ecotone\Messaging\Channel;
 
+use Ecotone\Messaging\Conversion\MediaType;
 use Ecotone\Messaging\Endpoint\PollingConsumer\ConnectionException;
 use Ecotone\Messaging\Handler\InterfaceToCallRegistry;
 use Ecotone\Messaging\Handler\ReferenceSearchService;
 use Ecotone\Messaging\Message;
 use Ecotone\Messaging\MessageChannel;
+use Ecotone\Messaging\MessageConverter\DefaultHeaderMapper;
+use Ecotone\Messaging\MessageConverter\HeaderMapper;
 use Ecotone\Messaging\PollableChannel;
 use RuntimeException;
 
-class ExceptionalQueueChannel implements PollableChannel, MessageChannelBuilder
+class ExceptionalQueueChannel implements PollableChannel, MessageChannelWithSerializationBuilder
 {
     private int $exceptionCount = 0;
     private QueueChannel $queueChannel;
 
-    private function __construct(private string $channelName, private bool $exceptionOnReceive, private bool $exceptionOnSend, private int $recoverAtAttempt)
+    private function __construct(private string $channelName, private bool $exceptionOnReceive, private bool $exceptionOnSend, private int $stopFailingAfterAttempt)
     {
         $this->queueChannel = QueueChannel::create();
     }
 
-    public static function createWithExceptionOnReceive(string $channelName = 'exceptionalChannel', int $recoverAtAttempt = 100): self
+    public static function createWithExceptionOnReceive(string $channelName = 'exceptionalChannel', int $stopFailingAfterAttempt = 100): self
     {
-        return new self($channelName, true, false, $recoverAtAttempt);
+        return new self($channelName, true, false, $stopFailingAfterAttempt);
     }
 
-    public static function createWithExceptionOnSend(string $channelName = 'exceptionalChannel', int $recoverAtAttempt = 100): self
+    public static function createWithExceptionOnSend(string $channelName = 'exceptionalChannel', int $stopFailingAfterAttempt = 100): self
     {
-        return new self($channelName, false, true, $recoverAtAttempt);
+        return new self($channelName, false, true, $stopFailingAfterAttempt);
     }
 
     /**
@@ -37,7 +40,7 @@ class ExceptionalQueueChannel implements PollableChannel, MessageChannelBuilder
      */
     public function send(Message $message): void
     {
-        if ($this->exceptionOnSend && $this->exceptionCount < $this->recoverAtAttempt) {
+        if ($this->exceptionOnSend && $this->exceptionCount < $this->stopFailingAfterAttempt) {
             $this->exceptionCount++;
             throw new RuntimeException('Exception on send');
         }
@@ -50,12 +53,22 @@ class ExceptionalQueueChannel implements PollableChannel, MessageChannelBuilder
      */
     public function receive(): ?Message
     {
-        if ($this->exceptionOnReceive && $this->exceptionCount < $this->recoverAtAttempt) {
+        if ($this->exceptionOnReceive && $this->exceptionCount < $this->stopFailingAfterAttempt) {
             $this->exceptionCount++;
             throw new ConnectionException();
         }
 
         return $this->queueChannel->receive();
+    }
+
+    public function getConversionMediaType(): ?MediaType
+    {
+        return null;
+    }
+
+    public function getHeaderMapper(): HeaderMapper
+    {
+        return DefaultHeaderMapper::createAllHeadersMapping();
     }
 
     /**

--- a/packages/Ecotone/src/Messaging/Channel/PollableChannel/GlobalPollableChannelConfiguration.php
+++ b/packages/Ecotone/src/Messaging/Channel/PollableChannel/GlobalPollableChannelConfiguration.php
@@ -7,32 +7,28 @@ namespace Ecotone\Messaging\Channel\PollableChannel;
 use Ecotone\Messaging\Handler\Recoverability\RetryTemplate;
 use Ecotone\Messaging\Handler\Recoverability\RetryTemplateBuilder;
 
-class PollableChannelConfiguration
+final class GlobalPollableChannelConfiguration
 {
     private function __construct(
-        private string        $channelName,
         private RetryTemplate $retryTemplate,
         private bool          $collectorEnabled = true,
-        private ?string       $errorChannelName = null
+        private ?string $errorChannelName = null
     ) {
     }
 
-    public static function createWithDefaults(string $channelName): self
+    public static function createWithDefaults(): self
     {
-        return new self(
-            $channelName,
-            self::defaultRetry(),
-        );
+        return new self(self::defaultRetry());
     }
 
-    public static function create(string $channelName, RetryTemplate $retryTemplate): self
+    public static function create(RetryTemplate $retryTemplate): self
     {
-        return new self($channelName, $retryTemplate);
+        return new self($retryTemplate);
     }
 
-    public static function neverRetry(string $channelName): self
+    public static function neverRetry(): self
     {
-        return new self($channelName, RetryTemplate::createNeverRetry());
+        return new self(RetryTemplate::createNeverRetry());
     }
 
     public function withCollector(bool $collectorEnabled): self
@@ -56,11 +52,6 @@ class PollableChannelConfiguration
         return RetryTemplateBuilder::exponentialBackoff(1, 20)
             ->maxRetryAttempts(2)
             ->build();
-    }
-
-    public function getChannelName(): string
-    {
-        return $this->channelName;
     }
 
     public function getRetryTemplate(): RetryTemplate

--- a/packages/Ecotone/src/Messaging/Channel/PollableChannel/SendRetries/PollableChannelSendRetriesModule.php
+++ b/packages/Ecotone/src/Messaging/Channel/PollableChannel/SendRetries/PollableChannelSendRetriesModule.php
@@ -41,7 +41,8 @@ final class PollableChannelSendRetriesModule extends NoExternalConfigurationModu
             $messagingConfiguration->registerChannelInterceptor(
                 new RetriesChannelInterceptorBuilder(
                     $pollableMessageChannel->getMessageChannelName(),
-                    $channelConfiguration->getRetryTemplate()
+                    $channelConfiguration->getRetryTemplate(),
+                    $channelConfiguration->getDlqChannelName()
                 )
             );
         }

--- a/packages/Ecotone/src/Messaging/Channel/PollableChannel/SendRetries/PollableChannelSendRetriesModule.php
+++ b/packages/Ecotone/src/Messaging/Channel/PollableChannel/SendRetries/PollableChannelSendRetriesModule.php
@@ -7,6 +7,7 @@ namespace Ecotone\Messaging\Channel\PollableChannel\SendRetries;
 use Ecotone\AnnotationFinder\AnnotationFinder;
 use Ecotone\Messaging\Attribute\ModuleAnnotation;
 use Ecotone\Messaging\Channel\MessageChannelBuilder;
+use Ecotone\Messaging\Channel\PollableChannel\GlobalPollableChannelConfiguration;
 use Ecotone\Messaging\Channel\PollableChannel\PollableChannelConfiguration;
 use Ecotone\Messaging\Config\Annotation\AnnotationModule;
 use Ecotone\Messaging\Config\Annotation\ModuleConfiguration\ExtensionObjectResolver;
@@ -26,11 +27,12 @@ final class PollableChannelSendRetriesModule extends NoExternalConfigurationModu
 
     public function prepare(Configuration $messagingConfiguration, array $extensionObjects, ModuleReferenceSearchService $moduleReferenceSearchService, InterfaceToCallRegistry $interfaceToCallRegistry): void
     {
+        $globalPollableChannelConfiguration = ExtensionObjectResolver::resolveUnique(GlobalPollableChannelConfiguration::class, $extensionObjects, GlobalPollableChannelConfiguration::createWithDefaults());
         $pollableMessageChannels = ExtensionObjectResolver::resolve(MessageChannelBuilder::class, $extensionObjects);
         $pollableChannelConfigurations = ExtensionObjectResolver::resolve(PollableChannelConfiguration::class, $extensionObjects);
 
         foreach ($pollableMessageChannels as $pollableMessageChannel) {
-            $channelConfiguration = PollableChannelConfiguration::createWithDefaults($pollableMessageChannel->getMessageChannelName());
+            $channelConfiguration = $globalPollableChannelConfiguration;
 
             foreach ($pollableChannelConfigurations as $pollableChannelConfiguration) {
                 if ($pollableChannelConfiguration->getChannelName() === $pollableMessageChannel->getMessageChannelName()) {
@@ -42,7 +44,7 @@ final class PollableChannelSendRetriesModule extends NoExternalConfigurationModu
                 new RetriesChannelInterceptorBuilder(
                     $pollableMessageChannel->getMessageChannelName(),
                     $channelConfiguration->getRetryTemplate(),
-                    $channelConfiguration->getDlqChannelName()
+                    $channelConfiguration->getErrorChannelName()
                 )
             );
         }
@@ -51,6 +53,7 @@ final class PollableChannelSendRetriesModule extends NoExternalConfigurationModu
     public function canHandle($extensionObject): bool
     {
         return $extensionObject instanceof PollableChannelConfiguration
+            || $extensionObject instanceof GlobalPollableChannelConfiguration
             || ($extensionObject instanceof MessageChannelBuilder && $extensionObject->isPollable());
     }
 

--- a/packages/Ecotone/src/Messaging/Channel/PollableChannel/SendRetries/RetriesChannelInterceptorBuilder.php
+++ b/packages/Ecotone/src/Messaging/Channel/PollableChannel/SendRetries/RetriesChannelInterceptorBuilder.php
@@ -18,7 +18,7 @@ final class RetriesChannelInterceptorBuilder implements ChannelInterceptorBuilde
     public function __construct(
         private string $relatedChannel,
         private RetryTemplate $retryTemplate,
-        private ?string $deadLetterChannel
+        private ?string $errorChannel
     )
     {
     }
@@ -48,7 +48,7 @@ final class RetriesChannelInterceptorBuilder implements ChannelInterceptorBuilde
         return new SendRetryChannelInterceptor(
             $this->relatedChannel,
             $this->retryTemplate,
-            $this->deadLetterChannel,
+            $this->errorChannel,
             $referenceSearchService->get(ConfiguredMessagingSystem::class),
             $referenceSearchService->get(LoggingHandlerBuilder::LOGGER_REFERENCE)
         );

--- a/packages/Ecotone/src/Messaging/Channel/PollableChannel/SendRetries/RetriesChannelInterceptorBuilder.php
+++ b/packages/Ecotone/src/Messaging/Channel/PollableChannel/SendRetries/RetriesChannelInterceptorBuilder.php
@@ -6,6 +6,7 @@ namespace Ecotone\Messaging\Channel\PollableChannel\SendRetries;
 
 use Ecotone\Messaging\Channel\ChannelInterceptor;
 use Ecotone\Messaging\Channel\ChannelInterceptorBuilder;
+use Ecotone\Messaging\Config\ConfiguredMessagingSystem;
 use Ecotone\Messaging\Handler\InterfaceToCallRegistry;
 use Ecotone\Messaging\Handler\Logger\LoggingHandlerBuilder;
 use Ecotone\Messaging\Handler\Recoverability\RetryTemplate;
@@ -14,7 +15,11 @@ use Ecotone\Messaging\PrecedenceChannelInterceptor;
 
 final class RetriesChannelInterceptorBuilder implements ChannelInterceptorBuilder
 {
-    public function __construct(private string $relatedChannel, private RetryTemplate $retryTemplate)
+    public function __construct(
+        private string $relatedChannel,
+        private RetryTemplate $retryTemplate,
+        private ?string $deadLetterChannel
+    )
     {
     }
 
@@ -43,6 +48,8 @@ final class RetriesChannelInterceptorBuilder implements ChannelInterceptorBuilde
         return new SendRetryChannelInterceptor(
             $this->relatedChannel,
             $this->retryTemplate,
+            $this->deadLetterChannel,
+            $referenceSearchService->get(ConfiguredMessagingSystem::class),
             $referenceSearchService->get(LoggingHandlerBuilder::LOGGER_REFERENCE)
         );
     }

--- a/packages/Ecotone/src/Messaging/Channel/PollableChannel/SendRetries/SendRetryChannelInterceptor.php
+++ b/packages/Ecotone/src/Messaging/Channel/PollableChannel/SendRetries/SendRetryChannelInterceptor.php
@@ -6,9 +6,16 @@ namespace Ecotone\Messaging\Channel\PollableChannel\SendRetries;
 
 use Ecotone\Messaging\Channel\AbstractChannelInterceptor;
 use Ecotone\Messaging\Channel\ChannelInterceptor;
+use Ecotone\Messaging\Channel\MessageDispatchingException;
+use Ecotone\Messaging\Config\ConfiguredMessagingSystem;
+use Ecotone\Messaging\Handler\MessageHandlingException;
 use Ecotone\Messaging\Handler\Recoverability\RetryTemplate;
 use Ecotone\Messaging\Message;
 use Ecotone\Messaging\MessageChannel;
+use Ecotone\Messaging\MessageHeaders;
+use Ecotone\Messaging\MessagingException;
+use Ecotone\Messaging\Support\ErrorMessage;
+use Ecotone\Messaging\Support\MessageBuilder;
 use Exception;
 use Psr\Log\LoggerInterface;
 use Throwable;
@@ -18,6 +25,8 @@ final class SendRetryChannelInterceptor extends AbstractChannelInterceptor imple
     public function __construct(
         private string $relatedChannel,
         private RetryTemplate $retryTemplate,
+        private ?string $deadLetterChannel,
+        private ConfiguredMessagingSystem $configuredMessagingSystem,
         private LoggerInterface $logger,
     ) {
     }
@@ -54,6 +63,18 @@ final class SendRetryChannelInterceptor extends AbstractChannelInterceptor imple
             'exception' => $exception->getMessage(),
             'relatedChannel' => $this->relatedChannel,
         ]);
+
+        if ($this->deadLetterChannel !== null) {
+            $this->configuredMessagingSystem->getMessageChannelByName($this->deadLetterChannel)
+                ->send(ErrorMessage::create(MessageDispatchingException::fromOtherException(
+                    $exception,
+                    MessageBuilder::fromMessage($message)
+                        ->setHeader(MessageHeaders::POLLED_CHANNEL_NAME, $this->relatedChannel)
+                        ->build()
+                )));
+
+            return true;
+        }
 
         return false;
     }

--- a/packages/Ecotone/src/Messaging/Conversion/ObjectToSerialized/SerializingConverter.php
+++ b/packages/Ecotone/src/Messaging/Conversion/ObjectToSerialized/SerializingConverter.php
@@ -20,7 +20,7 @@ class SerializingConverter implements Converter
      */
     public function convert($source, TypeDescriptor $sourceType, MediaType $sourceMediaType, TypeDescriptor $targetType, MediaType $targetMediaType): string
     {
-        return serialize($source);
+        return addslashes(serialize($source));
     }
 
     /**

--- a/packages/Ecotone/src/Messaging/Conversion/SerializedToObject/DeserializingConverter.php
+++ b/packages/Ecotone/src/Messaging/Conversion/SerializedToObject/DeserializingConverter.php
@@ -20,7 +20,7 @@ class DeserializingConverter implements Converter
      */
     public function convert($source, TypeDescriptor $sourceType, MediaType $sourceMediaType, TypeDescriptor $targetType, MediaType $targetMediaType)
     {
-        return unserialize($source);
+        return unserialize(stripslashes($source));
     }
 
     /**

--- a/packages/Ecotone/src/Messaging/Handler/MessageHandlingException.php
+++ b/packages/Ecotone/src/Messaging/Handler/MessageHandlingException.php
@@ -14,20 +14,6 @@ use Throwable;
 final class MessageHandlingException extends MessagingException
 {
     /**
-     * @param Throwable $cause
-     * @param Message $originalMessage
-     * @return MessageHandlingException|static
-     */
-    public static function fromOtherException(Throwable $cause, Message $originalMessage): MessagingException
-    {
-        $messageHandlingException = self::createWithFailedMessage($cause->getMessage(), $originalMessage);
-
-        $messageHandlingException->setCausationException($cause);
-
-        return $messageHandlingException;
-    }
-
-    /**
      * @inheritDoc
      */
     protected static function errorCode(): int

--- a/packages/Ecotone/src/Messaging/MessagingException.php
+++ b/packages/Ecotone/src/Messaging/MessagingException.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Ecotone\Messaging;
 
+use Ecotone\Messaging\Handler\MessageHandlingException;
 use Exception;
 use Throwable;
 
@@ -66,6 +67,20 @@ abstract class MessagingException extends Exception
     {
         /** @phpstan-ignore-next-line */
         return new static($message, static::errorCode(), $throwable);
+    }
+
+    /**
+     * @param Throwable $cause
+     * @param Message $originalMessage
+     * @return MessageHandlingException|static
+     */
+    public static function fromOtherException(Throwable $cause, Message $originalMessage): MessagingException
+    {
+        $messageHandlingException = self::createWithFailedMessage($cause->getMessage(), $originalMessage);
+
+        $messageHandlingException->setCausationException($cause);
+
+        return $messageHandlingException;
     }
 
     /**

--- a/packages/Ecotone/tests/Messaging/Unit/Channel/PollableChannel/PollableChannelSendRetriesModuleTest.php
+++ b/packages/Ecotone/tests/Messaging/Unit/Channel/PollableChannel/PollableChannelSendRetriesModuleTest.php
@@ -9,6 +9,7 @@ use Ecotone\Lite\Test\FlowTestSupport;
 use Ecotone\Messaging\Channel\ExceptionalQueueChannel;
 use Ecotone\Messaging\Channel\MessageChannelBuilder;
 use Ecotone\Messaging\Channel\PollableChannel\PollableChannelConfiguration;
+use Ecotone\Messaging\Channel\SimpleMessageChannelBuilder;
 use Ecotone\Messaging\Config\ServiceConfiguration;
 use Ecotone\Messaging\Handler\Recoverability\RetryTemplateBuilder;
 use Exception;
@@ -42,7 +43,7 @@ final class PollableChannelSendRetriesModuleTest extends TestCase
         $this->assertCount(1, $loggerExample->getInfo());
     }
 
-    public function test_retrying_two_time_on_failure_with_success()
+    public function test_retrying_two_time_on_failure_and_recovering()
     {
         $loggerExample = LoggerExample::create();
         $ecotoneLite = $this->bootstrapEcotone(
@@ -135,6 +136,57 @@ final class PollableChannelSendRetriesModuleTest extends TestCase
         $this->assertNull($message);
         $this->assertCount(1, $loggerExample->getError());
     }
+
+    public function test_sending_to_dead_letter_on_failure()
+    {
+        $loggerExample = LoggerExample::create();
+
+        $ecotoneLite = $this->bootstrapEcotone(
+            [OrderService::class],
+            [new OrderService(), 'logger' => $loggerExample],
+            [
+                ExceptionalQueueChannel::createWithExceptionOnSend('orders', 1),
+                SimpleMessageChannelBuilder::createQueueChannel('deadLetter')
+            ],
+            [
+                PollableChannelConfiguration::neverRetry('orders')
+                    ->withDeadLetterChannel('deadLetter')
+            ]
+        );
+
+        $ecotoneLite->sendCommand(new PlaceOrder('1'));
+
+        $this->assertNull($ecotoneLite->getMessageChannel('orders')->receive());
+        $this->assertNotNull($ecotoneLite->getMessageChannel('deadLetter')->receive());
+    }
+
+    public function test_on_success_recover_message_is_not_sent_to_dlq()
+    {
+        $loggerExample = LoggerExample::create();
+        $ecotoneLite = $this->bootstrapEcotone(
+            [OrderService::class],
+            [new OrderService(), 'logger' => $loggerExample],
+            [
+                ExceptionalQueueChannel::createWithExceptionOnSend('orders', 2),
+                SimpleMessageChannelBuilder::createQueueChannel('deadLetter')
+            ],
+            [
+                PollableChannelConfiguration::create(
+                    'orders',
+                    RetryTemplateBuilder::fixedBackOff(1)
+                        ->maxRetryAttempts(2)
+                        ->build()
+                )
+                    ->withDeadLetterChannel('deadLetter')
+            ]
+        );
+
+        $ecotoneLite->sendCommand(new PlaceOrder('1'));
+
+        $this->assertNotNull($ecotoneLite->getMessageChannel('orders')->receive());
+        $this->assertNull($ecotoneLite->getMessageChannel('deadLetter')->receive());
+    }
+
 
     /**
      * @param string[] $classesToResolve

--- a/packages/Ecotone/tests/Messaging/Unit/Channel/Serialization/PollableChannelSerializationModuleTest.php
+++ b/packages/Ecotone/tests/Messaging/Unit/Channel/Serialization/PollableChannelSerializationModuleTest.php
@@ -35,7 +35,7 @@ final class PollableChannelSerializationModuleTest extends TestCase
         $ecotoneLite->sendCommand(new PlaceOrder('1'));
 
         $this->assertSame(
-            serialize(new PlaceOrder('1')),
+            addslashes(serialize(new PlaceOrder('1'))),
             $ecotoneLite->getMessageChannel('orders')->receive()->getPayload()
         );
     }

--- a/packages/Ecotone/tests/Messaging/Unit/Handler/Logger/LoggingServiceTest.php
+++ b/packages/Ecotone/tests/Messaging/Unit/Handler/Logger/LoggingServiceTest.php
@@ -67,7 +67,7 @@ class LoggingServiceTest extends TestCase
         $logger
             ->expects($this->once())
             ->method('debug')
-            ->with(serialize($payload));
+            ->with(addslashes(serialize($payload)));
 
         $loggingService = new LoggingService(AutoCollectionConversionService::createWith([
             new SerializingConverter(),

--- a/packages/Ecotone/tests/Messaging/Unit/Handler/Processor/MethodInvokerTest.php
+++ b/packages/Ecotone/tests/Messaging/Unit/Handler/Processor/MethodInvokerTest.php
@@ -236,7 +236,7 @@ class MethodInvokerTest extends MessagingTest
             );
 
         $replyMessage = $methodInvocation->executeEndpoint(
-            MessageBuilder::withPayload(serialize(Order::create('1', 'correct')))
+            MessageBuilder::withPayload(addslashes(serialize(Order::create('1', 'correct'))))
                 ->setContentType(MediaType::createApplicationXPHPSerialized())
                 ->build()
         );

--- a/packages/Ecotone/tests/Modelling/Behat/Bootstrap/DomainContext.php
+++ b/packages/Ecotone/tests/Modelling/Behat/Bootstrap/DomainContext.php
@@ -86,7 +86,7 @@ class DomainContext extends TestCase implements Context
      */
     public function thereShouldBeProductsForOrderWithIdRetrievedFrom(int $productsAmount, int $orderId, string $channelName)
     {
-        $executeWithContentType = AnnotationBasedMessagingContext::getQueryBus()->sendWithRouting($channelName, serialize(GetOrderAmountQuery::createWith($orderId)), MediaType::APPLICATION_X_PHP_SERIALIZED);
+        $executeWithContentType = AnnotationBasedMessagingContext::getQueryBus()->sendWithRouting($channelName, addslashes(serialize(GetOrderAmountQuery::createWith($orderId))), MediaType::APPLICATION_X_PHP_SERIALIZED);
         $this->assertEquals(
             $productsAmount,
             $executeWithContentType


### PR DESCRIPTION
This allows to set up Dead Letter in case our Message fails on sending. This way we can ensure consistency even if unrecoverable issue happen.

![Screenshot from 2023-08-01 08-29-57](https://github.com/ecotoneframework/ecotone-dev/assets/6060791/400dcbee-1baa-43d5-8ddc-01645d3689ac)
