### PR TITLE
Speed up async in memory tests

### DIFF
--- a/packages/Dbal/tests/Integration/CollectorModuleTest.php
+++ b/packages/Dbal/tests/Integration/CollectorModuleTest.php
@@ -119,7 +119,7 @@ final class CollectorModuleTest extends DbalMessagingTestCase
         $messageId = Uuid::uuid4()->toString();
         $ecotoneLite->sendCommand(new RegisterPerson(100, 'Johny'));
 
-        $ecotoneLite->run('notifications', ExecutionPollingMetadata::createWithTestingSetup());
+        $ecotoneLite->run('notifications');
         $this->assertFalse($ecotoneLite->sendQueryWithRouting('notification.isNotified'));
 
         /** @var DeadLetterGateway $deadLetterGateway */
@@ -129,7 +129,7 @@ final class CollectorModuleTest extends DbalMessagingTestCase
         }
         $this->assertFalse($ecotoneLite->sendQueryWithRouting('notification.isNotified'));
 
-        $ecotoneLite->run('notifications', ExecutionPollingMetadata::createWithTestingSetup());
+        $ecotoneLite->run('notifications');
         $this->assertTrue($ecotoneLite->sendQueryWithRouting('notification.isNotified'));
     }
 

--- a/packages/Ecotone/src/Lite/EcotoneLite.php
+++ b/packages/Ecotone/src/Lite/EcotoneLite.php
@@ -150,6 +150,7 @@ final class EcotoneLite
     }
 
     private static function getFileNameBasedOnConfig(
+        string $pathToRootCatalog,
         bool $useCachedVersion,
         array $classesToResolve,
         ServiceConfiguration $serviceConfiguration,
@@ -163,6 +164,10 @@ final class EcotoneLite
         // this is temporary cache based on if files have changed
         // get file contents based on class names, configuration and configuration variables
         $fileSha = '';
+
+        if (file_exists($pathToRootCatalog . 'composer.lock')) {
+            $fileSha .= sha1_file($pathToRootCatalog . 'composer.lock');
+        }
 
         foreach ($classesToResolve as $class) {
             $filePath = (new ReflectionClass($class))->getFileName();
@@ -197,12 +202,12 @@ final class EcotoneLite
 
         $serviceCacheConfiguration = new ServiceCacheConfiguration(
             $serviceConfiguration->getCacheDirectoryPath(),
-            true,
+            self::shouldUseAutomaticCache($useCachedVersion, $pathToRootCatalog),
         );
         $configurationVariableService = InMemoryConfigurationVariableService::create($configurationVariables);
         $definitionHolder = null;
 
-        $messagingSystemCachePath = $serviceCacheConfiguration->getPath() . DIRECTORY_SEPARATOR . self::getFileNameBasedOnConfig($useCachedVersion, $classesToResolve, $serviceConfiguration, $configurationVariables, $enableTesting);
+        $messagingSystemCachePath = $serviceCacheConfiguration->getPath() . DIRECTORY_SEPARATOR . self::getFileNameBasedOnConfig($pathToRootCatalog, $useCachedVersion, $classesToResolve, $serviceConfiguration, $configurationVariables, $enableTesting);
         if ($serviceCacheConfiguration->shouldUseCache() && file_exists($messagingSystemCachePath)) {
             /** It may fail on deserialization, then return `false` and we can build new one */
             $definitionHolder = unserialize(file_get_contents($messagingSystemCachePath));
@@ -314,5 +319,24 @@ final class EcotoneLite
         }
 
         return $configuration;
+    }
+
+    private static function shouldUseAutomaticCache(bool $useCachedVersion, string $pathToRootCatalog): bool
+    {
+        if (!$useCachedVersion && file_exists($pathToRootCatalog . 'composer.json')) {
+            $composer = \json_decode(file_get_contents($pathToRootCatalog . 'composer.json'), true);
+            if (!self::isRunningTestsForEcotoneFramework($composer['name'])) {
+                $useCachedVersion = true;
+            }
+        } else {
+            $useCachedVersion = true;
+        }
+
+        return $useCachedVersion;
+    }
+
+    private static function isRunningTestsForEcotoneFramework($name): bool
+    {
+        return str_starts_with($name, 'ecotone/');
     }
 }

--- a/packages/Ecotone/tests/Lite/Test/MessagingTestSupportFrameworkTest.php
+++ b/packages/Ecotone/tests/Lite/Test/MessagingTestSupportFrameworkTest.php
@@ -162,7 +162,7 @@ final class MessagingTestSupportFrameworkTest extends TestCase
         /** Failing on event serialization */
         $this->expectException(ConversionException::class);
 
-        $ecotoneTestSupport->run('orders', ExecutionPollingMetadata::createWithTestingSetup());
+        $ecotoneTestSupport->run('orders');
     }
 
     public function test_serializing_command_and_event_before_sending_to_asynchronous_channel()


### PR DESCRIPTION
- Speed up async tests with in memory
- Do not Cache Ecotone Lite tests when running inside Ecotone Framework