### PR TITLE
Add support for Laravel 11

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -114,7 +114,7 @@
         "friendsofphp/proxy-manager-lts": "^1.0.12",
         "jms/serializer": "^3.17",
         "laminas/laminas-zendframework-bridge": "^1.0.0",
-        "laravel/framework": "^9.5.2|^10.0",
+        "laravel/framework": "^9.5.2|^10.0|^11.0",
         "prooph/pdo-event-store": "^1.15.1",
         "psr/log": "^2.0|^3.0",
         "queue-interop/queue-interop": "^0.8",

--- a/packages/Laravel/composer.json
+++ b/packages/Laravel/composer.json
@@ -35,7 +35,7 @@
     },
     "require": {
         "ecotone/ecotone": "~1.212.0",
-        "laravel/framework": "^9.5.2|^10.0"
+        "laravel/framework": "^9.5.2|^10.0|^11.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5",


### PR DESCRIPTION
Laravel 11 requires a minimum PHP version of 8.2. Tests on 8.0 will not pass.