### PR TITLE
Explicitly use bash shell in PR stats workflow

### DIFF
--- a/.github/workflows/benchmark-pr.yml
+++ b/.github/workflows/benchmark-pr.yml
@@ -100,11 +100,12 @@ jobs:
         run: composer update --${{ matrix.stability }} --prefer-dist --no-interaction
 
       - name: Benchmark PR
+        shell: bash
         env:
           PHPBENCH_REF_OPTION: "${{ steps.baseline.outcome == 'success' && '--ref=main' || '' }}"
         run: |
           echo "Baseline: $PHPBENCH_REF_OPTION"
-          false | bin/phpbench-to-md.sh > benchmark.md
+          vendor/bin/phpbench run --retry-threshold=5 --report=github-report $PHPBENCH_REF_OPTION | bin/phpbench-to-md.sh > benchmark.md
           cat benchmark.md
           echo '## Benchmark' >> "$GITHUB_STEP_SUMMARY"
           cat benchmark.md >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/benchmark-pr.yml
+++ b/.github/workflows/benchmark-pr.yml
@@ -105,7 +105,7 @@ jobs:
           PHPBENCH_REF_OPTION: "${{ steps.baseline.outcome == 'success' && '--ref=main' || '' }}"
         run: |
           echo "Baseline: $PHPBENCH_REF_OPTION"
-          vendor/bin/phpbench run --retry-threshold=5 --report=github-report $PHPBENCH_REF_OPTION | bin/phpbench-to-md.sh > benchmark.md
+          false | bin/phpbench-to-md.sh > benchmark.md
           cat benchmark.md
           echo '## Benchmark' >> "$GITHUB_STEP_SUMMARY"
           cat benchmark.md >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/benchmark-pr.yml
+++ b/.github/workflows/benchmark-pr.yml
@@ -100,7 +100,6 @@ jobs:
         run: composer update --${{ matrix.stability }} --prefer-dist --no-interaction
 
       - name: Benchmark PR
-        shell: bash
         env:
           PHPBENCH_REF_OPTION: "${{ steps.baseline.outcome == 'success' && '--ref=main' || '' }}"
         run: |

--- a/.github/workflows/benchmark-pr.yml
+++ b/.github/workflows/benchmark-pr.yml
@@ -91,7 +91,6 @@ jobs:
           clean: false
 
       - name: Remove cached files
-        working-directory:
         run: |
           rm -rf Monorepo/ExampleApp/Lite/var/cache
           rm -rf Monorepo/ExampleApp/Symfony/var/cache
@@ -101,6 +100,7 @@ jobs:
         run: composer update --${{ matrix.stability }} --prefer-dist --no-interaction
 
       - name: Benchmark PR
+        shell: bash
         env:
           PHPBENCH_REF_OPTION: "${{ steps.baseline.outcome == 'success' && '--ref=main' || '' }}"
         run: |


### PR DESCRIPTION
Checking if what I am saying is true, presumably closes #224.