### PR TITLE
Distributing events with star

### DIFF
--- a/packages/Amqp/src/Distribution/AmqpDistributionModule.php
+++ b/packages/Amqp/src/Distribution/AmqpDistributionModule.php
@@ -71,6 +71,8 @@ class AmqpDistributionModule
                 $amqpConfiguration[] = AmqpBinding::createFromNames(self::AMQP_DISTRIBUTED_EXCHANGE, $queueName, $applicationConfiguration->getServiceName());
 
                 foreach ($this->distributedEventHandlers as $distributedEventHandler) {
+                    /** Adjust star to RabbitMQ so it can substitute for zero or more words. */
+                    $distributedEventHandler = str_replace("*", "#", $distributedEventHandler);
                     $amqpConfiguration[] = AmqpBinding::createFromNames(self::AMQP_DISTRIBUTED_EXCHANGE, $queueName, $distributedEventHandler);
                 }
             }

--- a/packages/Amqp/tests/Fixture/DistributedEventBus/Publisher/UserService.php
+++ b/packages/Amqp/tests/Fixture/DistributedEventBus/Publisher/UserService.php
@@ -9,7 +9,7 @@ use Ecotone\Modelling\DistributedBus;
 class UserService
 {
     public const CHANGE_BILLING_DETAILS = 'changeBillingDetails';
-    public const BILLING_DETAILS_WERE_CHANGED = 'userService.billingDetailsWereChanged';
+    public const BILLING_DETAILS_WERE_CHANGED = 'userService.billing.DetailsWereChanged';
 
     #[CommandHandler(self::CHANGE_BILLING_DETAILS)]
     public function changeBillingDetails(#[Reference] DistributedBus $distributedBus)

--- a/packages/Ecotone/src/Modelling/DistributedBus.php
+++ b/packages/Ecotone/src/Modelling/DistributedBus.php
@@ -12,7 +12,7 @@ interface DistributedBus
 
     public function publishEvent(string $routingKey, string $event, string $sourceMediaType = MediaType::TEXT_PLAIN, array $metadata = []): void;
 
-    public function convertAndPublishEvent(string $routingKey, object|array $event, array $metadata): void;
+    public function convertAndPublishEvent(string $routingKey, object|array $event, array $metadata = []): void;
 
     public function sendMessage(string $destination, string $targetChannelName, string $payload, string $sourceMediaType = MediaType::TEXT_PLAIN, array $metadata = []): void;
 }


### PR DESCRIPTION
This adjust the star for distribution event to be used as RabbitMQ hash (#)