### PR TITLE
Handle same Dead Message for different Asynchronous Endpoints

### DIFF
--- a/packages/Dbal/src/Recoverability/DbalDeadLetterHandler.php
+++ b/packages/Dbal/src/Recoverability/DbalDeadLetterHandler.php
@@ -6,6 +6,7 @@ namespace Ecotone\Dbal\Recoverability;
 
 use DateTime;
 use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Types\Types;
 use Ecotone\Dbal\Compatibility\QueryBuilderProxy;
@@ -24,6 +25,7 @@ use Enqueue\Dbal\DbalContext;
 use Interop\Queue\ConnectionFactory;
 use Interop\Queue\Exception\Exception;
 
+use Ramsey\Uuid\Uuid;
 use function json_decode;
 use function json_encode;
 
@@ -58,7 +60,10 @@ class DbalDeadLetterHandler
             ->fetchAllAssociative();
 
         return array_map(function (array $message) {
-            return ErrorContext::fromHeaders($this->decodeHeaders($message));
+            return ErrorContext::fromHeaders(array_merge(
+                $this->decodeHeaders($message),
+                [MessageHeaders::MESSAGE_ID => $message['message_id']]
+            ));
         }, $messages);
     }
 
@@ -187,21 +192,12 @@ class DbalDeadLetterHandler
 
     private function insertHandledMessage(string $payload, array $headers): void
     {
-        $rowsAffected = $this->getConnection()->insert(
-            $this->getTableName(),
-            [
-                'message_id' => $headers[MessageHeaders::MESSAGE_ID],
-                'failed_at' =>  new DateTime(date('Y-m-d H:i:s.u', $headers[MessageHeaders::TIMESTAMP])),
-                'payload' => $payload,
-                'headers' => json_encode($this->headerMapper->mapFromMessageHeaders($headers, $this->conversionService), JSON_THROW_ON_ERROR | JSON_INVALID_UTF8_IGNORE),
-            ],
-            [
-                'message_id' => Types::STRING,
-                'failed_at' => Types::DATETIME_MUTABLE,
-                'payload' => Types::TEXT,
-                'headers' => Types::TEXT,
-            ]
-        );
+        try {
+            $rowsAffected = $this->storeInDatabase($headers[MessageHeaders::MESSAGE_ID], $headers, $payload);
+        }catch (UniqueConstraintViolationException) {
+            /** If same Message for different Event Handlers failed */
+            $rowsAffected = $this->storeInDatabase(Uuid::uuid4()->toString(), $headers, $payload);
+        }
 
         if (1 !== $rowsAffected) {
             throw new Exception('There was a problem inserting exceptional message. Dbal did not confirm that the record is inserted.');
@@ -290,5 +286,25 @@ class DbalDeadLetterHandler
             ->andWhere('message_id = :messageId')
             ->setParameter('messageId', $messageId, Types::TEXT)
             ->executeStatement();
+    }
+
+    private function storeInDatabase(mixed $messageId, array $headers, string $payload): string|int
+    {
+        $rowsAffected = $this->getConnection()->insert(
+            $this->getTableName(),
+            [
+                'message_id' => $messageId,
+                'failed_at' => new DateTime(date('Y-m-d H:i:s.u', $headers[MessageHeaders::TIMESTAMP])),
+                'payload' => $payload,
+                'headers' => json_encode($this->headerMapper->mapFromMessageHeaders($headers, $this->conversionService), JSON_THROW_ON_ERROR | JSON_INVALID_UTF8_IGNORE),
+            ],
+            [
+                'message_id' => Types::STRING,
+                'failed_at' => Types::DATETIME_MUTABLE,
+                'payload' => Types::TEXT,
+                'headers' => Types::TEXT,
+            ]
+        );
+        return $rowsAffected;
     }
 }

--- a/packages/Dbal/tests/Fixture/DeadLetter/DoubleEventHandler/DoubleEventHandler.php
+++ b/packages/Dbal/tests/Fixture/DeadLetter/DoubleEventHandler/DoubleEventHandler.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Ecotone\Dbal\Fixture\DeadLetter\DoubleEventHandler;
+
+use Ecotone\Messaging\Attribute\Asynchronous;
+use Ecotone\Modelling\Attribute\EventHandler;
+
+final class DoubleEventHandler
+{
+    private int $callCount = 0;
+    public int $successfulCalls = 0;
+
+    #[Asynchronous('async')]
+    #[EventHandler(endpointId: 'first')]
+    public function handleOne(ExampleEvent $event): void
+    {
+        $this->callCount += 1;
+
+        if ($this->callCount > 2) {
+            $this->successfulCalls++;
+
+            return;
+        }
+
+        throw new \InvalidArgumentException('exception');
+    }
+
+    #[Asynchronous('async')]
+    #[EventHandler(endpointId: 'second')]
+    public function handleTwo(ExampleEvent $event): void
+    {
+        $this->callCount += 1;
+
+        if ($this->callCount > 2) {
+            $this->successfulCalls++;
+
+            return;
+        }
+
+        throw new \InvalidArgumentException('exception');
+    }
+}

--- a/packages/Dbal/tests/Fixture/DeadLetter/DoubleEventHandler/EcotoneConfiguration.php
+++ b/packages/Dbal/tests/Fixture/DeadLetter/DoubleEventHandler/EcotoneConfiguration.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Test\Ecotone\Dbal\Fixture\DeadLetter\DoubleEventHandler;
+
+use Ecotone\Dbal\DbalBackedMessageChannelBuilder;
+use Ecotone\Dbal\Recoverability\DbalDeadLetterBuilder;
+use Ecotone\Messaging\Attribute\ServiceContext;
+use Ecotone\Messaging\Endpoint\PollingMetadata;
+
+final class EcotoneConfiguration
+{
+    #[ServiceContext]
+    public function pollingConfiguration()
+    {
+        return PollingMetadata::create('async')
+            ->setExecutionTimeLimitInMilliseconds(1000)
+            ->setHandledMessageLimit(1)
+            ->setErrorChannelName(DbalDeadLetterBuilder::STORE_CHANNEL);
+    }
+
+    #[ServiceContext]
+    public function channel()
+    {
+        return DbalBackedMessageChannelBuilder::create("async");
+    }
+}

--- a/packages/Dbal/tests/Fixture/DeadLetter/DoubleEventHandler/ExampleEvent.php
+++ b/packages/Dbal/tests/Fixture/DeadLetter/DoubleEventHandler/ExampleEvent.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Ecotone\Dbal\Fixture\DeadLetter\DoubleEventHandler;
+
+final class ExampleEvent
+{
+    public function __construct(string $data)
+    {
+
+    }
+}

--- a/packages/Dbal/tests/Integration/DeadLetterTest.php
+++ b/packages/Dbal/tests/Integration/DeadLetterTest.php
@@ -10,8 +10,12 @@ use Ecotone\Lite\Test\FlowTestSupport;
 use Ecotone\Messaging\Config\ModulePackageList;
 use Ecotone\Messaging\Config\ServiceConfiguration;
 use Ecotone\Messaging\Handler\Recoverability\ErrorContext;
+use Ecotone\Messaging\MessageHeaders;
 use Enqueue\Dbal\DbalConnectionFactory;
+use Ramsey\Uuid\Uuid;
 use Test\Ecotone\Dbal\DbalMessagingTestCase;
+use Test\Ecotone\Dbal\Fixture\DeadLetter\DoubleEventHandler\DoubleEventHandler;
+use Test\Ecotone\Dbal\Fixture\DeadLetter\DoubleEventHandler\ExampleEvent;
 use Test\Ecotone\Dbal\Fixture\DeadLetter\Example\ErrorConfigurationContext;
 use Test\Ecotone\Dbal\Fixture\DeadLetter\Example\OrderGateway;
 use Test\Ecotone\Dbal\Fixture\DeadLetter\Example\OrderService;
@@ -40,11 +44,11 @@ final class DeadLetterTest extends DbalMessagingTestCase
 
         self::assertEquals(0, $gateway->getOrderAmount());
 
-        $this->assertErrorMessageCount($ecotone, 1);
+        $this->assertErrorMessageCount($ecotone, 1, ErrorConfigurationContext::CUSTOM_GATEWAY_REFERENCE_NAME);
 
         $this->replyAllErrorMessages($ecotone);
 
-        $this->assertErrorMessageCount($ecotone, 0);
+        $this->assertErrorMessageCount($ecotone, 0, ErrorConfigurationContext::CUSTOM_GATEWAY_REFERENCE_NAME);
 
         $ecotone->run('orderService');
 
@@ -70,11 +74,11 @@ final class DeadLetterTest extends DbalMessagingTestCase
         $ecotone->run('orderService');
         $ecotone->run('orderService');
 
-        $this->assertErrorMessageCount($ecotone, 2);
+        $this->assertErrorMessageCount($ecotone, 2, ErrorConfigurationContext::CUSTOM_GATEWAY_REFERENCE_NAME);
 
         $this->replyAllErrorMessagesById($ecotone);
 
-        $this->assertErrorMessageCount($ecotone, 0);
+        $this->assertErrorMessageCount($ecotone, 0, ErrorConfigurationContext::CUSTOM_GATEWAY_REFERENCE_NAME);
 
         $ecotone->run('orderService');
         $ecotone->run('orderService');
@@ -101,11 +105,11 @@ final class DeadLetterTest extends DbalMessagingTestCase
         $ecotone->run('orderService');
         $ecotone->run('orderService');
 
-        $this->assertErrorMessageCount($ecotone, 2);
+        $this->assertErrorMessageCount($ecotone, 2, ErrorConfigurationContext::CUSTOM_GATEWAY_REFERENCE_NAME);
 
         $this->deleteAllErrorMessagesById($ecotone);
 
-        $this->assertErrorMessageCount($ecotone, 0);
+        $this->assertErrorMessageCount($ecotone, 0, ErrorConfigurationContext::CUSTOM_GATEWAY_REFERENCE_NAME);
 
         $ecotone->run('orderService');
         $ecotone->run('orderService');
@@ -113,7 +117,57 @@ final class DeadLetterTest extends DbalMessagingTestCase
         self::assertEquals(0, $gateway->getOrderAmount());
     }
 
-    private function assertErrorMessageCount(FlowTestSupport $ecotone, int $amount): void
+    public function test_same_event_is_stored_in_dead_letter_twice_for_different_endpoints_and_replayed(): void
+    {
+        $doubleEventHandler = new DoubleEventHandler();
+        $ecotone = $this->bootstrapEcotone([
+            'Test\Ecotone\Dbal\Fixture\DeadLetter\DoubleEventHandler',
+        ], [$doubleEventHandler]);
+
+        $ecotone->publishEvent(new ExampleEvent('test'));
+
+        $ecotone->run('async');
+        $ecotone->run('async');
+
+        $this->assertErrorMessageCount($ecotone, 2);
+        self::assertEquals(0, $doubleEventHandler->successfulCalls);
+
+        $this->replyAllErrorMessagesById($ecotone);
+        $this->assertErrorMessageCount($ecotone, 0);
+
+        $ecotone->run('async');
+        $ecotone->run('async');
+
+        self::assertEquals(2, $doubleEventHandler->successfulCalls);
+    }
+
+    public function test_same_event_is_stored_in_dead_letter_twice_for_different_endpoints_and_removed(): void
+    {
+        $doubleEventHandler = new DoubleEventHandler();
+        $ecotone = $this->bootstrapEcotone([
+            'Test\Ecotone\Dbal\Fixture\DeadLetter\DoubleEventHandler',
+        ], [$doubleEventHandler]);
+        $deadLetter = $ecotone->getGateway(DeadLetterGateway::class);
+
+        $messageId = Uuid::uuid4()->toString();
+        $ecotone->publishEvent(new ExampleEvent('test'), metadata: [MessageHeaders::MESSAGE_ID => $messageId]);
+
+        $ecotone->run('async');
+        $ecotone->run('async');
+
+        $this->assertErrorMessageCount($ecotone, 2);
+        $deadLetter->delete($messageId);
+        $this->assertErrorMessageCount($ecotone, 1);
+
+        $messages = $deadLetter->list(100, 0);
+        self::assertCount(1, $messages);
+        /** As new Message Id was generated */
+        self::assertNotEquals($messageId, $messages[0]->getMessageId());
+        $deadLetter->delete($messages[0]->getMessageId());
+        $this->assertErrorMessageCount($ecotone, 0);
+    }
+
+    private function assertErrorMessageCount(FlowTestSupport $ecotone, int $amount, string $deadLetterReference = DeadLetterGateway::class): void
     {
         $gateway = $ecotone->getGateway(DeadLetterGateway::class);
 
@@ -121,7 +175,7 @@ final class DeadLetterTest extends DbalMessagingTestCase
         self::assertEquals($amount, $gateway->count());
 
         /** @var DeadLetterGateway $gateway */
-        $gateway = $ecotone->getGateway(ErrorConfigurationContext::CUSTOM_GATEWAY_REFERENCE_NAME);
+        $gateway = $ecotone->getGateway($deadLetterReference);
 
         self::assertCount($amount, $gateway->list(100, 0));
         self::assertEquals($amount, $gateway->count());
@@ -146,12 +200,16 @@ final class DeadLetterTest extends DbalMessagingTestCase
         $ecotone->getGateway(DeadLetterGateway::class)->replyAll();
     }
 
-    private function bootstrapEcotone(array $namespaces): FlowTestSupport
+    private function bootstrapEcotone(array $namespaces, array $services = []): FlowTestSupport
     {
         $connectionFactory = $this->getConnectionFactory();
 
         return (EcotoneLite::bootstrapFlowTesting(
-            containerOrAvailableServices: [new OrderService(), DbalConnectionFactory::class => $connectionFactory, 'managerRegistry' => $connectionFactory],
+            containerOrAvailableServices: array_merge($services, [
+                new OrderService(),
+                DbalConnectionFactory::class => $connectionFactory,
+                'managerRegistry' => $connectionFactory
+            ]),
             configuration: ServiceConfiguration::createWithDefaults()
                 ->withEnvironment('prod')
                 ->withSkippedModulePackageNames(ModulePackageList::allPackagesExcept([ModulePackageList::DBAL_PACKAGE, ModulePackageList::ASYNCHRONOUS_PACKAGE]))


### PR DESCRIPTION
There may be a case when two Event Handlers for same Event Message will fail and store Message in Dead Letter.
In this situation second will be blocked from being stored as Message Id will be the same. 

For this situation new Message Id for Dead Letter will be generated, yet Message will preserve it's origin Message In in Message Headers. Therefore replaying dead message will replay it with original Message Id.