### PR TITLE
Making the symfony cache warmer's type compatible with symfony 7.

### DIFF
--- a/packages/Symfony/DepedencyInjection/Compiler/CacheWarmer.php
+++ b/packages/Symfony/DepedencyInjection/Compiler/CacheWarmer.php
@@ -14,12 +14,12 @@ class CacheWarmer implements CacheWarmerInterface
     ) {
     }
 
-    public function isOptional()
+    public function isOptional(): bool
     {
         return true;
     }
 
-    public function warmUp(string $cacheDir)
+    public function warmUp(string $cacheDir, string $buildDir = null): array
     {
         foreach ($this->configuredMessagingSystem->getGatewayList() as $gatewayReference) {
             $this->proxyFactory->createWithCurrentConfiguration(


### PR DESCRIPTION
Native return types have been added to it's functions and a new optional buildDir argument to it's warmUp function.
#286 