### PR TITLE
Allow to define custom persistence strategy per stream.

### DIFF
--- a/packages/PdoEventSourcing/src/EventSourcingConfiguration.php
+++ b/packages/PdoEventSourcing/src/EventSourcingConfiguration.php
@@ -25,6 +25,8 @@ class EventSourcingConfiguration extends BaseEventSourcingConfiguration
     private bool $isInMemory = false;
     private ?InMemoryEventStore $inMemoryEventStore = null;
     private ?\Prooph\EventStore\Projection\ProjectionManager $inMemoryProjectionManager = null;
+    /** @var array<string> */
+    private array $persistenceStrategies = [];
 
     private function __construct(string $connectionReferenceName = DbalConnectionFactory::class, string $eventStoreReferenceName = EventStore::class, string $projectManagerReferenceName = ProjectionManager::class)
     {
@@ -80,6 +82,13 @@ class EventSourcingConfiguration extends BaseEventSourcingConfiguration
     public function withSimpleStreamPersistenceStrategy(): static
     {
         $this->persistenceStrategy = LazyProophEventStore::SIMPLE_STREAM_PERSISTENCE;
+
+        return $this;
+    }
+
+    public function withPersistenceStrategyFor(string $streamName, string $strategy): self
+    {
+        $this->persistenceStrategies[$streamName] = $strategy;
 
         return $this;
     }
@@ -151,6 +160,11 @@ class EventSourcingConfiguration extends BaseEventSourcingConfiguration
     public function isUsingAggregateStreamStrategy(): bool
     {
         return $this->getPersistenceStrategy() === LazyProophEventStore::AGGREGATE_STREAM_PERSISTENCE;
+    }
+
+    public function isUsingAggregateStreamStrategyFor(string $streamName): bool
+    {
+        return array_key_exists($streamName, $this->persistenceStrategies) && $this->persistenceStrategies[$streamName] === LazyProophEventStore::AGGREGATE_STREAM_PERSISTENCE;
     }
 
     public function isUsingSimpleStreamStrategy(): bool

--- a/packages/PdoEventSourcing/src/EventSourcingRepository.php
+++ b/packages/PdoEventSourcing/src/EventSourcingRepository.php
@@ -132,7 +132,10 @@ class EventSourcingRepository implements EventSourcedRepository
             $streamName =  $this->aggregateStreamMapping->getAggregateToStreamMapping()[$aggregateClassName];
         }
 
-        if ($this->eventSourcingConfiguration->isUsingAggregateStreamStrategy()) {
+        if (
+            $this->eventSourcingConfiguration->isUsingAggregateStreamStrategy()
+            || $this->eventSourcingConfiguration->isUsingAggregateStreamStrategyFor($streamName)
+        ) {
             $streamName = $streamName . '-' . $aggregateId;
         }
 

--- a/packages/PdoEventSourcing/tests/Fixture/MultiplePersistenceStrategies/Basket.php
+++ b/packages/PdoEventSourcing/tests/Fixture/MultiplePersistenceStrategies/Basket.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Ecotone\EventSourcing\Fixture\MultiplePersistenceStrategies;
+
+use Ecotone\EventSourcing\Attribute\AggregateType;
+use Ecotone\EventSourcing\Attribute\Stream;
+use Ecotone\Modelling\Attribute\EventSourcingAggregate;
+use Ecotone\Modelling\Attribute\EventSourcingHandler;
+use Ecotone\Modelling\Attribute\Identifier;
+use Ecotone\Modelling\WithAggregateVersioning;
+
+#[EventSourcingAggregate]
+#[AggregateType(self::AGGREGATE_TYPE)]
+#[Stream(self::STREAM)]
+final class Basket
+{
+    use WithAggregateVersioning;
+
+    public const AGGREGATE_TYPE = 'basket';
+    public const STREAM = 'basket';
+
+    #[Identifier]
+    public string $basketId;
+
+    #[EventSourcingHandler]
+    public function applyBasketCreated(BasketCreated $event): void
+    {
+        $this->basketId = $event->basketId;
+    }
+}

--- a/packages/PdoEventSourcing/tests/Fixture/MultiplePersistenceStrategies/BasketCreated.php
+++ b/packages/PdoEventSourcing/tests/Fixture/MultiplePersistenceStrategies/BasketCreated.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Ecotone\EventSourcing\Fixture\MultiplePersistenceStrategies;
+
+use Ecotone\Modelling\Attribute\NamedEvent;
+
+#[NamedEvent(self::NAME)]
+final class BasketCreated
+{
+    public const NAME = 'basket_created';
+
+    public function __construct(
+        public string $basketId,
+    ) {
+    }
+}

--- a/packages/PdoEventSourcing/tests/Fixture/MultiplePersistenceStrategies/BasketProjection.php
+++ b/packages/PdoEventSourcing/tests/Fixture/MultiplePersistenceStrategies/BasketProjection.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Ecotone\EventSourcing\Fixture\MultiplePersistenceStrategies;
+
+use Doctrine\DBAL\Connection;
+use Ecotone\EventSourcing\Attribute\Projection;
+use Ecotone\EventSourcing\Attribute\ProjectionInitialization;
+use Ecotone\Modelling\Attribute\EventHandler;
+use Ecotone\Modelling\Attribute\QueryHandler;
+
+#[Projection(self::NAME, fromStreams: ['basket'])]
+final class BasketProjection
+{
+    public const NAME = 'basket-projection';
+
+    public function __construct(private Connection $connection)
+    {
+    }
+
+    #[QueryHandler('baskets')]
+    public function getBaskets(): array
+    {
+        return $this->connection->fetchFirstColumn('select basket_id from baskets');
+    }
+
+    #[EventHandler(listenTo: BasketCreated::NAME)]
+    public function basketCreated(BasketCreated $event): void
+    {
+        $this->connection->insert('baskets', ['basket_id' => $event->basketId]);
+    }
+
+    #[ProjectionInitialization]
+    public function initialize(): void
+    {
+        $this->connection->executeStatement('DROP TABLE IF EXISTS baskets');
+        $this->connection->executeStatement('CREATE TABLE baskets (basket_id VARCHAR(36) PRIMARY KEY)');
+    }
+}

--- a/packages/PdoEventSourcing/tests/Fixture/MultiplePersistenceStrategies/EventsConverter.php
+++ b/packages/PdoEventSourcing/tests/Fixture/MultiplePersistenceStrategies/EventsConverter.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Ecotone\EventSourcing\Fixture\MultiplePersistenceStrategies;
+
+use Ecotone\Messaging\Attribute\Converter;
+
+final class EventsConverter
+{
+    #[Converter]
+    public function convertFromOrderCreated(OrderCreated $event): array
+    {
+        return ['orderId' => $event->orderId];
+    }
+
+    #[Converter]
+    public function convertToOrderCreated(array $payload): OrderCreated
+    {
+        return new OrderCreated($payload['orderId']);
+    }
+
+    #[Converter]
+    public function convertFromBasketCreated(BasketCreated $event): array
+    {
+        return ['basketId' => $event->basketId];
+    }
+
+    #[Converter]
+    public function convertToBasketCreated(array $payload): BasketCreated
+    {
+        return new BasketCreated($payload['basketId']);
+    }
+}

--- a/packages/PdoEventSourcing/tests/Fixture/MultiplePersistenceStrategies/Order.php
+++ b/packages/PdoEventSourcing/tests/Fixture/MultiplePersistenceStrategies/Order.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Ecotone\EventSourcing\Fixture\MultiplePersistenceStrategies;
+
+use Ecotone\EventSourcing\Attribute\AggregateType;
+use Ecotone\EventSourcing\Attribute\Stream;
+use Ecotone\Modelling\Attribute\EventSourcingAggregate;
+use Ecotone\Modelling\Attribute\EventSourcingHandler;
+use Ecotone\Modelling\Attribute\Identifier;
+use Ecotone\Modelling\WithAggregateVersioning;
+
+#[EventSourcingAggregate]
+#[AggregateType(self::AGGREGATE_TYPE)]
+#[Stream(self::STREAM)]
+final class Order
+{
+    use WithAggregateVersioning;
+
+    public const AGGREGATE_TYPE = 'order';
+    public const STREAM = 'order';
+
+    #[Identifier]
+    public string $orderId;
+
+    #[EventSourcingHandler]
+    public function applyOrderCreated(OrderCreated $event): void
+    {
+        $this->orderId = $event->orderId;
+    }
+}

--- a/packages/PdoEventSourcing/tests/Fixture/MultiplePersistenceStrategies/OrderCreated.php
+++ b/packages/PdoEventSourcing/tests/Fixture/MultiplePersistenceStrategies/OrderCreated.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Ecotone\EventSourcing\Fixture\MultiplePersistenceStrategies;
+
+use Ecotone\Modelling\Attribute\NamedEvent;
+
+#[NamedEvent(self::NAME)]
+final class OrderCreated
+{
+    public const NAME = 'order_created';
+
+    public function __construct(
+        public string $orderId,
+    ) {
+    }
+}

--- a/packages/PdoEventSourcing/tests/Fixture/MultiplePersistenceStrategies/OrderProjection.php
+++ b/packages/PdoEventSourcing/tests/Fixture/MultiplePersistenceStrategies/OrderProjection.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Ecotone\EventSourcing\Fixture\MultiplePersistenceStrategies;
+
+use Doctrine\DBAL\Connection;
+use Ecotone\EventSourcing\Attribute\Projection;
+use Ecotone\EventSourcing\Attribute\ProjectionInitialization;
+use Ecotone\Modelling\Attribute\EventHandler;
+use Ecotone\Modelling\Attribute\QueryHandler;
+
+#[Projection(self::NAME, fromCategories: ['order'])]
+final class OrderProjection
+{
+    public const NAME = 'order-projection';
+
+    public function __construct(private Connection $connection)
+    {
+    }
+
+    #[QueryHandler('orders')]
+    public function getOrders(): array
+    {
+        return $this->connection->fetchFirstColumn('select order_id from orders');
+    }
+
+    #[EventHandler(listenTo: OrderCreated::NAME)]
+    public function orderCreated(OrderCreated $event): void
+    {
+        $this->connection->insert('orders', ['order_id' => $event->orderId]);
+    }
+
+    #[ProjectionInitialization]
+    public function initialize(): void
+    {
+        $this->connection->executeStatement('DROP TABLE IF EXISTS orders');
+        $this->connection->executeStatement('CREATE TABLE orders (order_id VARCHAR(36) PRIMARY KEY)');
+    }
+}

--- a/packages/PdoEventSourcing/tests/Integration/MultiplePersistenceStrategiesTest.php
+++ b/packages/PdoEventSourcing/tests/Integration/MultiplePersistenceStrategiesTest.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Ecotone\EventSourcing\Integration;
+
+use Ecotone\EventSourcing\EventSourcingConfiguration;
+use Ecotone\EventSourcing\EventStore;
+use Ecotone\EventSourcing\Prooph\LazyProophEventStore;
+use Ecotone\Lite\EcotoneLite;
+use Ecotone\Messaging\Config\ModulePackageList;
+use Ecotone\Messaging\Config\ServiceConfiguration;
+use Test\Ecotone\EventSourcing\EventSourcingMessagingTestCase;
+use Test\Ecotone\EventSourcing\Fixture\MultiplePersistenceStrategies\Basket;
+use Test\Ecotone\EventSourcing\Fixture\MultiplePersistenceStrategies\BasketCreated;
+use Test\Ecotone\EventSourcing\Fixture\MultiplePersistenceStrategies\BasketProjection;
+use Test\Ecotone\EventSourcing\Fixture\MultiplePersistenceStrategies\EventsConverter;
+use Test\Ecotone\EventSourcing\Fixture\MultiplePersistenceStrategies\Order;
+use Test\Ecotone\EventSourcing\Fixture\MultiplePersistenceStrategies\OrderCreated;
+use Test\Ecotone\EventSourcing\Fixture\MultiplePersistenceStrategies\OrderProjection;
+
+final class MultiplePersistenceStrategiesTest extends EventSourcingMessagingTestCase
+{
+    public function test_allow_multiple_persistent_strategies_per_aggregate(): void
+    {
+        $ecotone = EcotoneLite::bootstrapFlowTestingWithEventStore(
+            classesToResolve: [Order::class, Basket::class, BasketProjection::class, OrderProjection::class],
+            containerOrAvailableServices: [
+                new EventsConverter(),
+                new BasketProjection($this->getConnection()),
+                new OrderProjection($this->getConnection()),
+                $this->getConnectionFactory(),
+            ],
+            configuration: ServiceConfiguration::createWithDefaults()
+                ->withEnvironment('prod')
+                ->withSkippedModulePackageNames([ModulePackageList::AMQP_PACKAGE, ModulePackageList::JMS_CONVERTER_PACKAGE])
+                ->withExtensionObjects([
+                    EventSourcingConfiguration::createWithDefaults()
+                        ->withSimpleStreamPersistenceStrategy()
+                        ->withPersistenceStrategyFor(Order::STREAM, LazyProophEventStore::AGGREGATE_STREAM_PERSISTENCE)
+                ])
+                ->withNamespaces([
+                    'Test\Ecotone\EventSourcing\Fixture\MultiplePersistenceStrategies',
+                ]),
+            pathToRootCatalog: __DIR__ . '/../../',
+            runForProductionEventStore: true
+        );
+
+        $ecotone
+            ->initializeProjection(BasketProjection::NAME)
+            ->initializeProjection(OrderProjection::NAME)
+            ->withEventsFor(
+                identifiers: 'order-1',
+                aggregateClass: Order::class,
+                events: [
+                    new OrderCreated('order-1'),
+                ]
+            )
+            ->withEventsFor(
+                identifiers: 'order-2',
+                aggregateClass: Order::class,
+                events: [
+                    new OrderCreated('order-2'),
+                ]
+            )
+            ->withEventsFor(
+                identifiers: 'basket-1',
+                aggregateClass: Basket::class,
+                events: [
+                    new BasketCreated('basket-1'),
+                ]
+            )
+            ->withEventsFor(
+                identifiers: 'basket-2',
+                aggregateClass: Basket::class,
+                events: [
+                    new BasketCreated('basket-2'),
+                ]
+            )
+            ->triggerProjection(BasketProjection::NAME)
+            ->triggerProjection(OrderProjection::NAME)
+        ;
+
+        $eventStore = $ecotone->getGateway(EventStore::class);
+
+        self::assertTrue($eventStore->hasStream(Order::STREAM.'-order-1'));
+        self::assertTrue($eventStore->hasStream(Order::STREAM.'-order-2'));
+        self::assertTrue($eventStore->hasStream(Basket::STREAM));
+
+        self::assertCount(1, $eventStore->load(Order::STREAM.'-order-1'));
+        self::assertCount(1, $eventStore->load(Order::STREAM.'-order-2'));
+        self::assertCount(2, $eventStore->load(Basket::STREAM));
+
+        self::assertEquals(['order-1', 'order-2'], $ecotone->sendQueryWithRouting('orders'));
+        self::assertEquals(['basket-1', 'basket-2'], $ecotone->sendQueryWithRouting('baskets'));
+    }
+}


### PR DESCRIPTION
If custom strategy is not defined, the one default will be used.

resolves #202