### PR TITLE
AMQP header containing serialized aggregate

### DIFF
--- a/packages/Amqp/tests/Fixture/Calendar/Calendar.php
+++ b/packages/Amqp/tests/Fixture/Calendar/Calendar.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Ecotone\Amqp\Fixture\Calendar;
+
+use Ecotone\Messaging\Attribute\Asynchronous;
+use Ecotone\Modelling\Attribute\Aggregate;
+use Ecotone\Modelling\Attribute\CommandHandler;
+use Ecotone\Modelling\Attribute\Identifier;
+
+#[Aggregate]
+final class Calendar
+{
+    private array $meetings = [];
+
+    public function __construct(#[Identifier] private string $calendarId)
+    {
+    }
+
+    #[CommandHandler]
+    public static function create(CreateCalendar $command): self
+    {
+        return new self($command->calendarId);
+    }
+
+    #[CommandHandler(endpointId: 'calendar.schedule-meeting')]
+    #[Asynchronous(channelName: 'calendar')]
+    public function scheduleMeeting(ScheduleMeeting $command): void
+    {
+        $this->meetings[] = $command->meetingId;
+    }
+}

--- a/packages/Amqp/tests/Fixture/Calendar/CreateCalendar.php
+++ b/packages/Amqp/tests/Fixture/Calendar/CreateCalendar.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Ecotone\Amqp\Fixture\Calendar;
+
+final class CreateCalendar
+{
+    public function __construct(public string $calendarId)
+    {
+    }
+}

--- a/packages/Amqp/tests/Fixture/Calendar/ScheduleMeeting.php
+++ b/packages/Amqp/tests/Fixture/Calendar/ScheduleMeeting.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Ecotone\Amqp\Fixture\Calendar;
+
+final class ScheduleMeeting
+{
+    public function __construct(
+        public string $calendarId,
+        public string $meetingId,
+    ) {
+    }
+}

--- a/packages/Amqp/tests/Integration/CallAggregateAsynchronousEndpointTest.php
+++ b/packages/Amqp/tests/Integration/CallAggregateAsynchronousEndpointTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Ecotone\Amqp\Integration;
+
+use Ecotone\Amqp\AmqpBackedMessageChannelBuilder;
+use Ecotone\Lite\EcotoneLite;
+use Ecotone\Messaging\Config\ModulePackageList;
+use Ecotone\Messaging\Config\ServiceConfiguration;
+use Ecotone\Modelling\AggregateMessage;
+use Enqueue\AmqpExt\AmqpConnectionFactory;
+use Test\Ecotone\Amqp\AmqpMessagingTest;
+use Test\Ecotone\Amqp\Fixture\Calendar\Calendar;
+use Test\Ecotone\Amqp\Fixture\Calendar\ScheduleMeeting;
+
+final class CallAggregateAsynchronousEndpointTest extends AmqpMessagingTest
+{
+    public function test_sending_command_to_aggregate(): void
+    {
+        $ecotone = EcotoneLite::bootstrapFlowTesting(
+            classesToResolve: [Calendar::class],
+            containerOrAvailableServices: [
+                AmqpConnectionFactory::class => self::getRabbitConnectionFactory(),
+            ],
+            configuration: ServiceConfiguration::createWithDefaults()
+                ->withSkippedModulePackageNames(ModulePackageList::allPackagesExcept([ModulePackageList::AMQP_PACKAGE, ModulePackageList::ASYNCHRONOUS_PACKAGE]))
+                ->withExtensionObjects([
+                    AmqpBackedMessageChannelBuilder::create('calendar')
+                ])
+        );
+
+        $ecotone
+            ->withStateFor(new Calendar('1'))
+            ->sendCommand(new ScheduleMeeting('1', '2'))
+        ;
+
+        self::assertFalse($ecotone->getMessageChannel('calendar')->receive()->getHeaders()->containsKey(AggregateMessage::CALLED_AGGREGATE_OBJECT));
+    }
+}

--- a/packages/Ecotone/src/Messaging/Channel/PollableChannel/Serialization/OutboundMessageConverter.php
+++ b/packages/Ecotone/src/Messaging/Channel/PollableChannel/Serialization/OutboundMessageConverter.php
@@ -28,6 +28,7 @@ class OutboundMessageConverter
         $messagePayload = $messageToConvert->getPayload();
 
         $applicationHeaders = $messageToConvert->getHeaders()->headers() ?? [];
+        $applicationHeaders = MessageHeaders::unsetAggregateKeys($applicationHeaders);
         $applicationHeaders = MessageHeaders::unsetEnqueueMetadata($applicationHeaders);
 
         $applicationHeaders                             = $this->headerMapper->mapFromMessageHeaders($applicationHeaders, $conversionService);


### PR DESCRIPTION
in some cases message sent to the queue contains serialized aggregate which may exceed the max length AMQP header that can have