### PR TITLE
Add support of env variables in Ecotone configuration for Symfony

### DIFF
--- a/packages/Symfony/DependencyInjection/EcotoneExtension.php
+++ b/packages/Symfony/DependencyInjection/EcotoneExtension.php
@@ -22,6 +22,7 @@ class EcotoneExtension extends Extension
     {
         $configuration = new Configuration();
         $config = $this->processConfiguration($configuration, $configs);
+        $config = $container->resolveEnvPlaceholders($config, true);
 
         $skippedModules = $config['skippedModulePackageNames'] ?? [];
         if (! $config['test']) {
@@ -51,7 +52,7 @@ class EcotoneExtension extends Extension
                 ->withConsumerMemoryLimit($config['defaultMemoryLimit']);
         }
         if (isset($config['defaultConnectionExceptionRetry'])) {
-            $retryTemplate            = $config['defaultConnectionExceptionRetry'];
+            $retryTemplate = $config['defaultConnectionExceptionRetry'];
             $serviceConfiguration = $serviceConfiguration
                 ->withConnectionRetryTemplate(
                     RetryTemplateBuilder::exponentialBackoffWithMaxDelay(


### PR DESCRIPTION
We can use env variables in Symfony bundle config. Example:
```
ecotone:
  serviceName: "%env(SERVICE_NAME)%"
  defaultErrorChannel: "dbal_dead_letter"

parameters:
  env(SERVICE_NAME): backoffice_service
```