### PR TITLE
fix dbal parameter definition

### DIFF
--- a/packages/Dbal/src/Attribute/DbalParameter.php
+++ b/packages/Dbal/src/Attribute/DbalParameter.php
@@ -63,7 +63,9 @@ final class DbalParameter implements DefinedObject
             [
                 $this->name,
                 $this->type,
+                $this->expression,
                 $this->convertToMediaType,
+                $this->ignored
             ]
         );
     }


### PR DESCRIPTION
## Description

Fixes DbalParameter attribute definition which was not correctly dumped in cached container

## Type of change

- Bug fix (non-breaking change which fixes an issue)

<!--
Please note that by submitting this pull request, you agree to the contribution terms defined in [CONTRIBUTING.md](https://github.com/ecotoneframework/ecotone-dev/blob/main/CONTRIBUTING.md). This part of the template must not be removed.
-->