### PR TITLE
Skip test package in laravel and symfony by default

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,7 @@ services:
       DATABASE_MYSQL: mysql://ecotone:secret@database-mysql:3306/ecotone
       SQS_DSN: sqs:?key=key&secret=secret&region=us-east-1&endpoint=http://localstack:4576&version=latest
       REDIS_DSN: redis://redis:6379
+      APP_MERGE_PLUGIN: "yes"
     env_file:
       - ".env"
   app8_1:
@@ -53,6 +54,7 @@ services:
       DATABASE_MYSQL: mysql://ecotone:secret@database-mysql:3306/ecotone
       SQS_DSN: sqs:?key=key&secret=secret&region=us-east-1&endpoint=http://localstack:4576&version=latest
       REDIS_DSN: redis://redis:6379
+      APP_MERGE_PLUGIN: "yes"
     env_file:
       - ".env"
   app8_0:
@@ -80,6 +82,7 @@ services:
       DATABASE_MYSQL: mysql://ecotone:secret@database-mysql:3306/ecotone
       SQS_DSN: sqs:?key=key&secret=secret&region=us-east-1&endpoint=http://localstack:4576&version=latest
       REDIS_DSN: redis://redis:6379
+      APP_MERGE_PLUGIN: "yes"
     env_file:
       - ".env"
   database:

--- a/packages/Laravel/src/EcotoneProvider.php
+++ b/packages/Laravel/src/EcotoneProvider.php
@@ -2,6 +2,7 @@
 
 namespace Ecotone\Laravel;
 
+use Ecotone\Messaging\Config\ModulePackageList;
 use const DIRECTORY_SEPARATOR;
 
 use Ecotone\Lite\PsrContainerReferenceSearchService;
@@ -57,7 +58,7 @@ class EcotoneProvider extends ServiceProvider
             ->withLoadCatalog(Config::get('ecotone.loadAppNamespaces') ? 'app' : '')
             ->withFailFast(false)
             ->withNamespaces(Config::get('ecotone.namespaces'))
-            ->withSkippedModulePackageNames(Config::get('ecotone.skippedModulePackageNames'));
+            ->withSkippedModulePackageNames(array_merge(Config::get('ecotone.skippedModulePackageNames'), [ModulePackageList::TEST_PACKAGE]));
 
         if ($isCachingConfiguration) {
             $applicationConfiguration = $applicationConfiguration

--- a/packages/Laravel/src/EcotoneProvider.php
+++ b/packages/Laravel/src/EcotoneProvider.php
@@ -53,6 +53,7 @@ class EcotoneProvider extends ServiceProvider
 
         $errorChannel = Config::get('ecotone.defaultErrorChannel');
 
+        /** @TODO Ecotone 2.0 use ServiceContext to configure Laravel */
         $applicationConfiguration = ServiceConfiguration::createWithDefaults()
             ->withEnvironment($environment)
             ->withLoadCatalog(Config::get('ecotone.loadAppNamespaces') ? 'app' : '')

--- a/packages/Symfony/DepedencyInjection/Compiler/EcotoneCompilerPass.php
+++ b/packages/Symfony/DepedencyInjection/Compiler/EcotoneCompilerPass.php
@@ -6,6 +6,7 @@ use Ecotone\Lite\PsrContainerReferenceSearchService;
 use Ecotone\Messaging\Config\Configuration;
 use Ecotone\Messaging\Config\ConfiguredMessagingSystem;
 use Ecotone\Messaging\Config\MessagingSystemConfiguration;
+use Ecotone\Messaging\Config\ModulePackageList;
 use Ecotone\Messaging\Config\ProxyGenerator;
 use Ecotone\Messaging\Config\ServiceConfiguration;
 use Ecotone\Messaging\ConfigurationVariableService;
@@ -56,7 +57,7 @@ class EcotoneCompilerPass implements CompilerPassInterface
             ->withFailFast($container->getParameter('kernel.environment') === 'prod' ? false : $container->getParameter(self::FAIL_FAST_CONFIG))
             ->withLoadCatalog($container->getParameter(self::LOAD_SRC) ? 'src' : '')
             ->withNamespaces($container->getParameter(self::WORKING_NAMESPACES_CONFIG))
-            ->withSkippedModulePackageNames($container->getParameter(self::SKIPPED_MODULE_PACKAGES))
+            ->withSkippedModulePackageNames(array_merge($container->getParameter(self::SKIPPED_MODULE_PACKAGES), [ModulePackageList::TEST_PACKAGE]))
             ->withCacheDirectoryPath($ecotoneCacheDirectory);
 
         if ($container->getParameter(self::SERVICE_NAME)) {

--- a/packages/Symfony/DepedencyInjection/Compiler/EcotoneCompilerPass.php
+++ b/packages/Symfony/DepedencyInjection/Compiler/EcotoneCompilerPass.php
@@ -52,6 +52,7 @@ class EcotoneCompilerPass implements CompilerPassInterface
     public static function getMessagingConfiguration(ContainerInterface $container, bool $useCachedVersion = false): Configuration
     {
         $ecotoneCacheDirectory    = $container->getParameter('kernel.cache_dir') . self::CACHE_DIRECTORY_SUFFIX;
+        /** @TODO Ecotone 2.0 use ServiceContext to configure Symfony */
         $serviceConfiguration = ServiceConfiguration::createWithDefaults()
             ->withEnvironment($container->getParameter('kernel.environment'))
             ->withFailFast($container->getParameter('kernel.environment') === 'prod' ? false : $container->getParameter(self::FAIL_FAST_CONFIG))


### PR DESCRIPTION
Currently symfony and laravel loads test package, which is not meant to run on production.