### PR TITLE
Fix running two asynchronous endpoints with same process

### DIFF
--- a/packages/Amqp/tests/Integration/AmqpMessageChannelTest.php
+++ b/packages/Amqp/tests/Integration/AmqpMessageChannelTest.php
@@ -182,8 +182,7 @@ final class AmqpMessageChannelTest extends AmqpMessagingTest
                 ->withSkippedModulePackageNames(ModulePackageList::allPackagesExcept([ModulePackageList::AMQP_PACKAGE, ModulePackageList::ASYNCHRONOUS_PACKAGE]))
                 ->withFailFast(false),
         );
-
-        // Running this endpoint first will make the $queueName to have two interceptors registered
+        
         $ecotoneLite->run('incorrectOrdersEndpoint');
 
         /** https://www.rabbitmq.com/channels.html */

--- a/packages/Amqp/tests/Integration/AmqpMessageChannelTest.php
+++ b/packages/Amqp/tests/Integration/AmqpMessageChannelTest.php
@@ -183,6 +183,9 @@ final class AmqpMessageChannelTest extends AmqpMessagingTest
                 ->withFailFast(false),
         );
 
+        // Running this endpoint first will make the $queueName to have two interceptors registered
+        $ecotoneLite->run('incorrectOrdersEndpoint');
+
         /** https://www.rabbitmq.com/channels.html */
         $ecotoneLite->getCommandBus()->sendWithRouting('order.register', 'milk');
         /** Nothing was done yet */

--- a/packages/Ecotone/src/Messaging/Channel/PollableChannel/InMemory/InMemoryAcknowledgeCallback.php
+++ b/packages/Ecotone/src/Messaging/Channel/PollableChannel/InMemory/InMemoryAcknowledgeCallback.php
@@ -7,11 +7,17 @@ namespace Ecotone\Messaging\Channel\PollableChannel\InMemory;
 use Ecotone\Messaging\Endpoint\AcknowledgementCallback;
 use Ecotone\Messaging\Message;
 use Ecotone\Messaging\PollableChannel;
+use Ecotone\Messaging\Support\Assert;
 use RuntimeException;
 
 final class InMemoryAcknowledgeCallback implements AcknowledgementCallback
 {
-    public function __construct(private PollableChannel $queueChannel, private Message $message, private bool $isAutoAck = true)
+    public function __construct(
+        private PollableChannel $queueChannel,
+        private Message $message,
+        private bool $isAutoAck = true,
+        private bool $wasAcked = false
+    )
     {
     }
 
@@ -36,6 +42,9 @@ final class InMemoryAcknowledgeCallback implements AcknowledgementCallback
      */
     public function accept(): void
     {
+        Assert::isFalse($this->wasAcked, "Trying to acknowledge message that was already acknowledged");
+
+        $this->wasAcked = true;
     }
 
     /**
@@ -43,6 +52,9 @@ final class InMemoryAcknowledgeCallback implements AcknowledgementCallback
      */
     public function reject(): void
     {
+        Assert::isFalse($this->wasAcked, 'Trying to acknowledge message that was already acknowledged');
+
+        $this->wasAcked = true;
     }
 
     private int $requeueCount = 0;

--- a/packages/Ecotone/src/Messaging/Config/MessagingSystem.php
+++ b/packages/Ecotone/src/Messaging/Config/MessagingSystem.php
@@ -144,14 +144,8 @@ final class MessagingSystem implements ConfiguredMessagingSystem
             foreach ($messageHandlerConsumerFactories as $messageHandlerConsumerBuilder) {
                 if ($messageHandlerConsumerBuilder->isSupporting($messageHandlerBuilder, $messageChannel)) {
                     if ($messageHandlerConsumerBuilder->isPollingConsumer()) {
-                        $consumerBuilderForGivenHandler = $messageHandlerConsumerBuilder;
-                        if ($messageHandlerConsumerBuilder instanceof InterceptedEndpoint) {
-                            $consumerBuilderForGivenHandler = clone $messageHandlerConsumerBuilder;
-                            $consumerBuilderForGivenHandler->withEndpointAnnotations([new AsynchronousRunningEndpoint($messageHandlerBuilder->getEndpointId())]);
-                        }
-
                         $pollingConsumerBuilders[$messageHandlerBuilder->getEndpointId()] = [
-                            self::CONSUMER_BUILDER => $consumerBuilderForGivenHandler,
+                            self::CONSUMER_BUILDER => $messageHandlerConsumerBuilder,
                             self::CONSUMER_HANDLER => $messageHandlerBuilder,
                         ];
                     } else {

--- a/packages/Ecotone/src/Messaging/Config/MessagingSystemConfiguration.php
+++ b/packages/Ecotone/src/Messaging/Config/MessagingSystemConfiguration.php
@@ -18,6 +18,7 @@ use Ecotone\Messaging\ConfigurationVariableService;
 use Ecotone\Messaging\Conversion\AutoCollectionConversionService;
 use Ecotone\Messaging\Conversion\ConversionService;
 use Ecotone\Messaging\Conversion\ConverterBuilder;
+use Ecotone\Messaging\Endpoint\AcknowledgeConfirmationInterceptor;
 use Ecotone\Messaging\Endpoint\ChannelAdapterConsumerBuilder;
 use Ecotone\Messaging\Endpoint\MessageHandlerConsumerBuilder;
 use Ecotone\Messaging\Endpoint\PollingConsumer\PollingConsumerBuilder;
@@ -661,12 +662,12 @@ final class MessagingSystemConfiguration implements Configuration
                 continue;
             }
 
+            /** Name will be provided during build for given Message Handler. Looking in PollingConsumerBuilder. This is only for pointcut lookup */
             $endpointAnnotations = [new AsynchronousRunningEndpoint('')];
             if ($this->aroundMethodInterceptors) {
                 $aroundInterceptors = $this->getRelatedInterceptors(
                     $this->aroundMethodInterceptors,
                     $consumerFactory->getInterceptedInterface($interfaceRegistry),
-                    /** Name will be provided during build for given Message Handler. Looking in MessagingSystem */
                     $endpointAnnotations,
                     $consumerFactory->getRequiredInterceptorNames(),
                     $interfaceRegistry

--- a/packages/Ecotone/src/Messaging/Endpoint/InterceptedChannelAdapterBuilder.php
+++ b/packages/Ecotone/src/Messaging/Endpoint/InterceptedChannelAdapterBuilder.php
@@ -31,7 +31,6 @@ abstract class InterceptedChannelAdapterBuilder implements ChannelAdapterConsume
         $pollingMetadata = $this->withContinuesPolling() ? $pollingMetadata->setFixedRateInMilliseconds(1) : $pollingMetadata;
         $interceptors = InterceptedConsumer::createInterceptorsForPollingMetadata($pollingMetadata, $referenceSearchService);
 
-        $results = [];
         foreach ($interceptors as $interceptor) {
             if ($interceptor->isInterestedInPostSend()) {
                 $this->addAroundInterceptor(

--- a/packages/Ecotone/src/Messaging/Endpoint/PollingConsumer/PollingConsumerBuilder.php
+++ b/packages/Ecotone/src/Messaging/Endpoint/PollingConsumer/PollingConsumerBuilder.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Ecotone\Messaging\Endpoint\PollingConsumer;
 
+use Ecotone\Messaging\Attribute\AsynchronousRunningEndpoint;
 use Ecotone\Messaging\Channel\DirectChannel;
 use Ecotone\Messaging\Channel\MessageChannelBuilder;
 use Ecotone\Messaging\Config\InMemoryChannelResolver;
@@ -31,24 +32,25 @@ use Ecotone\Messaging\Support\Assert;
 use Ramsey\Uuid\Uuid;
 
 /**
- * Class PollingConsumerBuilder
- * @package Ecotone\Messaging\Endpoint\PollingConsumer
- * @author Dariusz Gafka <dgafka.mail@gmail.com>
+ * This class is stateless Service which creates Message Consumers for Message Handlers.
+ * It should not hold any state, as it will be reused for different endpoints.
  */
 class PollingConsumerBuilder extends InterceptedMessageHandlerConsumerBuilder implements MessageHandlerConsumerBuilder
 {
-    private \Ecotone\Messaging\Handler\Gateway\GatewayProxyBuilder $entrypointGateway;
-    private string $requestChannelName;
-
-    public function __construct()
+    /**
+     * @param AroundInterceptorReference[] $aroundInterceptorReferences
+     * @param MethodInterceptor[] $beforeInterceptors
+     * @param MethodInterceptor[] $afterInterceptors
+     * @param object[] $endpointAnnotations
+     */
+    public function __construct(
+        private array $aroundInterceptorReferences = [],
+        private array $beforeInterceptors = [],
+        private array $afterInterceptors = [],
+        private array $endpointAnnotations = [],
+    )
     {
-        $this->requestChannelName = Uuid::uuid4()->toString();
-        $this->entrypointGateway = GatewayProxyBuilder::create(
-            'handler',
-            InboundChannelAdapterEntrypoint::class,
-            'executeEntrypoint',
-            $this->requestChannelName
-        );
+
     }
 
     public function isPollingConsumer(): bool
@@ -61,7 +63,7 @@ class PollingConsumerBuilder extends InterceptedMessageHandlerConsumerBuilder im
      */
     public function addAroundInterceptor(AroundInterceptorReference $aroundInterceptorReference): self
     {
-        $this->entrypointGateway->addAroundInterceptor($aroundInterceptorReference);
+        $this->aroundInterceptorReferences[] = $aroundInterceptorReference;
 
         return $this;
     }
@@ -72,7 +74,7 @@ class PollingConsumerBuilder extends InterceptedMessageHandlerConsumerBuilder im
      */
     public function addBeforeInterceptor(MethodInterceptor $methodInterceptor): self
     {
-        $this->entrypointGateway->addBeforeInterceptor($methodInterceptor);
+        $this->beforeInterceptors[] = $methodInterceptor;
 
         return $this;
     }
@@ -83,7 +85,7 @@ class PollingConsumerBuilder extends InterceptedMessageHandlerConsumerBuilder im
      */
     public function addAfterInterceptor(MethodInterceptor $methodInterceptor): self
     {
-        $this->entrypointGateway->addAfterInterceptor($methodInterceptor);
+        $this->afterInterceptors[] = $methodInterceptor;
 
         return $this;
     }
@@ -93,7 +95,7 @@ class PollingConsumerBuilder extends InterceptedMessageHandlerConsumerBuilder im
      */
     public function getInterceptedInterface(InterfaceToCallRegistry $interfaceToCallRegistry): InterfaceToCall
     {
-        return $this->entrypointGateway->getInterceptedInterface($interfaceToCallRegistry);
+        return $interfaceToCallRegistry->getFor(InboundChannelAdapterEntrypoint::class, 'executeEntrypoint');
     }
 
     /**
@@ -101,7 +103,7 @@ class PollingConsumerBuilder extends InterceptedMessageHandlerConsumerBuilder im
      */
     public function withEndpointAnnotations(iterable $endpointAnnotations): self
     {
-        $this->entrypointGateway->withEndpointAnnotations($endpointAnnotations);
+        $this->endpointAnnotations = $endpointAnnotations;
 
         return $this;
     }
@@ -111,7 +113,7 @@ class PollingConsumerBuilder extends InterceptedMessageHandlerConsumerBuilder im
      */
     public function getEndpointAnnotations(): array
     {
-        return $this->entrypointGateway->getEndpointAnnotations();
+        return $this->endpointAnnotations;
     }
 
     /**
@@ -119,7 +121,7 @@ class PollingConsumerBuilder extends InterceptedMessageHandlerConsumerBuilder im
      */
     public function getRequiredInterceptorNames(): iterable
     {
-        return $this->entrypointGateway->getRequiredInterceptorNames();
+        return [];
     }
 
     /**
@@ -127,9 +129,9 @@ class PollingConsumerBuilder extends InterceptedMessageHandlerConsumerBuilder im
      */
     public function resolveRelatedInterfaces(InterfaceToCallRegistry $interfaceToCallRegistry): iterable
     {
-        return array_merge([
+        return [
             $interfaceToCallRegistry->getFor(InboundGatewayEntrypoint::class, 'executeEntrypoint'),
-        ], $this->entrypointGateway->resolveRelatedInterfaces($interfaceToCallRegistry));
+        ];
     }
 
     /**
@@ -137,8 +139,6 @@ class PollingConsumerBuilder extends InterceptedMessageHandlerConsumerBuilder im
      */
     public function withRequiredInterceptorNames(iterable $interceptorNames): self
     {
-        $this->entrypointGateway->withRequiredInterceptorNames($interceptorNames);
-
         return $this;
     }
 
@@ -158,13 +158,30 @@ class PollingConsumerBuilder extends InterceptedMessageHandlerConsumerBuilder im
         Assert::notNullAndEmpty($messageHandlerBuilder->getEndpointId(), "Message Endpoint name can't be empty for {$messageHandlerBuilder}");
         Assert::notNull($pollingMetadata, "No polling meta data defined for polling endpoint {$messageHandlerBuilder}");
 
-        // This is where the magic happens
-        // the builder is cloned in MessagingSystemConfiguration
-        // but not the entrypointGateway, so each clone will keep the preceding interceptors + this one
-        $this->entrypointGateway->addAroundInterceptor(AcknowledgeConfirmationInterceptor::createAroundInterceptor(
+        $requestChannelName = Uuid::uuid4()->toString();
+        $entrypointGateway = GatewayProxyBuilder::create(
+            'handler',
+            InboundChannelAdapterEntrypoint::class,
+            'executeEntrypoint',
+            $requestChannelName
+        );
+        $entrypointGateway->withEndpointAnnotations(array_merge(
+            $this->endpointAnnotations,
+            [new AsynchronousRunningEndpoint($messageHandlerBuilder->getEndpointId())]
+        ));
+        foreach ($this->beforeInterceptors as $beforeInterceptor) {
+            $entrypointGateway->addBeforeInterceptor($beforeInterceptor);
+        }
+        foreach ($this->aroundInterceptorReferences as $aroundInterceptorReference) {
+            $entrypointGateway->addAroundInterceptor($aroundInterceptorReference);
+        }
+        $entrypointGateway->addAroundInterceptor(AcknowledgeConfirmationInterceptor::createAroundInterceptor(
             $referenceSearchService->get(InterfaceToCallRegistry::REFERENCE_NAME),
             $pollingMetadata
         ));
+        foreach ($this->afterInterceptors as $afterInterceptor) {
+            $entrypointGateway->addAfterInterceptor($afterInterceptor);
+        }
 
         $messageHandler = $messageHandlerBuilder->build($channelResolver, $referenceSearchService);
         $connectionChannel = DirectChannel::create();
@@ -173,12 +190,12 @@ class PollingConsumerBuilder extends InterceptedMessageHandlerConsumerBuilder im
         $pollableChannel = $channelResolver->resolve($messageHandlerBuilder->getInputMessageChannelName());
         Assert::isTrue($pollableChannel instanceof PollableChannel, 'Channel passed to Polling Consumer must be pollable');
 
-        $gateway = $this->entrypointGateway
+        $gateway = $entrypointGateway
             ->withErrorChannel($pollingMetadata->getErrorChannelName())
             ->buildWithoutProxyObject(
                 $referenceSearchService,
                 InMemoryChannelResolver::createWithChannelResolver($channelResolver, [
-                    $this->requestChannelName => $connectionChannel,
+                    $requestChannelName => $connectionChannel,
                 ])
             );
 

--- a/packages/Ecotone/src/Messaging/Endpoint/PollingConsumer/PollingConsumerBuilder.php
+++ b/packages/Ecotone/src/Messaging/Endpoint/PollingConsumer/PollingConsumerBuilder.php
@@ -158,6 +158,9 @@ class PollingConsumerBuilder extends InterceptedMessageHandlerConsumerBuilder im
         Assert::notNullAndEmpty($messageHandlerBuilder->getEndpointId(), "Message Endpoint name can't be empty for {$messageHandlerBuilder}");
         Assert::notNull($pollingMetadata, "No polling meta data defined for polling endpoint {$messageHandlerBuilder}");
 
+        // This is where the magic happens
+        // the builder is cloned in MessagingSystemConfiguration
+        // but not the entrypointGateway, so each clone will keep the preceding interceptors + this one
         $this->entrypointGateway->addAroundInterceptor(AcknowledgeConfirmationInterceptor::createAroundInterceptor(
             $referenceSearchService->get(InterfaceToCallRegistry::REFERENCE_NAME),
             $pollingMetadata

--- a/packages/Ecotone/tests/Messaging/Fixture/Service/CalculatingServiceForAsynchronousScenario.php
+++ b/packages/Ecotone/tests/Messaging/Fixture/Service/CalculatingServiceForAsynchronousScenario.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Ecotone\Messaging\Fixture\Service;
+
+use Ecotone\Messaging\Attribute\Asynchronous;
+use Ecotone\Messaging\Attribute\AsynchronousRunningEndpoint;
+use Ecotone\Messaging\Attribute\Interceptor\Before;
+use Ecotone\Modelling\Attribute\CommandHandler;
+
+/**
+ * Class CalculatingService
+ * @package Test\Ecotone\Messaging\Fixture\Service
+ * @author Dariusz Gafka <dgafka.mail@gmail.com>
+ */
+class CalculatingServiceForAsynchronousScenario
+{
+    /**
+     * @var int
+     */
+    private $secondValueForMathOperations;
+
+    private $lastResult;
+
+    /**
+     * @param int $secondValueForMathOperations
+     * @return CalculatingService
+     */
+    public static function create(int $secondValueForMathOperations): self
+    {
+        $calculatingService = new self();
+        $calculatingService->secondValueForMathOperations = $secondValueForMathOperations;
+
+        return $calculatingService;
+    }
+
+    #[Asynchronous('asyncOne')]
+    #[CommandHandler('getResultOne', endpointId: "getResultOneEndpoint")]
+    public function resultOne(int $amount): int
+    {
+        $this->lastResult = $amount;
+        return $amount;
+    }
+
+    #[Asynchronous('asyncTwo')]
+    #[CommandHandler('getResultTwo', endpointId: "getResultTwoEndpoint")]
+    public function resultTwo(int $amount): int
+    {
+        $this->lastResult = $amount;
+        return $amount;
+    }
+
+    #[Before(pointcut: AsynchronousRunningEndpoint::class)]
+    public function multiply(int $amount): int
+    {
+        return $amount * $this->secondValueForMathOperations;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getLastResult()
+    {
+        return $this->lastResult;
+    }
+}

--- a/packages/Ecotone/tests/Messaging/Unit/Config/MessagingSystemConfigurationTest.php
+++ b/packages/Ecotone/tests/Messaging/Unit/Config/MessagingSystemConfigurationTest.php
@@ -4,10 +4,13 @@ declare(strict_types=1);
 
 namespace Test\Ecotone\Messaging\Unit\Config;
 
+use Ecotone\AnnotationFinder\InMemory\InMemoryAnnotationFinder;
 use Ecotone\Lite\EcotoneLite;
+use Ecotone\Messaging\Attribute\AsynchronousRunningEndpoint;
 use Ecotone\Messaging\Channel\ChannelInterceptor;
 use Ecotone\Messaging\Channel\DirectChannel;
 use Ecotone\Messaging\Channel\MessageChannelInterceptorAdapter;
+use Ecotone\Messaging\Channel\PollableChannel\InMemory\InMemoryQueueAcknowledgeModule;
 use Ecotone\Messaging\Channel\PublishSubscribeChannel;
 use Ecotone\Messaging\Channel\QueueChannel;
 use Ecotone\Messaging\Channel\SimpleChannelInterceptorBuilder;
@@ -62,6 +65,7 @@ use Test\Ecotone\Messaging\Fixture\Handler\Processor\StubCallSavingService;
 use Test\Ecotone\Messaging\Fixture\SameChannelAndRouting\SomeTestCommandHandler;
 use Test\Ecotone\Messaging\Fixture\SameChannelAndRouting\SomeTestEventHandler;
 use Test\Ecotone\Messaging\Fixture\Service\CalculatingService;
+use Test\Ecotone\Messaging\Fixture\Service\CalculatingServiceForAsynchronousScenario;
 use Test\Ecotone\Messaging\Fixture\Service\ServiceInterface\ServiceInterfaceCalculatingService;
 use Test\Ecotone\Messaging\Fixture\Service\ServiceWithoutReturnValue;
 use Test\Ecotone\Messaging\Fixture\Service\ServiceWithReturnValue;
@@ -433,6 +437,33 @@ class MessagingSystemConfigurationTest extends MessagingTest
         $this->assertNull($calculatingService->getLastResult());
         $configuredMessagingSystem->run('asyncChannel');
         $this->assertEquals(3, $calculatingService->getLastResult());
+    }
+
+    /**
+     * Use this as template for future tests in MessagingSystem, to avoid using low level components wiring
+     *
+     * @template
+     */
+    public function test_registering_multiple_asynchronous_message_handlers_with_interceptors()
+    {
+        $calculatingService = CalculatingServiceForAsynchronousScenario::create(2);
+        $ecotoneLite = EcotoneLite::bootstrapFlowTesting(
+            [CalculatingServiceForAsynchronousScenario::class],
+            [$calculatingService],
+            ServiceConfiguration::createWithAsynchronicityOnly()
+                ->withExtensionObjects([
+                    SimpleMessageChannelBuilder::createQueueChannel('asyncOne'),
+                    SimpleMessageChannelBuilder::createQueueChannel('asyncTwo'),
+                ])
+        );
+
+        $ecotoneLite->sendCommandWithRoutingKey('getResultOne', 2);
+        $ecotoneLite->run('asyncOne');
+        $this->assertEquals(4, $calculatingService->getLastResult());
+
+        $ecotoneLite->sendCommandWithRoutingKey('getResultTwo', 3);
+        $ecotoneLite->run('asyncTwo');
+        $this->assertEquals(6, $calculatingService->getLastResult());
     }
 
     public function test_registering_before_call_intercepted_asynchronous_endpoint_with_two_channels()


### PR DESCRIPTION
In case two asynchronous endpoints are run within same process (Which may happen for test cases), it will register same interceptors twice. 
This PR makes building PollingConsumers fully stateless, so this does not rehappen.

Solves #229 