### PR TITLE
Reset manager if closed

### DIFF
--- a/packages/Dbal/src/DbalConnection.php
+++ b/packages/Dbal/src/DbalConnection.php
@@ -3,135 +3,23 @@
 namespace Ecotone\Dbal;
 
 use Doctrine\DBAL\Connection;
-use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\Persistence\ManagerRegistry;
-use Doctrine\Persistence\ObjectManager;
-use Doctrine\Persistence\ObjectRepository;
-use Ecotone\Messaging\Support\InvalidArgumentException;
 use Enqueue\Dbal\DbalConnectionFactory;
-use Enqueue\Dbal\ManagerRegistryConnectionFactory;
 
-class DbalConnection implements ManagerRegistry
+class DbalConnection
 {
-    private function __construct(private ?Connection $connection, private ?EntityManagerInterface $entityManager = null)
+    public static function fromConnectionFactory(DbalConnectionFactory $dbalConnectionFactory): EcotoneManagerRegistryConnectionFactory
     {
+        return new EcotoneManagerRegistryConnectionFactory(new ManagerRegistryEmulator(($dbalConnectionFactory->createContext()->getDbalConnection())));
     }
 
-    public static function fromConnectionFactory(DbalConnectionFactory $dbalConnectionFactory): ManagerRegistryConnectionFactory
+    public static function create(Connection $connection): EcotoneManagerRegistryConnectionFactory
     {
-        return new ManagerRegistryConnectionFactory(new self($dbalConnectionFactory->createContext()->getDbalConnection()));
+        return new EcotoneManagerRegistryConnectionFactory(new ManagerRegistryEmulator($connection));
     }
 
-    public static function create(Connection $connection): ManagerRegistryConnectionFactory
+    public static function createForManagerRegistry(ManagerRegistry $managerRegistry, string $connectionName): EcotoneManagerRegistryConnectionFactory
     {
-        return new ManagerRegistryConnectionFactory(new self($connection));
-    }
-
-    public static function createEntityManager(EntityManagerInterface $entityManager): ManagerRegistryConnectionFactory
-    {
-        return new ManagerRegistryConnectionFactory(new self($entityManager->getConnection(), $entityManager));
-    }
-
-    public static function createForManagerRegistry(ManagerRegistry $managerRegistry, string $connectionName): ManagerRegistryConnectionFactory
-    {
-        return new ManagerRegistryConnectionFactory($managerRegistry, ['connection_name' => $connectionName]);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getDefaultConnectionName(): string
-    {
-        return 'default';
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getConnection($name = null): object
-    {
-        return $this->connection;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getConnections(): array
-    {
-        return [$this->connection];
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getConnectionNames(): array
-    {
-        return ['default'];
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getDefaultManagerName(): string
-    {
-        return 'default';
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getManager($name = null): ObjectManager
-    {
-        return $this->entityManager;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getManagers(): array
-    {
-        return $this->entityManager ? [$this->entityManager] : [];
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function resetManager($name = null): ObjectManager
-    {
-        $this->entityManager->getUnitOfWork()->clear();
-
-        return $this->entityManager;
-    }
-
-    /**
-     * @throws InvalidArgumentException
-     */
-    public function getAliasNamespace($alias): string
-    {
-        throw InvalidArgumentException::create('Method not supported');
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getManagerNames(): array
-    {
-        return ['default'];
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getRepository($persistentObject, $persistentManagerName = null): ObjectRepository
-    {
-        return $this->entityManager->getRepository($persistentObject);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getManagerForClass($class): ?ObjectManager
-    {
-        return $this->entityManager;
+        return new EcotoneManagerRegistryConnectionFactory($managerRegistry, ['connection_name' => $connectionName]);
     }
 }

--- a/packages/Dbal/src/EcotoneManagerRegistryConnectionFactory.php
+++ b/packages/Dbal/src/EcotoneManagerRegistryConnectionFactory.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ecotone\Dbal;
+
+use Doctrine\Persistence\ManagerRegistry;
+use Enqueue\Dbal\ManagerRegistryConnectionFactory;
+
+final class EcotoneManagerRegistryConnectionFactory extends ManagerRegistryConnectionFactory
+{
+    private ManagerRegistry $registry;
+
+    public function __construct(ManagerRegistry $registry, array $config = [])
+    {
+        parent::__construct($registry, $config);
+
+        $this->registry = $registry;
+    }
+
+    public function getRegistry(): ManagerRegistry
+    {
+        return $this->registry;
+    }
+}

--- a/packages/Dbal/src/ManagerRegistryEmulator.php
+++ b/packages/Dbal/src/ManagerRegistryEmulator.php
@@ -1,0 +1,166 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ecotone\Dbal;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Tools\Setup;
+use Doctrine\Persistence\ManagerRegistry;
+use Doctrine\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectRepository;
+use Ecotone\Messaging\Support\InvalidArgumentException;
+use Enqueue\Dbal\DbalConnectionFactory;
+
+final class ManagerRegistryEmulator implements ManagerRegistry
+{
+    /**
+     * @param string[] $pathsToMapping
+     */
+    public function __construct(
+        private Connection $connection,
+        private array $pathsToMapping = [],
+        private ?EntityManager $entityManager = null
+    )
+    {
+    }
+
+    public static function fromConnectionFactory(DbalConnectionFactory $dbalConnectionFactory): EcotoneManagerRegistryConnectionFactory
+    {
+        return new EcotoneManagerRegistryConnectionFactory(new self($dbalConnectionFactory->createContext()->getDbalConnection()));
+    }
+
+    public static function create(Connection $connection): EcotoneManagerRegistryConnectionFactory
+    {
+        return new EcotoneManagerRegistryConnectionFactory(new self($connection));
+    }
+
+    public static function createEntityManager(EntityManagerInterface $entityManager): EcotoneManagerRegistryConnectionFactory
+    {
+        return new EcotoneManagerRegistryConnectionFactory(new self($entityManager->getConnection(), $entityManager));
+    }
+
+    public static function createForManagerRegistry(ManagerRegistry $managerRegistry, string $connectionName): EcotoneManagerRegistryConnectionFactory
+    {
+        return new EcotoneManagerRegistryConnectionFactory($managerRegistry, ['connection_name' => $connectionName]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDefaultConnectionName(): string
+    {
+        return 'default';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getConnection($name = null): object
+    {
+        return $this->connection;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getConnections(): array
+    {
+        return [$this->connection];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getConnectionNames(): array
+    {
+        return ['default'];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDefaultManagerName(): string
+    {
+        return 'default';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getManager($name = null): EntityManagerInterface
+    {
+        return $this->getEntityManager();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getManagers(): array
+    {
+        return $this->getEntityManager() ? [$this->getEntityManager()] : [];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function resetManager($name = null): ObjectManager
+    {
+        $this->entityManager = null;
+
+        return $this->getEntityManager();
+    }
+
+    /**
+     * @throws InvalidArgumentException
+     */
+    public function getAliasNamespace($alias): string
+    {
+        throw InvalidArgumentException::create('Method not supported');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getManagerNames(): array
+    {
+        return ['default'];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getRepository($persistentObject, $persistentManagerName = null): ObjectRepository
+    {
+        return $this->getEntityManager()->getRepository($persistentObject);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getManagerForClass($class): ?ObjectManager
+    {
+        return $this->getEntityManager();
+    }
+
+    private function getEntityManager(): ?EntityManager
+    {
+        if ($this->entityManager === null) {
+            $this->setupEntityManager();
+        }
+
+        return $this->entityManager;
+    }
+
+    private function setupEntityManager(): void
+    {
+        $config = Setup::createAttributeMetadataConfiguration(
+            $this->pathsToMapping,
+            true
+        );
+
+        $this->entityManager = EntityManager::create($this->getConnection(), $config);
+    }
+}

--- a/packages/Dbal/tests/Fixture/ORM/PersonRepository/ORMPersonRepository.php
+++ b/packages/Dbal/tests/Fixture/ORM/PersonRepository/ORMPersonRepository.php
@@ -5,23 +5,24 @@ declare(strict_types=1);
 namespace Test\Ecotone\Dbal\Fixture\ORM\PersonRepository;
 
 use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\Persistence\ManagerRegistry;
 use Ecotone\Messaging\Support\Assert;
 use Test\Ecotone\Dbal\Fixture\ORM\Person\Person;
 
 final class ORMPersonRepository
 {
-    public function __construct(private EntityManagerInterface $entityManager)
+    public function __construct(private ManagerRegistry $managerRegistry)
     {
     }
 
     public function save(Person $person): void
     {
-        $this->entityManager->persist($person);
+        $this->managerRegistry->getManager()->persist($person);
     }
 
     public function get(int $personId): Person
     {
-        $person = $this->entityManager->getRepository(Person::class)->find($personId);
+        $person = $this->managerRegistry->getRepository(Person::class)->find($personId);
         Assert::notNull($person, "Person with id {$personId} not found");
 
         return $person;

--- a/packages/Dbal/tests/Integration/ORMTest.php
+++ b/packages/Dbal/tests/Integration/ORMTest.php
@@ -11,6 +11,7 @@ use Ecotone\Messaging\Config\ModulePackageList;
 use Ecotone\Messaging\Config\ServiceConfiguration;
 use Ecotone\Messaging\Support\InvalidArgumentException;
 use Enqueue\Dbal\DbalConnectionFactory;
+use Symfony\Bridge\Doctrine\ManagerRegistry;
 use Test\Ecotone\Dbal\DbalMessagingTestCase;
 use Test\Ecotone\Dbal\Fixture\ORM\Person\Person;
 use Test\Ecotone\Dbal\Fixture\ORM\Person\RegisterPerson;
@@ -38,12 +39,12 @@ final class ORMTest extends DbalMessagingTestCase
     public function test_flushing_object_manager_on_command_bus()
     {
         $this->setupUserTable();
-        $entityManager = $this->setupEntityManagerFor([__DIR__.'/../Fixture/ORM/Person']);
-        $ORMPersonRepository = new ORMPersonRepository($entityManager);
+        $connectionFactory = $this->getORMConnectionFactory([__DIR__ . '/../Fixture/ORM/Person']);
+        $ORMPersonRepository = new ORMPersonRepository($connectionFactory->getRegistry());
 
         $ecotone = EcotoneLite::bootstrapFlowTesting(
             containerOrAvailableServices: [
-                DbalConnectionFactory::class => $this->getORMConnectionFactory($entityManager),
+                DbalConnectionFactory::class => $connectionFactory,
                 ORMPersonRepository::class => $ORMPersonRepository,
                 RegisterPersonService::class => new RegisterPersonService(),
                 SaveMultipleEntitiesHandler::class => new SaveMultipleEntitiesHandler(),
@@ -74,12 +75,13 @@ final class ORMTest extends DbalMessagingTestCase
     public function test_disabling_flushing_object_manager_on_command_bus()
     {
         $this->setupUserTable();
-        $entityManager = $this->setupEntityManagerFor([__DIR__.'/../Fixture/ORM/Person']);
-        $ORMPersonRepository = new ORMPersonRepository($entityManager);
+        $connectionFactory = $this->getORMConnectionFactory([__DIR__ . '/../Fixture/ORM/Person']);
+        $entityManager = $connectionFactory->getRegistry()->getManager();
+        $ORMPersonRepository = new ORMPersonRepository($connectionFactory->getRegistry());
 
         $ecotone = EcotoneLite::bootstrapFlowTesting(
             containerOrAvailableServices: [
-                DbalConnectionFactory::class => $this->getORMConnectionFactory($entityManager),
+                DbalConnectionFactory::class => $connectionFactory,
                 ORMPersonRepository::class => $ORMPersonRepository,
                 RegisterPersonService::class => new RegisterPersonService(),
             ],
@@ -102,6 +104,36 @@ final class ORMTest extends DbalMessagingTestCase
         $this->expectException(InvalidArgumentException::class);
 
         $ORMPersonRepository->get(100);
+    }
+
+    public function test_object_manager_reconnects_on_command_bus()
+    {
+        $this->setupUserTable();
+        $connectionFactory = $this->getORMConnectionFactory([__DIR__ . '/../Fixture/ORM/Person']);
+        $entityManager = $connectionFactory->getRegistry()->getManager();
+        $ORMPersonRepository = new ORMPersonRepository($connectionFactory->getRegistry());
+
+        $ecotone = EcotoneLite::bootstrapFlowTesting(
+            containerOrAvailableServices: [
+                DbalConnectionFactory::class => $connectionFactory,
+                ORMPersonRepository::class => $ORMPersonRepository,
+                RegisterPersonService::class => new RegisterPersonService(),
+            ],
+            configuration: ServiceConfiguration::createWithDefaults()
+                ->withSkippedModulePackageNames(ModulePackageList::allPackagesExcept([ModulePackageList::DBAL_PACKAGE, ModulePackageList::ASYNCHRONOUS_PACKAGE]))
+                ->withNamespaces([
+                    'Test\Ecotone\Dbal\Fixture\ORM\PersonRepository',
+                ]),
+            pathToRootCatalog: __DIR__ . '/../../',
+            addInMemoryStateStoredRepository: false
+        );
+
+        $entityManager->close();
+        $ecotone->sendCommand(new RegisterPerson(100, 'Johnny'));
+
+        $this->assertNotNull(
+            $ORMPersonRepository->get(100)
+        );
     }
 
     private function bootstrapEcotone(): FlowTestSupport


### PR DESCRIPTION
If you register Connection with Manager Registry, Ecotone will take care of object flush and clearing your object manager. This can be disabled via DbalConfiguration.

As EntityManager may be closed use ManagerRegistry to ensure asynchronous scenarios will always be able to auto-recover (reset and create new EntityManager).