### PR TITLE
Clearing object manager on command bus in a synchronous flow

### DIFF
--- a/packages/Dbal/tests/Fixture/ORM/Person/Person.php
+++ b/packages/Dbal/tests/Fixture/ORM/Person/Person.php
@@ -19,6 +19,8 @@ class Person
 {
     use WithEvents;
 
+    public const RENAME_COMMAND = 'person.rename';
+
     #[ORM\Id]
     #[ORM\Column(name: 'person_id', type: 'integer')]
     #[Identifier]
@@ -44,6 +46,14 @@ class Person
         }
 
         return $person;
+    }
+
+    #[CommandHandler(self::RENAME_COMMAND)]
+    public function changeName(string $name): void
+    {
+        $this->name = $name;
+
+        $this->recordThat(new PersonWasRenamed($this->personId, $name));
     }
 
     #[QueryHandler('person.getName')]

--- a/packages/Dbal/tests/Fixture/ORM/Person/PersonWasRenamed.php
+++ b/packages/Dbal/tests/Fixture/ORM/Person/PersonWasRenamed.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Test\Ecotone\Dbal\Fixture\ORM\Person;
+
+class PersonWasRenamed
+{
+    public function __construct(private int $personId, private string $name)
+    {
+    }
+
+    public function getPersonId(): int
+    {
+        return $this->personId;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+}

--- a/packages/Dbal/tests/Fixture/ORM/PersonRepository/RegisterPersonService.php
+++ b/packages/Dbal/tests/Fixture/ORM/PersonRepository/RegisterPersonService.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace Test\Ecotone\Dbal\Fixture\ORM\PersonRepository;
 
 use Ecotone\Modelling\Attribute\CommandHandler;
+use Ecotone\Modelling\EventBus;
 use Test\Ecotone\Dbal\Fixture\ORM\Person\Person;
+use Test\Ecotone\Dbal\Fixture\ORM\Person\PersonWasRenamed;
 use Test\Ecotone\Dbal\Fixture\ORM\Person\RegisterPerson;
 
 final class RegisterPersonService
@@ -14,5 +16,15 @@ final class RegisterPersonService
     public function register(RegisterPerson $command, ORMPersonRepository $repository): void
     {
         $repository->save(Person::register($command));
+    }
+
+    #[CommandHandler(Person::RENAME_COMMAND)]
+    public function rename(string $command, array $metadata, ORMPersonRepository $repository, EventBus $eventBus): void
+    {
+        $id = $metadata['aggregate.id'];
+        $person = $repository->get($id);
+        $person->changeName($command);
+        $eventBus->publish(new PersonWasRenamed($id, $command));
+        $repository->save($person);
     }
 }

--- a/packages/Dbal/tests/Fixture/ORM/SynchronousEventHandler/SaveMultipleEntitiesHandler.php
+++ b/packages/Dbal/tests/Fixture/ORM/SynchronousEventHandler/SaveMultipleEntitiesHandler.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Test\Ecotone\Dbal\Fixture\ORM\SynchronousEventHandler;
+
+use Ecotone\Modelling\Attribute\EventHandler;
+use Ecotone\Modelling\CommandBus;
+use Test\Ecotone\Dbal\Fixture\ORM\Person\PersonWasRenamed;
+use Test\Ecotone\Dbal\Fixture\ORM\Person\RegisterPerson;
+
+class SaveMultipleEntitiesHandler
+{
+    #[EventHandler]
+    public function whenPersonWasRenamed(PersonWasRenamed $event, CommandBus $commandBus): void
+    {
+        $commandBus->send(new RegisterPerson(
+            $event->getPersonId() + 1,
+            $event->getName() . "2"
+        ));
+    }
+}


### PR DESCRIPTION
**Ecotone version(s) affected**: 1.99.0

**Description**  
My tests with synchronous event handlers are failing because of duplicate aggregates primary key when upgrading to 1.99.0 because of the new default configuration clearing the object manager on command bus.
The new default configuration is flushing and clearing the object manager after handling commands. In the case of a synchronous event handler dispatching another command (Command A => Event => Command B), command A will fetch Aggregate A, the event handler will be executed, then Aggregate B will be fetched and saved by Command B, the object manager is cleared, making Aggregate A untracked. When Aggregate A is saved, the object manager think it is a new object and will insert it instead of updating it.

**Possible Solution**  
Flush on every command but clear only after the topmost command.