### PR TITLE
Improve traces with events

### DIFF
--- a/packages/Ecotone/src/Messaging/Channel/Collector/CollectorSenderInterceptor.php
+++ b/packages/Ecotone/src/Messaging/Channel/Collector/CollectorSenderInterceptor.php
@@ -6,9 +6,11 @@ namespace Ecotone\Messaging\Channel\Collector;
 
 use Ecotone\Messaging\Attribute\Parameter\Reference;
 use Ecotone\Messaging\Config\ConfiguredMessagingSystem;
+use Ecotone\Messaging\Handler\Logger\LoggingGateway;
 use Ecotone\Messaging\Handler\Processor\MethodInvoker\MethodInvocation;
 use Ecotone\Messaging\MessageChannel;
 use Psr\Log\LoggerInterface;
+use Ecotone\Messaging\Message;
 
 final class CollectorSenderInterceptor
 {
@@ -16,7 +18,12 @@ final class CollectorSenderInterceptor
     {
     }
 
-    public function send(MethodInvocation $methodInvocation, #[Reference] ConfiguredMessagingSystem $configuredMessagingSystem, #[Reference('logger')] LoggerInterface $logger): mixed
+    public function send(
+        MethodInvocation $methodInvocation,
+        Message $message,
+        #[Reference] ConfiguredMessagingSystem $configuredMessagingSystem,
+        #[Reference] LoggingGateway $logger
+    ): mixed
     {
         /** For example Command Bus inside Command Bus */
         if ($this->collectorStorage->isEnabled()) {
@@ -26,7 +33,7 @@ final class CollectorSenderInterceptor
         $this->collectorStorage->enable();
         try {
             $result = $methodInvocation->proceed();
-            $collectedMessages = $this->collectorStorage->releaseMessages($logger);
+            $collectedMessages = $this->collectorStorage->releaseMessages($logger, $message);
             if ($collectedMessages !== []) {
                 $messageChannel = $this->getTargetChannel($configuredMessagingSystem);
 

--- a/packages/Ecotone/src/Messaging/Channel/Collector/CollectorStorage.php
+++ b/packages/Ecotone/src/Messaging/Channel/Collector/CollectorStorage.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Ecotone\Messaging\Channel\Collector;
 
+use Ecotone\Messaging\Handler\Logger\LoggingGateway;
 use Ecotone\Messaging\Message;
 use Psr\Log\LoggerInterface;
 
@@ -39,19 +40,22 @@ final class CollectorStorage
         return $this->enabled;
     }
 
-    public function collect(Message $message, LoggerInterface $logger): void
+    public function collect(Message $message, LoggingGateway $logger): void
     {
-        $logger->info(sprintf('Collecting message with id: %s', $message->getHeaders()->getMessageId()));
+        $logger->info(
+            sprintf('Collecting message with id: %s', $message->getHeaders()->getMessageId()),
+            $message
+        );
         $this->collectedMessages[] = $message;
     }
 
     /**
      * @return Message[]
      */
-    public function releaseMessages(LoggerInterface $logger): array
+    public function releaseMessages(LoggingGateway $logger, Message $message): array
     {
         if (count($this->collectedMessages) > 0) {
-            $logger->info(sprintf('Releasing collected %s message(s) to send them to Message Channels', count($this->collectedMessages)));
+            $logger->info(sprintf('Releasing collected %s message(s) to send them to Message Channels', count($this->collectedMessages)), $message);
         }
         $collectedMessages = $this->collectedMessages;
         $this->disable();

--- a/packages/Ecotone/src/Messaging/Channel/Collector/Config/CollectorChannelInterceptorBuilder.php
+++ b/packages/Ecotone/src/Messaging/Channel/Collector/Config/CollectorChannelInterceptorBuilder.php
@@ -9,6 +9,7 @@ use Ecotone\Messaging\Channel\Collector\MessageCollectorChannelInterceptor;
 use Ecotone\Messaging\Config\Container\Definition;
 use Ecotone\Messaging\Config\Container\MessagingContainerBuilder;
 use Ecotone\Messaging\Config\Container\Reference;
+use Ecotone\Messaging\Handler\Logger\LoggingGateway;
 use Ecotone\Messaging\Handler\Logger\LoggingHandlerBuilder;
 use Ecotone\Messaging\PrecedenceChannelInterceptor;
 
@@ -34,7 +35,7 @@ final class CollectorChannelInterceptorBuilder implements ChannelInterceptorBuil
             MessageCollectorChannelInterceptor::class,
             [
                 $this->collectorStorageReference,
-                new Reference(LoggingHandlerBuilder::LOGGER_REFERENCE),
+                new Reference(LoggingGateway::class),
             ]
         );
     }

--- a/packages/Ecotone/src/Messaging/Channel/Collector/MessageCollectorChannelInterceptor.php
+++ b/packages/Ecotone/src/Messaging/Channel/Collector/MessageCollectorChannelInterceptor.php
@@ -6,6 +6,7 @@ namespace Ecotone\Messaging\Channel\Collector;
 
 use Ecotone\Messaging\Channel\AbstractChannelInterceptor;
 use Ecotone\Messaging\Channel\ChannelInterceptor;
+use Ecotone\Messaging\Handler\Logger\LoggingGateway;
 use Ecotone\Messaging\Message;
 use Ecotone\Messaging\MessageChannel;
 use Psr\Log\LoggerInterface;
@@ -14,7 +15,7 @@ final class MessageCollectorChannelInterceptor extends AbstractChannelIntercepto
 {
     public function __construct(
         private CollectorStorage $collectorStorage,
-        private LoggerInterface $logger
+        private LoggingGateway $logger
     ) {
     }
 

--- a/packages/Ecotone/src/Messaging/Config/Annotation/ModuleConfiguration/BasicMessagingModule.php
+++ b/packages/Ecotone/src/Messaging/Config/Annotation/ModuleConfiguration/BasicMessagingModule.php
@@ -11,8 +11,10 @@ use Ecotone\Messaging\Config\Annotation\AnnotationModule;
 use Ecotone\Messaging\Config\Annotation\ModuleConfiguration\MessagingCommands\MessagingCommandsModule;
 use Ecotone\Messaging\Config\Configuration;
 use Ecotone\Messaging\Config\Container\Definition;
+use Ecotone\Messaging\Config\Container\Reference;
 use Ecotone\Messaging\Config\ModulePackageList;
 use Ecotone\Messaging\Config\ModuleReferenceSearchService;
+use Ecotone\Messaging\Conversion\ConversionService;
 use Ecotone\Messaging\Conversion\ObjectToSerialized\SerializingConverterBuilder;
 use Ecotone\Messaging\Conversion\SerializedToObject\DeserializingConverterBuilder;
 use Ecotone\Messaging\Conversion\StringToUuid\StringToUuidConverterBuilder;
@@ -31,6 +33,8 @@ use Ecotone\Messaging\Handler\Gateway\ParameterToMessageConverter\GatewayHeaderB
 use Ecotone\Messaging\Handler\Gateway\ParameterToMessageConverter\GatewayHeadersBuilder;
 use Ecotone\Messaging\Handler\Gateway\ParameterToMessageConverter\GatewayPayloadBuilder;
 use Ecotone\Messaging\Handler\InterfaceToCallRegistry;
+use Ecotone\Messaging\Handler\Logger\LoggingHandlerBuilder;
+use Ecotone\Messaging\Handler\Logger\LoggingService;
 use Ecotone\Messaging\Handler\MessageHandlerBuilder;
 use Ecotone\Messaging\Handler\Router\HeaderRouter;
 use Ecotone\Messaging\Handler\Router\RouterBuilder;
@@ -167,6 +171,17 @@ class BasicMessagingModule extends NoExternalConfigurationModule implements Anno
                 GatewayHeaderBuilder::create('commandName', MessagingCommandsModule::ECOTONE_CONSOLE_COMMAND_NAME),
                 GatewayPayloadBuilder::create('parameters'),
             ])
+        );
+
+        $messagingConfiguration->registerServiceDefinition(
+            LoggingService::class,
+            new Definition(
+                LoggingService::class,
+                [
+                    Reference::to(ConversionService::REFERENCE_NAME),
+                    Reference::to(LoggingHandlerBuilder::LOGGER_REFERENCE)
+                ]
+            )
         );
     }
 

--- a/packages/Ecotone/src/Messaging/Config/Annotation/ModuleConfiguration/ErrorHandlerModule.php
+++ b/packages/Ecotone/src/Messaging/Config/Annotation/ModuleConfiguration/ErrorHandlerModule.php
@@ -13,6 +13,7 @@ use Ecotone\Messaging\Config\Container\Definition;
 use Ecotone\Messaging\Config\ModulePackageList;
 use Ecotone\Messaging\Config\ModuleReferenceSearchService;
 use Ecotone\Messaging\Handler\InterfaceToCallRegistry;
+use Ecotone\Messaging\Handler\Logger\LoggingGateway;
 use Ecotone\Messaging\Handler\Logger\LoggingHandlerBuilder;
 use Ecotone\Messaging\Handler\Processor\MethodInvoker\Converter\ReferenceBuilder;
 use Ecotone\Messaging\Handler\Recoverability\ErrorHandler;
@@ -62,7 +63,7 @@ class ErrorHandlerModule extends NoExternalConfigurationModule implements Annota
                 ->withEndpointId('error_handler.' . $extensionObject->getErrorChannelName())
                 ->withInputChannelName($extensionObject->getErrorChannelName())
                 ->withMethodParameterConverters([
-                    ReferenceBuilder::create('logger', LoggingHandlerBuilder::LOGGER_REFERENCE),
+                    ReferenceBuilder::create('logger', LoggingGateway::class),
                 ]);
             if ($extensionObject->getDeadLetterQueueChannel()) {
                 $errorHandler = $errorHandler->withOutputMessageChannel($extensionObject->getDeadLetterQueueChannel());

--- a/packages/Ecotone/src/Messaging/Config/Container/ContainerConfig.php
+++ b/packages/Ecotone/src/Messaging/Config/Container/ContainerConfig.php
@@ -11,6 +11,8 @@ use Ecotone\Messaging\Config\Container\Compiler\ValidityCheckPass;
 use Ecotone\Messaging\Config\ServiceCacheConfiguration;
 use Ecotone\Messaging\ConfigurationVariableService;
 use Ecotone\Messaging\Handler\Gateway\ProxyFactory;
+use Ecotone\Messaging\Handler\Logger\LoggingGateway;
+use Ecotone\Messaging\Handler\Logger\StubLoggingGateway;
 use Ecotone\Messaging\InMemoryConfigurationVariableService;
 use Psr\Container\ContainerInterface;
 
@@ -30,6 +32,9 @@ class ContainerConfig
         $container = new LazyInMemoryContainer($containerBuilder->getDefinitions(), $externalContainer);
         $container->set(ConfigurationVariableService::REFERENCE_NAME, $configurationVariableService ?? InMemoryConfigurationVariableService::createEmpty());
         $container->set(ProxyFactory::class, $proxyFactory ?? new ProxyFactory(ServiceCacheConfiguration::noCache()));
+        if (!$container->has(LoggingGateway::class)) {
+            $container->set(LoggingGateway::class, StubLoggingGateway::create());
+        }
         return $container->get(ConfiguredMessagingSystem::class);
     }
 

--- a/packages/Ecotone/src/Messaging/Config/MessagingSystemConfiguration.php
+++ b/packages/Ecotone/src/Messaging/Config/MessagingSystemConfiguration.php
@@ -664,7 +664,7 @@ final class MessagingSystemConfiguration implements Configuration
                 $serviceConfiguration->getNamespaces(),
                 $serviceConfiguration->getEnvironment(),
                 $serviceConfiguration->getLoadedCatalog() ?? '',
-                array_filter($modulesClasses, fn (string $moduleClassName): bool => class_exists($moduleClassName)),
+                array_filter($modulesClasses, fn (string $moduleClassName): bool => class_exists($moduleClassName) || interface_exists($moduleClassName)),
                 $userLandClassesToRegister,
                 $enableTestPackage
             ),

--- a/packages/Ecotone/src/Messaging/Config/ModuleClassList.php
+++ b/packages/Ecotone/src/Messaging/Config/ModuleClassList.php
@@ -39,6 +39,8 @@ use Ecotone\Messaging\Config\Annotation\ModuleConfiguration\ServiceActivatorModu
 use Ecotone\Messaging\Config\Annotation\ModuleConfiguration\SplitterModule;
 use Ecotone\Messaging\Config\Annotation\ModuleConfiguration\TransformerModule;
 use Ecotone\Messaging\Handler\Logger\Config\LoggingModule;
+use Ecotone\Messaging\Handler\Logger\LoggingGateway;
+use Ecotone\Messaging\Handler\Logger\LoggingService;
 use Ecotone\Modelling\Config\BusModule;
 use Ecotone\Modelling\Config\BusRoutingModule;
 use Ecotone\Modelling\Config\DistributedGatewayModule;
@@ -77,6 +79,10 @@ class ModuleClassList
         TransformerModule::class,
         MessageConsumerModule::class,
         InstantRetryModule::class,
+
+        /** Attribute based configurations */
+        LoggingGateway::class,
+        LoggingService::class
     ];
 
     public const ASYNCHRONOUS_MODULE = [

--- a/packages/Ecotone/src/Messaging/Handler/Logger/LoggingGateway.php
+++ b/packages/Ecotone/src/Messaging/Handler/Logger/LoggingGateway.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ecotone\Messaging\Handler\Logger;
+
+use Ecotone\Messaging\Attribute\MessageGateway;
+use Ecotone\Messaging\Attribute\Parameter\Header;
+use Ecotone\Messaging\Attribute\Parameter\Payload;
+use Ecotone\Messaging\Message;
+
+interface LoggingGateway
+{
+    #[MessageGateway(LoggingService::INFO_LOGGING_CHANNEL)]
+    public function info(
+        #[Payload] string $text,
+        #[Header(LoggingService::CONTEXT_MESSAGE_HEADER)] Message $message,
+        #[Header(LoggingService::CONTEXT_EXCEPTION_HEADER)] ?\Exception $exception = null
+    ): void;
+
+    #[MessageGateway(LoggingService::ERROR_LOGGING_CHANNEL)]
+    public function error(
+        #[Payload] string $text,
+        #[Header(LoggingService::CONTEXT_MESSAGE_HEADER)] Message $message,
+        #[Header(LoggingService::CONTEXT_EXCEPTION_HEADER)] ?\Exception $exception = null
+    ): void;
+}

--- a/packages/Ecotone/src/Messaging/Handler/Logger/LoggingService.php
+++ b/packages/Ecotone/src/Messaging/Handler/Logger/LoggingService.php
@@ -4,6 +4,9 @@ declare(strict_types=0);
 
 namespace Ecotone\Messaging\Handler\Logger;
 
+use Ecotone\Messaging\Attribute\Parameter\Header;
+use Ecotone\Messaging\Attribute\Parameter\Payload;
+use Ecotone\Messaging\Attribute\ServiceActivator;
 use Ecotone\Messaging\Conversion\ConversionService;
 use Ecotone\Messaging\Conversion\MediaType;
 use Ecotone\Messaging\Handler\TypeDefinitionException;
@@ -21,6 +24,11 @@ use Throwable;
  */
 class LoggingService
 {
+    public const CONTEXT_MESSAGE_HEADER = 'ecotone.logging.contextMessage';
+    public const CONTEXT_EXCEPTION_HEADER = 'ecotone.logging.exceptionMessage';
+    public const INFO_LOGGING_CHANNEL = 'infoLoggingChannel';
+    public const ERROR_LOGGING_CHANNEL = 'errorLoggingChannel';
+
     private \Ecotone\Messaging\Conversion\ConversionService $conversionService;
     private \Psr\Log\LoggerInterface $logger;
 
@@ -33,6 +41,44 @@ class LoggingService
     {
         $this->conversionService = $conversionService;
         $this->logger = $logger;
+    }
+
+    #[ServiceActivator(self::INFO_LOGGING_CHANNEL)]
+    public function info(
+        #[Payload] string $text,
+        #[Header(self::CONTEXT_MESSAGE_HEADER)] Message $message,
+        #[Header(self::CONTEXT_EXCEPTION_HEADER)] ?\Exception $exception,
+    ): void
+    {
+        $this->logger->info(
+            $text,
+            [
+                'message_id' => $message->getHeaders()->getMessageId(),
+                'correlation_id' => $message->getHeaders()->getCorrelationId(),
+                'parent_id' => $message->getHeaders()->getParentId(),
+                'headers' => (string)$message->getHeaders(),
+                'exception' => $exception
+            ]
+        );
+    }
+
+    #[ServiceActivator(self::ERROR_LOGGING_CHANNEL)]
+    public function error(
+        #[Payload] string $text,
+        #[Header(self::CONTEXT_MESSAGE_HEADER)] Message $message,
+        #[Header(self::CONTEXT_EXCEPTION_HEADER)] ?\Exception $exception,
+    ): void
+    {
+        $this->logger->critical(
+            $text,
+            [
+                'message_id' => $message->getHeaders()->getMessageId(),
+                'correlation_id' => $message->getHeaders()->getCorrelationId(),
+                'parent_id' => $message->getHeaders()->getParentId(),
+                'headers' => (string)$message->getHeaders(),
+                'exception' => $exception
+            ]
+        );
     }
 
     /**

--- a/packages/Ecotone/src/Messaging/Handler/Logger/StubLoggingGateway.php
+++ b/packages/Ecotone/src/Messaging/Handler/Logger/StubLoggingGateway.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ecotone\Messaging\Handler\Logger;
+
+use Ecotone\Messaging\Message;
+
+final class StubLoggingGateway implements LoggingGateway
+{
+    private array $info = [];
+    private array $critical = [];
+
+    public static function create(): self
+    {
+        return new self();
+    }
+
+    public function info(string $text, Message $message, ?\Exception $exception = null): void
+    {
+        $this->info[] = $text;
+    }
+
+    public function error(string $text, Message $message, ?\Exception $exception = null): void
+    {
+        $this->critical[] = $text;
+    }
+
+    public function getCritical(): array
+    {
+        return $this->critical;
+    }
+
+    public function getInfo(): array
+    {
+        return $this->info;
+    }
+}

--- a/packages/Ecotone/src/Messaging/Handler/Recoverability/ErrorHandler.php
+++ b/packages/Ecotone/src/Messaging/Handler/Recoverability/ErrorHandler.php
@@ -6,6 +6,7 @@ namespace Ecotone\Messaging\Handler\Recoverability;
 
 use Ecotone\Messaging\Attribute\Parameter\Reference;
 use Ecotone\Messaging\Handler\ChannelResolver;
+use Ecotone\Messaging\Handler\Logger\LoggingGateway;
 use Ecotone\Messaging\Handler\Logger\LoggingHandlerBuilder;
 use Ecotone\Messaging\Message;
 use Ecotone\Messaging\MessageChannel;
@@ -33,8 +34,7 @@ class ErrorHandler
     public function handle(
         ErrorMessage $errorMessage,
         ChannelResolver $channelResolver,
-        #[Reference(LoggingHandlerBuilder::LOGGER_REFERENCE)]
-        LoggerInterface $logger
+        #[Reference] LoggingGateway $logger
     ): ?Message {
         /** @var MessagingException $messagingException */
         $messagingException = $errorMessage->getPayload();
@@ -61,27 +61,29 @@ class ErrorHandler
 
         if ($this->shouldBeSendToDeadLetter($retryNumber)) {
             if (! $this->hasDeadLetterOutput) {
-                $logger->critical(
+                $logger->error(
                     sprintf(
                         'Discarding message %s as no dead letter channel was defined. Retried maximum number of `%s` times. Due to: %s',
                         $failedMessage->getHeaders()->getMessageId(),
                         $retryNumber,
                         $cause->getMessage()
                     ),
-                    ['exception' => $cause]
+                    $failedMessage,
+                    $cause
                 );
 
                 return null;
             }
 
-            $logger->critical(
+            $logger->error(
                 sprintf(
                     'Sending message `%s` to dead letter channel, as retried maximum number of `%s` times. Due to: %s',
                     $failedMessage->getHeaders()->getMessageId(),
                     $retryNumber,
                     $cause->getMessage()
                 ),
-                ['exception' => $cause]
+                $failedMessage,
+                $cause
             );
             $messageBuilder->removeHeader(self::ECOTONE_RETRY_HEADER);
 
@@ -97,14 +99,16 @@ class ErrorHandler
         $delayMs = $this->delayedRetryTemplate->calculateNextDelay($retryNumber);
         $logger->info(
             sprintf(
-                'Retrying message with id `%s` with delay of `%d` ms. %s',
+                'Retrying message with id `%s` with delay of `%d` ms. %s. Due to %s',
                 $failedMessage->getHeaders()->getMessageId(),
                 $delayMs,
                 $this->delayedRetryTemplate->getMaxAttempts()
                     ? sprintf('Try %d out of %s', $retryNumber, $this->delayedRetryTemplate->getMaxAttempts())
-                    : ''
+                    : '',
+                $cause->getMessage()
             ),
-            ['exception' => $cause]
+            $failedMessage,
+            $cause
         );
         $messageChannel->send(
             $messageBuilder

--- a/packages/Ecotone/src/Modelling/Config/InstantRetry/InstantRetryInterceptor.php
+++ b/packages/Ecotone/src/Modelling/Config/InstantRetry/InstantRetryInterceptor.php
@@ -5,10 +5,12 @@ namespace Ecotone\Modelling\Config\InstantRetry;
 use Ecotone\Messaging\Attribute\Parameter\Reference;
 use Ecotone\Messaging\Config\Container\DefinedObject;
 use Ecotone\Messaging\Config\Container\Definition;
+use Ecotone\Messaging\Handler\Logger\LoggingGateway;
 use Ecotone\Messaging\Handler\Processor\MethodInvoker\MethodInvocation;
 use Ecotone\Messaging\Handler\TypeDescriptor;
 use Exception;
 use Psr\Log\LoggerInterface;
+use Ecotone\Messaging\Message;
 
 class InstantRetryInterceptor implements DefinedObject
 {
@@ -16,7 +18,7 @@ class InstantRetryInterceptor implements DefinedObject
     {
     }
 
-    public function retry(MethodInvocation $methodInvocation, #[Reference('logger')] LoggerInterface $logger)
+    public function retry(MethodInvocation $methodInvocation, Message $message, #[Reference] LoggingGateway $logger)
     {
         $isSuccessful = false;
         $retries = 0;
@@ -28,16 +30,25 @@ class InstantRetryInterceptor implements DefinedObject
                 $isSuccessful = true;
             } catch (Exception $exception) {
                 if (! $this->canRetryThrownException($exception) || $retries >= $this->maxRetryAttempts) {
-                    $logger->info(sprintf('Instant retry have exceed %d/%d retry limit. No more retries will be done', $retries, $this->maxRetryAttempts), [
-                        'exception' => $exception->getMessage(),
-                    ]);
+                    $logger->info(
+                        sprintf('Instant retry have exceed %d/%d retry limit. No more retries will be done', $retries, $this->maxRetryAttempts),
+                        $message,
+                        $exception
+                    );
                     throw $exception;
                 }
 
                 $retries++;
-                $logger->info(sprintf('Exception happened. Trying to self-heal by doing instant try %d out of %d.', $retries, $this->maxRetryAttempts), [
-                    'exception' => $exception->getMessage(),
-                ]);
+                $logger->info(
+                    sprintf(
+                        'Exception happened. Trying to self-heal by doing instant try %d out of %d. Due to %s',
+                        $retries,
+                        $this->maxRetryAttempts,
+                        $exception->getMessage()
+                    ),
+                    $message,
+                    $exception
+                );
             }
         }
 

--- a/packages/Ecotone/src/Test/ComponentTestBuilder.php
+++ b/packages/Ecotone/src/Test/ComponentTestBuilder.php
@@ -24,6 +24,8 @@ use Ecotone\Messaging\Endpoint\EndpointRunner;
 use Ecotone\Messaging\Endpoint\ExecutionPollingMetadata;
 use Ecotone\Messaging\Endpoint\MessageHandlerConsumerBuilder;
 use Ecotone\Messaging\Endpoint\PollingMetadata;
+use Ecotone\Messaging\Handler\Logger\LoggingGateway;
+use Ecotone\Messaging\Handler\Logger\StubLoggingGateway;
 use Ecotone\Messaging\Handler\MessageHandlerBuilder;
 
 use Ecotone\Messaging\InMemoryConfigurationVariableService;
@@ -46,6 +48,7 @@ class ComponentTestBuilder
         $container = InMemoryPSRContainer::createFromAssociativeArray([
             ServiceCacheConfiguration::class => ServiceCacheConfiguration::noCache(),
             ConfigurationVariableService::REFERENCE_NAME => InMemoryConfigurationVariableService::createEmpty(),
+            LoggingGateway::class => StubLoggingGateway::create()
         ]);
         $containerBuilder = new ContainerBuilder();
         $containerBuilder->addCompilerPass(new RegisterSingletonMessagingServices());

--- a/packages/Ecotone/tests/Messaging/Unit/Handler/ErrorHandler/ErrorHandlerTest.php
+++ b/packages/Ecotone/tests/Messaging/Unit/Handler/ErrorHandler/ErrorHandlerTest.php
@@ -6,6 +6,7 @@ namespace Test\Ecotone\Messaging\Unit\Handler\ErrorHandler;
 
 use Ecotone\Messaging\Channel\QueueChannel;
 use Ecotone\Messaging\Config\InMemoryChannelResolver;
+use Ecotone\Messaging\Handler\Logger\StubLoggingGateway;
 use Ecotone\Messaging\Handler\MessageHandlingException;
 use Ecotone\Messaging\Handler\Recoverability\ErrorHandler;
 use Ecotone\Messaging\Handler\Recoverability\RetryTemplateBuilder;
@@ -30,7 +31,7 @@ class ErrorHandlerTest extends TestCase
             ->build();
 
         $consumedChannel = QueueChannel::create();
-        $logger = LoggerExample::create();
+        $logger = StubLoggingGateway::create();
         $errorHandler = new ErrorHandler($retryTemplate, false);
 
         $this->assertNull(
@@ -80,7 +81,7 @@ class ErrorHandlerTest extends TestCase
                     ->build()
             ),
             InMemoryChannelResolver::createFromAssociativeArray(['errorChannel' => $consumedChannel]),
-            LoggerExample::create()
+            StubLoggingGateway::create()
         );
 
         $this->assertEquals(40, $consumedChannel->receive()->getHeaders()->get(MessageHeaders::DELIVERY_DELAY));
@@ -93,7 +94,7 @@ class ErrorHandlerTest extends TestCase
             ->build();
 
         $consumedChannel = QueueChannel::create();
-        $logger = LoggerExample::create();
+        $logger = StubLoggingGateway::create();
         $errorHandler = new ErrorHandler($retryTemplate, true);
 
         $resultMessage = $errorHandler->handle(
@@ -120,7 +121,7 @@ class ErrorHandlerTest extends TestCase
             ->build();
 
         $consumedChannel = QueueChannel::create();
-        $logger = LoggerExample::create();
+        $logger = StubLoggingGateway::create();
         $errorHandler = new ErrorHandler($retryTemplate, false);
 
         $resultMessage = $errorHandler->handle(
@@ -157,7 +158,7 @@ class ErrorHandlerTest extends TestCase
                 new InvalidArgumentException('causation')
             ),
             InMemoryChannelResolver::createFromAssociativeArray(['errorChannel' => $consumedChannel]),
-            LoggerExample::create()
+            StubLoggingGateway::create()
         );
 
         $this->assertEquals('causation', $resultMessage->getHeaders()->get(ErrorHandler::EXCEPTION_MESSAGE));
@@ -182,7 +183,7 @@ class ErrorHandlerTest extends TestCase
                 new InvalidArgumentException()
             ),
             InMemoryChannelResolver::createEmpty(),
-            LoggerExample::create()
+            StubLoggingGateway::create()
         );
     }
 }

--- a/packages/OpenTelemetry/src/Configuration/OpenTelemetryModule.php
+++ b/packages/OpenTelemetry/src/Configuration/OpenTelemetryModule.php
@@ -17,6 +17,7 @@ use Ecotone\Messaging\Config\Container\Reference;
 use Ecotone\Messaging\Config\ModulePackageList;
 use Ecotone\Messaging\Config\ModuleReferenceSearchService;
 use Ecotone\Messaging\Handler\InterfaceToCallRegistry;
+use Ecotone\Messaging\Handler\Logger\LoggingGateway;
 use Ecotone\Messaging\Handler\Processor\MethodInvoker\AroundInterceptorBuilder;
 use Ecotone\Messaging\Precedence;
 use Ecotone\Modelling\Attribute\CommandHandler;
@@ -67,6 +68,7 @@ final class OpenTelemetryModule extends NoExternalConfigurationModule implements
         $this->registerTracerFor('traceQueryBus', QueryBus::class, $messagingConfiguration, $interfaceToCallRegistry);
         $this->registerTracerFor('traceEventBus', EventBus::class, $messagingConfiguration, $interfaceToCallRegistry);
         $this->registerTracerFor('traceAsynchronousEndpoint', AsynchronousRunningEndpoint::class, $messagingConfiguration, $interfaceToCallRegistry);
+        $this->registerTracerFor('traceLogs', LoggingGateway::class, $messagingConfiguration, $interfaceToCallRegistry);
     }
 
     public function canHandle($extensionObject): bool

--- a/packages/OpenTelemetry/src/TracerInterceptor.php
+++ b/packages/OpenTelemetry/src/TracerInterceptor.php
@@ -8,6 +8,9 @@ use Ecotone\Messaging\Handler\Processor\MethodInvoker\MethodInvocation;
 use Ecotone\Messaging\Message;
 use Ecotone\Messaging\MessageHeaders;
 
+use OpenTelemetry\API\Trace\SpanContext;
+use OpenTelemetry\Context\Context;
+use OpenTelemetry\SDK\Trace\Span;
 use function json_decode;
 
 use OpenTelemetry\API\Trace\Propagation\TraceContextPropagator;

--- a/packages/OpenTelemetry/src/TracerInterceptor.php
+++ b/packages/OpenTelemetry/src/TracerInterceptor.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Ecotone\OpenTelemetry;
 
+use Ecotone\Messaging\Handler\Logger\LoggingService;
 use Ecotone\Messaging\Handler\Processor\MethodInvoker\MethodInvocation;
 use Ecotone\Messaging\Message;
 use Ecotone\Messaging\MessageHeaders;
@@ -103,6 +104,33 @@ final class TracerInterceptor
             $methodInvocation,
             $message,
         );
+    }
+
+    public function traceLogs(MethodInvocation $methodInvocation, Message $message)
+    {
+        $logMessage = $message->getPayload();
+        /** @var Message $contextMessage */
+        $contextMessage = $message->getHeaders()->get(LoggingService::CONTEXT_MESSAGE_HEADER);
+        $attributes = [
+            MessageHeaders::MESSAGE_ID => $contextMessage->getHeaders()->getMessageId(),
+            MessageHeaders::MESSAGE_CORRELATION_ID => $contextMessage->getHeaders()->getCorrelationId(),
+            MessageHeaders::PARENT_MESSAGE_ID => $contextMessage->getHeaders()->getParentId(),
+        ];
+
+        if ($message->getHeaders()->containsKey(LoggingService::CONTEXT_EXCEPTION_HEADER)) {
+            /** @var \Exception $exception */
+            $exception = $message->getHeaders()->get(LoggingService::CONTEXT_EXCEPTION_HEADER);
+            $attributes['exceptionMessage'] = $exception->getMessage();
+            $attributes['exceptionClass'] = $exception::class;
+            $attributes['exceptionTrace'] = $exception->getTraceAsString();
+        }
+
+        Span::getCurrent()->addEvent(
+            $logMessage,
+            $attributes
+        );
+
+        return $methodInvocation->proceed();
     }
 
     public function trace(

--- a/packages/OpenTelemetry/src/TracingChannelInterceptor.php
+++ b/packages/OpenTelemetry/src/TracingChannelInterceptor.php
@@ -36,6 +36,7 @@ final class TracingChannelInterceptor implements ChannelInterceptor
             ->startSpan();
         $spanScope = $span->activate();
 
+        /** @link https://github.com/open-telemetry/opentelemetry-php/blob/main/examples/traces/demo/src/index.php#L44 */
         $carrier = [];
         TraceContextPropagator::getInstance()->inject($carrier);
 

--- a/packages/OpenTelemetry/tests/Fixture/AsynchronousFlow/User.php
+++ b/packages/OpenTelemetry/tests/Fixture/AsynchronousFlow/User.php
@@ -9,11 +9,14 @@ use Ecotone\Modelling\Attribute\Aggregate;
 use Ecotone\Modelling\Attribute\AggregateIdentifier;
 use Ecotone\Modelling\Attribute\CommandHandler;
 use Ecotone\Modelling\Attribute\QueryHandler;
+use Ecotone\Modelling\WithEvents;
 use Test\Ecotone\OpenTelemetry\Fixture\CommandEventFlow\RegisterUser;
 
 #[Aggregate]
 final class User
 {
+    use WithEvents;
+
     #[AggregateIdentifier]
     private string $userId;
 
@@ -23,6 +26,8 @@ final class User
     {
         $user = new self();
         $user->userId = $command->userId;
+
+        $user->recordThat(new UserRegistered($command->userId));
 
         return $user;
     }

--- a/packages/OpenTelemetry/tests/Fixture/AsynchronousFlow/UserNotifier.php
+++ b/packages/OpenTelemetry/tests/Fixture/AsynchronousFlow/UserNotifier.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Ecotone\OpenTelemetry\Fixture\AsynchronousFlow;
+
+use Ecotone\Messaging\Attribute\Asynchronous;
+use Ecotone\Modelling\Attribute\EventHandler;
+
+final class UserNotifier
+{
+    #[Asynchronous('async_channel')]
+    #[EventHandler(endpointId: 'user.registered')]
+    public function handle(UserRegistered $event): void
+    {
+
+    }
+}

--- a/packages/OpenTelemetry/tests/Fixture/AsynchronousFlow/UserRegistered.php
+++ b/packages/OpenTelemetry/tests/Fixture/AsynchronousFlow/UserRegistered.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Ecotone\OpenTelemetry\Fixture\AsynchronousFlow;
+
+final class UserRegistered
+{
+    public function __construct(
+        public string $userId
+    ) {}
+}

--- a/packages/OpenTelemetry/tests/Integration/TracingTest.php
+++ b/packages/OpenTelemetry/tests/Integration/TracingTest.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Test\Ecotone\OpenTelemetry\Integration;
 
+use OpenTelemetry\API\Trace\SpanContext;
+use OpenTelemetry\API\Trace\SpanContextInterface;
+use OpenTelemetry\SDK\Trace\SpanDataInterface;
 use function json_encode;
 
 use OpenTelemetry\API\Trace\TracerProviderInterface;
@@ -28,6 +31,7 @@ abstract class TracingTest extends TestCase
     public static function buildTree(InMemoryExporter $exporter): array
     {
         $tree = [];
+        /** @var SpanDataInterface $span */
         foreach ($exporter->getSpans() as $span) {
             $preparedSpan = [
                 'details' => [
@@ -37,6 +41,7 @@ abstract class TracingTest extends TestCase
                     'attributes' => $span->getAttributes()->toArray(),
                     'kind' => $span->getKind(),
                     'links' => $span->getLinks(),
+                    'events' => $span->getEvents(),
                 ],
                 'children' => [],
             ];


### PR DESCRIPTION
This starts collecting logs as form of an event. Thanks we will be able to find out more about what actually happening within given trace.

For example sending asynchronous message via Event Bus, firstly collect those instead of sending right away:
![Screenshot from 2023-11-02 08-29-54](https://github.com/ecotoneframework/ecotone-dev/assets/6060791/38cbad7c-c515-42d9-8159-e7ca6078b164)
