### PR TITLE
Default php conversion for headers

### DIFF
--- a/packages/Ecotone/src/Messaging/Conversion/StringToUuid/StringToUuidConverter.php
+++ b/packages/Ecotone/src/Messaging/Conversion/StringToUuid/StringToUuidConverter.php
@@ -30,6 +30,8 @@ class StringToUuidConverter implements Converter
      */
     public function matches(TypeDescriptor $sourceType, MediaType $sourceMediaType, TypeDescriptor $targetType, MediaType $targetMediaType): bool
     {
-        return $sourceType->isString() && $targetType->isClassOfType(UuidInterface::class);
+        return $sourceType->isString()
+            && $sourceMediaType->isCompatibleWith(MediaType::createApplicationXPHP())
+            && $targetType->isClassOfType(UuidInterface::class);
     }
 }

--- a/packages/Ecotone/src/Messaging/Conversion/UuidToString/UuidToStringConverter.php
+++ b/packages/Ecotone/src/Messaging/Conversion/UuidToString/UuidToStringConverter.php
@@ -33,6 +33,8 @@ class UuidToStringConverter implements Converter
      */
     public function matches(TypeDescriptor $sourceType, MediaType $sourceMediaType, TypeDescriptor $targetType, MediaType $targetMediaType): bool
     {
-        return ($sourceType->isClassOfType(UuidInterface::class) && $targetType->isString());
+        return $sourceType->isClassOfType(UuidInterface::class)
+            && $targetType->isString()
+            && $targetMediaType->isCompatibleWith(MediaType::createApplicationXPHP());
     }
 }

--- a/packages/Ecotone/src/Messaging/Handler/Processor/MethodInvoker/Converter/HeaderConverter.php
+++ b/packages/Ecotone/src/Messaging/Handler/Processor/MethodInvoker/Converter/HeaderConverter.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Ecotone\Messaging\Handler\Processor\MethodInvoker\Converter;
 
+use Ecotone\Messaging\Conversion\ConversionException;
 use Ecotone\Messaging\Conversion\ConversionService;
 use Ecotone\Messaging\Conversion\MediaType;
 use Ecotone\Messaging\Handler\InterfaceParameter;
@@ -46,15 +47,13 @@ class HeaderConverter implements ParameterConverter
 
         $sourceValueType = TypeDescriptor::createFromVariable($headerValue);
         if (! $sourceValueType->isCompatibleWith($targetType)) {
-            if ($sourceValueType->isScalar() && $this->canConvertTo($headerValue, DefaultHeaderMapper::DEFAULT_HEADER_CONVERSION_MEDIA_TYPE, $targetType)) {
-                $headerValue = $this->doConversion($headerValue, DefaultHeaderMapper::DEFAULT_HEADER_CONVERSION_MEDIA_TYPE, $targetType);
-            } elseif ($this->canConvertTo($headerValue, MediaType::APPLICATION_X_PHP, $targetType)) {
+            if ($this->canConvertTo($headerValue, MediaType::APPLICATION_X_PHP, $targetType)) {
                 $headerValue = $this->doConversion($headerValue, MediaType::APPLICATION_X_PHP, $targetType);
+            }elseif ($sourceValueType->isScalar() && $this->canConvertTo($headerValue, DefaultHeaderMapper::FALLBACK_HEADER_CONVERSION_MEDIA_TYPE, $targetType)) {
+                $headerValue = $this->doConversion($headerValue, DefaultHeaderMapper::FALLBACK_HEADER_CONVERSION_MEDIA_TYPE, $targetType);
+            }else {
+                throw ConversionException::create("Can't convert {$this->headerName} from {$sourceValueType} to {$targetType}. Lack of PHP Converter or JSON Media Type Converter available.");
             }
-
-            //            @TODO
-            //            $fromType = TypeDescriptor::createFromVariable($headerValue);
-            //            throw ConversionException::create("Lack of converter available for {$interfaceToCall} with parameter name `{$this->parameter}` to convert it from {$fromType} to {$relatedParameter->getTypeDescriptor()}");
         }
 
         return $headerValue;

--- a/packages/Ecotone/src/Messaging/MessageConverter/DefaultHeaderMapper.php
+++ b/packages/Ecotone/src/Messaging/MessageConverter/DefaultHeaderMapper.php
@@ -8,6 +8,7 @@ use Ecotone\Messaging\Config\Container\Definition;
 use Ecotone\Messaging\Conversion\ConversionService;
 use Ecotone\Messaging\Conversion\MediaType;
 use Ecotone\Messaging\Handler\TypeDescriptor;
+use Ecotone\Messaging\Handler\UnionTypeDescriptor;
 
 /**
  * Class DefaultHeaderMapper
@@ -16,7 +17,7 @@ use Ecotone\Messaging\Handler\TypeDescriptor;
  */
 class DefaultHeaderMapper implements HeaderMapper
 {
-    public const DEFAULT_HEADER_CONVERSION_MEDIA_TYPE = MediaType::APPLICATION_JSON;
+    public const FALLBACK_HEADER_CONVERSION_MEDIA_TYPE = MediaType::APPLICATION_JSON;
     public const CONVERTED_HEADERS_TO_DIFFERENT_FORMAT = 'ecotone.convertedKeys';
 
     /**
@@ -168,23 +169,23 @@ class DefaultHeaderMapper implements HeaderMapper
             $conversionService->canConvert(
                 TypeDescriptor::createFromVariable($value),
                 MediaType::createApplicationXPHP(),
-                TypeDescriptor::createStringType(),
-                MediaType::parseMediaType(self::DEFAULT_HEADER_CONVERSION_MEDIA_TYPE)
+                UnionTypeDescriptor::createWith([TypeDescriptor::createStringType(), TypeDescriptor::createIntegerType()]),
+                MediaType::createApplicationXPHP()
             )
         ) {
             $convertedHeaders[$mappedHeader] =  $conversionService->convert(
                 $value,
                 TypeDescriptor::createFromVariable($value),
                 MediaType::createApplicationXPHP(),
-                TypeDescriptor::createStringType(),
-                MediaType::parseMediaType(self::DEFAULT_HEADER_CONVERSION_MEDIA_TYPE)
+                UnionTypeDescriptor::createWith([TypeDescriptor::createStringType(), TypeDescriptor::createIntegerType()]),
+                MediaType::createApplicationXPHP()
             );
         } elseif (
             $conversionService->canConvert(
                 TypeDescriptor::createFromVariable($value),
                 MediaType::createApplicationXPHP(),
                 TypeDescriptor::createStringType(),
-                MediaType::createApplicationXPHP()
+                MediaType::parseMediaType(self::FALLBACK_HEADER_CONVERSION_MEDIA_TYPE)
             )
         ) {
             $convertedHeaders[$mappedHeader] =  $conversionService->convert(
@@ -192,7 +193,7 @@ class DefaultHeaderMapper implements HeaderMapper
                 TypeDescriptor::createFromVariable($value),
                 MediaType::createApplicationXPHP(),
                 TypeDescriptor::createStringType(),
-                MediaType::createApplicationXPHP()
+                MediaType::parseMediaType(self::FALLBACK_HEADER_CONVERSION_MEDIA_TYPE)
             );
         }
 

--- a/packages/Ecotone/tests/Messaging/Fixture/Handler/HeaderConversion/ConvertedHeaderEndpoint.php
+++ b/packages/Ecotone/tests/Messaging/Fixture/Handler/HeaderConversion/ConvertedHeaderEndpoint.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Ecotone\Messaging\Fixture\Handler\HeaderConversion;
+
+use Ecotone\Messaging\Attribute\Asynchronous;
+use Ecotone\Messaging\Attribute\Parameter\Header;
+use Ecotone\Modelling\Attribute\CommandHandler;
+use Ramsey\Uuid\UuidInterface;
+
+final class ConvertedHeaderEndpoint
+{
+    private mixed $result;
+
+    #[Asynchronous('async')]
+    #[CommandHandler('withScalarConversion', endpointId: 'withScalarConversionEndpoint')]
+    public function handleWithScalarConversion(
+        #[Header('token')] UuidInterface $token
+    )
+    {
+        $this->result = $token;
+    }
+
+    #[Asynchronous('async')]
+    #[CommandHandler('withFallbackConversion', endpointId: 'withFallbackConversionEndpoint')]
+    public function handleWithFallbackConversion(
+        #[Header('tokens')] array $tokens
+    )
+    {
+        $this->result = $tokens;
+    }
+
+    public function result(): mixed
+    {
+        return $this->result;
+    }
+}

--- a/packages/Ecotone/tests/Messaging/Fixture/Handler/HeaderConversion/JsonConverter.php
+++ b/packages/Ecotone/tests/Messaging/Fixture/Handler/HeaderConversion/JsonConverter.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Ecotone\Messaging\Fixture\Handler\HeaderConversion;
+
+use Ecotone\Messaging\Attribute\MediaTypeConverter;
+use Ecotone\Messaging\Conversion\Converter;
+use Ecotone\Messaging\Conversion\MediaType;
+use Ecotone\Messaging\Handler\TypeDescriptor;
+use Ecotone\Messaging\Support\Assert;
+
+#[MediaTypeConverter]
+final class JsonConverter implements Converter
+{
+    public function convert($source, TypeDescriptor $sourceType, MediaType $sourceMediaType, TypeDescriptor $targetType, MediaType $targetMediaType)
+    {
+        Assert::isTrue($sourceType->isString() || $sourceType->isIterable(), "Json converter can only convert string or array, given {$sourceType}");
+
+        if ($targetMediaType->isCompatibleWith(MediaType::createApplicationXPHP())) {
+            return json_decode($source, true, 512, JSON_THROW_ON_ERROR);
+        }
+
+        return json_encode($source, JSON_THROW_ON_ERROR);
+    }
+
+    public function matches(TypeDescriptor $sourceType, MediaType $sourceMediaType, TypeDescriptor $targetType, MediaType $targetMediaType): bool
+    {
+        return $targetMediaType->isCompatibleWith(MediaType::createApplicationJson()) || $sourceMediaType->isCompatibleWith(MediaType::createApplicationJson());
+    }
+}

--- a/packages/Ecotone/tests/Messaging/Unit/Handler/HeaderConversionTest.php
+++ b/packages/Ecotone/tests/Messaging/Unit/Handler/HeaderConversionTest.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Ecotone\Messaging\Unit\Handler;
+
+use Ecotone\Lite\EcotoneLite;
+use Ecotone\Messaging\Channel\SimpleMessageChannelBuilder;
+use Ecotone\Messaging\Config\ServiceConfiguration;
+use Ecotone\Messaging\Conversion\MediaType;
+use PHPUnit\Framework\TestCase;
+use Ramsey\Uuid\Uuid;
+use \Test\Ecotone\Messaging\Fixture\Handler\HeaderConversion\ConvertedHeaderEndpoint;
+use Test\Ecotone\Messaging\Fixture\Handler\HeaderConversion\JsonConverter;
+
+final class HeaderConversionTest extends TestCase
+{
+    /**
+     * @dataProvider differentDefaultSerializations
+     */
+    public function test_using_scalar_in_metadata_for_conversion(ServiceConfiguration $serviceConfiguration): void
+    {
+        $convertedHeaderEndpoint = new ConvertedHeaderEndpoint();
+        $ecotoneLite = EcotoneLite::bootstrapFlowTesting(
+            [ConvertedHeaderEndpoint::class, JsonConverter::class],
+            [$convertedHeaderEndpoint, new JsonConverter()],
+            $serviceConfiguration,
+            enableAsynchronousProcessing: [
+                SimpleMessageChannelBuilder::createQueueChannel(
+                    'async'
+                )
+            ]
+        );
+
+        $ecotoneLite
+            ->sendCommandWithRoutingKey('withScalarConversion', metadata: [
+                'token' => '537edce7-7e56-4777-b6ec-a012c40b9d1b'
+            ])
+            ->run('async');
+
+        $this->assertEquals(
+            Uuid::fromString('537edce7-7e56-4777-b6ec-a012c40b9d1b'),
+            $convertedHeaderEndpoint->result()->toString()
+        );
+    }
+
+    /**
+     * @dataProvider differentDefaultSerializations
+     */
+    public function test_using_object_in_metadata_for_conversion(ServiceConfiguration $serviceConfiguration): void
+    {
+        $convertedHeaderEndpoint = new ConvertedHeaderEndpoint();
+        $ecotoneLite = EcotoneLite::bootstrapFlowTesting(
+            [ConvertedHeaderEndpoint::class, JsonConverter::class],
+            [$convertedHeaderEndpoint, new JsonConverter()],
+            $serviceConfiguration,
+            enableAsynchronousProcessing: [
+                SimpleMessageChannelBuilder::createQueueChannel(
+                    'async'
+                )
+            ]
+        );
+
+        $ecotoneLite
+            ->sendCommandWithRoutingKey('withScalarConversion', metadata: [
+                'token' => Uuid::fromString('537edce7-7e56-4777-b6ec-a012c40b9d1b')
+            ])
+            ->run('async');
+
+        $this->assertEquals(
+            Uuid::fromString('537edce7-7e56-4777-b6ec-a012c40b9d1b'),
+            $convertedHeaderEndpoint->result()->toString()
+        );
+    }
+
+    /**
+     * @dataProvider differentDefaultSerializations
+     */
+    public function test_using_fallback_conversion_to_json(ServiceConfiguration $serviceConfiguration): void
+    {
+        $convertedHeaderEndpoint = new ConvertedHeaderEndpoint();
+        $ecotoneLite = EcotoneLite::bootstrapFlowTesting(
+            [ConvertedHeaderEndpoint::class, JsonConverter::class],
+            [$convertedHeaderEndpoint, new JsonConverter()],
+            $serviceConfiguration,
+            enableAsynchronousProcessing: [
+                SimpleMessageChannelBuilder::createQueueChannel(
+                    'async'
+                )
+            ]
+        );
+
+        $ecotoneLite
+            ->sendCommandWithRoutingKey('withFallbackConversion', metadata: [
+                'tokens' => [1, 2, 3, 4, 5]
+            ])
+            ->run('async');
+
+        $this->assertEquals(
+            [1, 2, 3, 4, 5],
+            $convertedHeaderEndpoint->result()
+        );
+    }
+
+    /**
+     * This will change nothing, as it's used for payload, not header conversion.
+     * However to be sure that it's not affecting header conversion, it's part of the test scenario
+     */
+    public static function differentDefaultSerializations(): iterable
+    {
+        yield [
+            ServiceConfiguration::createWithAsynchronicityOnly()
+                ->withDefaultSerializationMediaType(MediaType::APPLICATION_X_PHP_SERIALIZED)
+        ];
+        yield [
+            ServiceConfiguration::createWithAsynchronicityOnly()
+                ->withDefaultSerializationMediaType(MediaType::APPLICATION_JSON)
+        ];
+    }
+}


### PR DESCRIPTION
This changes the default serialization for Headers to use PHP to PHP with Converters, only if this is not possible conversion will fallback to JSON conversion.

This refers to #309 