### PR TITLE
Use cache always for Ecotone Lite

### DIFF
--- a/packages/Ecotone/src/Lite/EcotoneLite.php
+++ b/packages/Ecotone/src/Lite/EcotoneLite.php
@@ -148,6 +148,37 @@ final class EcotoneLite
             ->getFlowTestSupport();
     }
 
+    private static function getFileNameBasedOnConfig(
+        bool $useCachedVersion,
+        array $classesToResolve,
+        ServiceConfiguration $serviceConfiguration,
+        array $configurationVariables,
+        bool $enableTesting
+    ): string
+    {
+        if ($useCachedVersion) {
+            return 'messaging';
+        }
+
+        // this is temporary cache based on if files have changed
+        // get file contents based on class names, configuration and configuration variables
+        $fileSha = '';
+
+        foreach ($classesToResolve as $class) {
+            $filePath = (new \ReflectionClass($class))->getFileName();
+
+            if ($filePath) {
+                $fileSha .= sha1_file($filePath);
+            }
+        }
+
+        $fileSha .= sha1(serialize($serviceConfiguration));
+        $fileSha .= sha1(serialize($configurationVariables));
+        $fileSha .= $enableTesting ? 'true' : 'false';
+
+        return sha1($fileSha);
+    }
+
     /**
      * @param string[] $packagesToEnable
      * @param ContainerInterface|object[] $containerOrAvailableServices
@@ -166,12 +197,12 @@ final class EcotoneLite
 
         $serviceCacheConfiguration = new ServiceCacheConfiguration(
             $serviceConfiguration->getCacheDirectoryPath(),
-            $useCachedVersion
+            true,
         );
         $configurationVariableService = InMemoryConfigurationVariableService::create($configurationVariables);
         $definitionHolder = null;
 
-        $messagingSystemCachePath = $serviceCacheConfiguration->getPath() . DIRECTORY_SEPARATOR . 'messaging_system';
+        $messagingSystemCachePath = $serviceCacheConfiguration->getPath() . DIRECTORY_SEPARATOR . self::getFileNameBasedOnConfig($useCachedVersion, $classesToResolve, $serviceConfiguration, $configurationVariables, $enableTesting);
         if ($serviceCacheConfiguration->shouldUseCache() && file_exists($messagingSystemCachePath)) {
             /** It may fail on deserialization, then return `false` and we can build new one */
             $definitionHolder = unserialize(file_get_contents($messagingSystemCachePath));
@@ -217,6 +248,7 @@ final class EcotoneLite
             $messagingSystem = new ConfiguredMessagingSystemWithTestSupport($messagingSystem);
         }
 
+        gc_collect_cycles();
         return $messagingSystem;
     }
 

--- a/packages/Ecotone/src/Messaging/Endpoint/PollingConsumer/PollToGatewayTaskExecutor.php
+++ b/packages/Ecotone/src/Messaging/Endpoint/PollingConsumer/PollToGatewayTaskExecutor.php
@@ -36,6 +36,7 @@ class PollToGatewayTaskExecutor implements TaskExecutor
                     ->setHeader(MessageHeaders::CONSUMER_POLLING_METADATA, $pollingMetadata)
                     ->build(),
             ]);
+            gc_collect_cycles();
         }
     }
 }


### PR DESCRIPTION
This is optimalization to speed up tests based on Ecotone Lite, plus forcing G/C to run when cleanup should be triggered