### PR TITLE
Configure lazy build for ecotone lite benchmarks

### DIFF
--- a/Monorepo/ExampleApp/Lite/app.php
+++ b/Monorepo/ExampleApp/Lite/app.php
@@ -38,6 +38,7 @@ return function (bool $useCachedVersion = true): ConfiguredMessagingSystem {
         serviceConfiguration: ServiceConfiguration::createWithDefaults()
             ->doNotLoadCatalog()
             ->withCacheDirectoryPath(__DIR__ . "/var/cache")
+            ->withFailFast(false)
             ->withSkippedModulePackageNames(ModulePackageList::allPackagesExcept([ModulePackageList::ASYNCHRONOUS_PACKAGE]))
             ->withNamespaces(['Monorepo\\ExampleApp\\Common\\']),
         cacheConfiguration: $useCachedVersion,


### PR DESCRIPTION
Disable fail fast in ecotone lite benchmark to be comparable with symfony and laravel. [benchmarks](https://github.com/ecotoneframework/ecotone-dev/actions/runs/6348697153)