### PR TITLE
Construct gateways only during the first execution and for given method

### DIFF
--- a/packages/Ecotone/src/Messaging/Config/MessagingSystem.php
+++ b/packages/Ecotone/src/Messaging/Config/MessagingSystem.php
@@ -204,18 +204,6 @@ final class MessagingSystem implements ConfiguredMessagingSystem
         return InMemoryChannelResolver::create($channels);
     }
 
-    /**
-     * @param GatewayProxyBuilder[][] $preparedGateways
-     * @param ReferenceSearchService $referenceSearchService
-     * @param ChannelResolver $channelResolver
-     * @return NonProxyCombinedGateway[]
-     * @throws MessagingException
-     */
-    private static function configureGateways(array $preparedGateways, ReferenceSearchService $referenceSearchService, ChannelResolver $channelResolver): array
-    {
-
-    }
-
     private static function getPollingMetadata(string $endpointId, array $pollingMetadataConfigurations): PollingMetadata
     {
         return array_key_exists($endpointId, $pollingMetadataConfigurations) ? $pollingMetadataConfigurations[$endpointId] : PollingMetadata::create($endpointId);

--- a/packages/Ecotone/src/Messaging/Config/MessagingSystem.php
+++ b/packages/Ecotone/src/Messaging/Config/MessagingSystem.php
@@ -110,14 +110,23 @@ final class MessagingSystem implements ConfiguredMessagingSystem
     ): MessagingSystem {
         $channelResolver = self::createChannelResolver($messageChannelInterceptors, $messageChannelBuilders, $referenceSearchService);
 
-        $nonProxyGateways = self::configureGateways($gatewayBuilders, $referenceSearchService, $channelResolver);
-        foreach ($nonProxyGateways as $gateway) {
-            /** A case when Symfony or Laravel are used, they provide own Proxy implementations */
-            if ($referenceSearchService->has($gateway->getReferenceName())) {
-                continue;
+        $nonProxyGateways = [];
+        foreach ($gatewayBuilders as $referenceName => $preparedGatewaysForReference) {
+            $nonProxyCombinedGatewaysMethods = [];
+            foreach ($preparedGatewaysForReference as $proxyBuilder) {
+                $nonProxyCombinedGatewaysMethods[$proxyBuilder->getRelatedMethodName()] = $proxyBuilder;
             }
+
+            $nonProxyGateways[$referenceName] = NonProxyCombinedGateway::createWith(
+                $referenceName,
+                $preparedGatewaysForReference[0]->getInterfaceName(),
+                $nonProxyCombinedGatewaysMethods,
+                $referenceSearchService,
+                $channelResolver
+            );
+
             $referenceSearchService->registerReferencedObject(
-                $gateway->getReferenceName(),
+                $referenceName,
                 fn ($referenceName) => self::createGatewayByName(
                     $referenceName,
                     $nonProxyGateways,
@@ -125,8 +134,8 @@ final class MessagingSystem implements ConfiguredMessagingSystem
                 )
             );
         }
-        $referenceSearchService->registerReferencedObject(ChannelResolver::class, $channelResolver);
 
+        $referenceSearchService->registerReferencedObject(ChannelResolver::class, $channelResolver);
         $eventDrivenConsumers = [];
         $pollingConsumerBuilders = [];
         foreach ($messageHandlerBuilders as $messageHandlerBuilder) {
@@ -204,24 +213,7 @@ final class MessagingSystem implements ConfiguredMessagingSystem
      */
     private static function configureGateways(array $preparedGateways, ReferenceSearchService $referenceSearchService, ChannelResolver $channelResolver): array
     {
-        $nonProxyCombinedGateways = [];
 
-        foreach ($preparedGateways as $referenceName => $preparedGatewaysForReference) {
-            $referenceName = $preparedGatewaysForReference[0]->getReferenceName();
-            $nonProxyCombinedGatewaysMethods = [];
-            /** @TODO build gateway when requested and cache it internally. No need to build everything at boot time */
-            foreach ($preparedGatewaysForReference as $proxyBuilder) {
-                $nonProxyCombinedGatewaysMethods[$proxyBuilder->getRelatedMethodName()] =
-                    $proxyBuilder->buildWithoutProxyObject($referenceSearchService, $channelResolver);
-            }
-
-            $nonProxyCombinedGateways[$referenceName] = NonProxyCombinedGateway::createWith(
-                $referenceName,
-                $preparedGatewaysForReference[0]->getInterfaceName(),
-                $nonProxyCombinedGatewaysMethods
-            );
-        }
-        return $nonProxyCombinedGateways;
     }
 
     private static function getPollingMetadata(string $endpointId, array $pollingMetadataConfigurations): PollingMetadata
@@ -299,7 +291,6 @@ final class MessagingSystem implements ConfiguredMessagingSystem
         ServiceCacheConfiguration $serviceCacheConfiguration
     ): object {
         $proxyFactory = ProxyFactory::createWithCache($serviceCacheConfiguration);
-
         $nonProxyCombinedGateway = $nonProxyGateways[$gatewayReferenceName];
 
         return $proxyFactory->createProxyClassWithAdapter(

--- a/packages/Ecotone/src/Messaging/Handler/Gateway/GatewayProxyBuilder.php
+++ b/packages/Ecotone/src/Messaging/Handler/Gateway/GatewayProxyBuilder.php
@@ -332,10 +332,9 @@ class GatewayProxyBuilder implements InterceptedEndpoint
             NonProxyCombinedGateway::createWith(
                 $this->referenceName,
                 $this->interfaceName,
-                [$this->getRelatedMethodName() => $this->buildWithoutProxyObject(
-                    $referenceSearchService,
-                    $channelResolver
-                )]
+                [$this->getRelatedMethodName() => $this],
+                $referenceSearchService,
+                $channelResolver
             )
         );
 

--- a/packages/Ecotone/tests/Messaging/Unit/Handler/Gateway/GatewayProxyBuilderTest.php
+++ b/packages/Ecotone/tests/Messaging/Unit/Handler/Gateway/GatewayProxyBuilderTest.php
@@ -119,7 +119,7 @@ class GatewayProxyBuilderTest extends MessagingTest
 
         $this->expectException(InvalidArgumentException::class);
 
-        $gatewayProxyBuilder->build(
+        $gatewayProxyBuilder->buildWithoutProxyObject(
             InMemoryReferenceSearchService::createEmpty(),
             InMemoryChannelResolver::create(
                 [
@@ -323,7 +323,7 @@ class GatewayProxyBuilderTest extends MessagingTest
 
         $this->expectException(InvalidArgumentException::class);
 
-        $gatewayProxyBuilder->build(
+        $gatewayProxyBuilder->buildWithoutProxyObject(
             InMemoryReferenceSearchService::createEmpty(),
             InMemoryChannelResolver::createFromAssociativeArray(
                 [
@@ -1093,7 +1093,7 @@ class GatewayProxyBuilderTest extends MessagingTest
 
         GatewayProxyBuilder::create('some', ServiceInterfaceReceiveOnly::class, 'sendMail', 'requestChannel')
             ->withErrorChannel('errorChannel')
-            ->build(
+            ->buildWithoutProxyObject(
                 InMemoryReferenceSearchService::createEmpty(),
                 InMemoryChannelResolver::createFromAssociativeArray([
                     'requestChannel' => DirectChannel::create(),


### PR DESCRIPTION
In relation to #223, with current configuration we are always building gateways, even if they are not really used. 
Besides that we may actually want to trigger single method from Gateway Interface, so in reallity booting only specific Gateway for executed method make sense. 

This will provide much of extra performance in testing scenario or HTTP Requests scenarios, where all we do is to send an Command or Query using single method on the Command/Query Bus.