### PR TITLE
add `void` return type to `CacheCleaner::clear()` and `EcotoneCompilerPass::process()`

### DIFF
--- a/packages/Symfony/DepedencyInjection/Compiler/CacheCleaner.php
+++ b/packages/Symfony/DepedencyInjection/Compiler/CacheCleaner.php
@@ -7,7 +7,7 @@ use Symfony\Component\HttpKernel\CacheClearer\CacheClearerInterface;
 
 class CacheCleaner implements CacheClearerInterface
 {
-    public function clear($cacheDir)
+    public function clear($cacheDir): void
     {
         MessagingSystemConfiguration::cleanCache($cacheDir . EcotoneCompilerPass::CACHE_DIRECTORY_SUFFIX);
     }

--- a/packages/Symfony/DepedencyInjection/Compiler/EcotoneCompilerPass.php
+++ b/packages/Symfony/DepedencyInjection/Compiler/EcotoneCompilerPass.php
@@ -105,7 +105,7 @@ class EcotoneCompilerPass implements CompilerPassInterface
         );
     }
 
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         $messagingConfiguration = $this->getMessagingConfiguration($container);
 


### PR DESCRIPTION
this fixes deprecation message from Symfony and ensures supporting Symfony 7.x in future