### PR TITLE
fix attribute resolver on promoted properties

### DIFF
--- a/packages/Ecotone/src/AnnotationFinder/AnnotationResolver/AttributeResolver.php
+++ b/packages/Ecotone/src/AnnotationFinder/AnnotationResolver/AttributeResolver.php
@@ -6,6 +6,7 @@ use Ecotone\AnnotationFinder\AnnotationResolver;
 use Ecotone\AnnotationFinder\ConfigurationException;
 use Ecotone\AnnotationFinder\TypeResolver;
 use Ecotone\Messaging\Attribute\IsAbstract;
+use Error;
 use ReflectionAttribute;
 use ReflectionClass;
 use ReflectionException;
@@ -81,7 +82,11 @@ class AttributeResolver implements AnnotationResolver
                         return $carry;
                     }
 
-                    $carry[] = $attribute->newInstance();
+                    try {
+                        $carry[] = $attribute->newInstance();
+                    } catch (Error) {
+                        // Do nothing: it is an attribute targeting a parameter promoted to a property
+                    }
 
                     return $carry;
                 }, []);

--- a/packages/Ecotone/src/AnnotationFinder/AnnotationResolver/AttributeResolver.php
+++ b/packages/Ecotone/src/AnnotationFinder/AnnotationResolver/AttributeResolver.php
@@ -84,8 +84,12 @@ class AttributeResolver implements AnnotationResolver
 
                     try {
                         $carry[] = $attribute->newInstance();
-                    } catch (Error) {
-                        // Do nothing: it is an attribute targeting a parameter promoted to a property
+                    } catch (Error $e) {
+                        if (\preg_match("/Attribute \"(.*)\" cannot target property/", $e->getMessage())) {
+                            // Do nothing: it is an attribute targeting a parameter promoted to a property
+                        } else {
+                            throw $e;
+                        }
                     }
 
                     return $carry;

--- a/packages/Ecotone/src/Messaging/Handler/TypeResolver.php
+++ b/packages/Ecotone/src/Messaging/Handler/TypeResolver.php
@@ -84,7 +84,11 @@ class TypeResolver
                 try {
                     $parameterAttributes[] = $attribute->newInstance();
                 } catch (Error $e) {
-                    // ignore errors (e.g. when attribute target property and we are retrieving constructor parameters)
+                    if (\preg_match("/Attribute \"(.*)\" cannot target parameter/", $e->getMessage())) {
+                        // Do nothing: it is an attribute targeting a property promoted from a parameter
+                    } else {
+                        throw $e;
+                    }
                 }
             }
 

--- a/packages/Ecotone/tests/AnnotationFinder/Fixture/Usage/Attribute/Annotation/ParameterAttribute.php
+++ b/packages/Ecotone/tests/AnnotationFinder/Fixture/Usage/Attribute/Annotation/ParameterAttribute.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Test\Ecotone\AnnotationFinder\Fixture\Usage\Attribute\Annotation;
+
+#[\Attribute(\Attribute::TARGET_PARAMETER)]
+class ParameterAttribute
+{
+
+}

--- a/packages/Ecotone/tests/AnnotationFinder/Fixture/Usage/Attribute/Annotation/PropertyAttribute.php
+++ b/packages/Ecotone/tests/AnnotationFinder/Fixture/Usage/Attribute/Annotation/PropertyAttribute.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Test\Ecotone\AnnotationFinder\Fixture\Usage\Attribute\Annotation;
+
+#[\Attribute(\Attribute::TARGET_PROPERTY)]
+class PropertyAttribute
+{
+
+}

--- a/packages/Ecotone/tests/AnnotationFinder/Fixture/Usage/Attribute/TestingNamespace/Correct/ClassWithPromotedConstructorParameterAttribute.php
+++ b/packages/Ecotone/tests/AnnotationFinder/Fixture/Usage/Attribute/TestingNamespace/Correct/ClassWithPromotedConstructorParameterAttribute.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Test\Ecotone\AnnotationFinder\Fixture\Usage\Attribute\TestingNamespace\Correct;
+
+use Test\Ecotone\AnnotationFinder\Fixture\Usage\Attribute\Annotation\MessageEndpoint;
+use Test\Ecotone\AnnotationFinder\Fixture\Usage\Attribute\Annotation\ParameterAttribute;
+
+class ClassWithPromotedConstructorParameterAttribute
+{
+    public function __construct(
+        #[ParameterAttribute, MessageEndpoint] public string $aPromotedProperty,
+    )
+    {
+    }
+}

--- a/packages/Ecotone/tests/AnnotationFinder/Fixture/Usage/Attribute/TestingNamespace/Correct/ClassWithPromotedConstructorParameterAttribute.php
+++ b/packages/Ecotone/tests/AnnotationFinder/Fixture/Usage/Attribute/TestingNamespace/Correct/ClassWithPromotedConstructorParameterAttribute.php
@@ -2,13 +2,13 @@
 
 namespace Test\Ecotone\AnnotationFinder\Fixture\Usage\Attribute\TestingNamespace\Correct;
 
-use Test\Ecotone\AnnotationFinder\Fixture\Usage\Attribute\Annotation\MessageEndpoint;
 use Test\Ecotone\AnnotationFinder\Fixture\Usage\Attribute\Annotation\ParameterAttribute;
+use Test\Ecotone\AnnotationFinder\Fixture\Usage\Attribute\Annotation\PropertyAttribute;
 
 class ClassWithPromotedConstructorParameterAttribute
 {
     public function __construct(
-        #[ParameterAttribute, MessageEndpoint] public string $aPromotedProperty,
+        #[ParameterAttribute, PropertyAttribute] public string $aPromotedProperty,
     )
     {
     }

--- a/packages/Ecotone/tests/AnnotationFinder/Unit/AttributeResolverTest.php
+++ b/packages/Ecotone/tests/AnnotationFinder/Unit/AttributeResolverTest.php
@@ -4,18 +4,17 @@ namespace Test\Ecotone\AnnotationFinder\Unit;
 
 use Ecotone\AnnotationFinder\AnnotationResolver\AttributeResolver;
 use PHPUnit\Framework\TestCase;
-use Test\Ecotone\AnnotationFinder\Fixture\Usage\Attribute\Annotation\MessageEndpoint;
+use Test\Ecotone\AnnotationFinder\Fixture\Usage\Attribute\Annotation\PropertyAttribute;
 use Test\Ecotone\AnnotationFinder\Fixture\Usage\Attribute\TestingNamespace\Correct\ClassWithPromotedConstructorParameterAttribute;
 
 class AttributeResolverTest extends TestCase
 {
-
     public function test_it_can_resolve_property_attributes_on_promoted_constructor_parameters(): void
     {
         $resolver = new AttributeResolver();
 
         $attributes = $resolver->getAnnotationsForProperty(ClassWithPromotedConstructorParameterAttribute::class, 'aPromotedProperty');
 
-        self::assertEquals([new MessageEndpoint()], $attributes);
+        self::assertEquals([new PropertyAttribute()], $attributes);
     }
 }

--- a/packages/Ecotone/tests/AnnotationFinder/Unit/AttributeResolverTest.php
+++ b/packages/Ecotone/tests/AnnotationFinder/Unit/AttributeResolverTest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Test\Ecotone\AnnotationFinder\Unit;
+
+use Ecotone\AnnotationFinder\AnnotationResolver\AttributeResolver;
+use PHPUnit\Framework\TestCase;
+use Test\Ecotone\AnnotationFinder\Fixture\Usage\Attribute\Annotation\MessageEndpoint;
+use Test\Ecotone\AnnotationFinder\Fixture\Usage\Attribute\TestingNamespace\Correct\ClassWithPromotedConstructorParameterAttribute;
+
+class AttributeResolverTest extends TestCase
+{
+
+    public function test_it_can_resolve_property_attributes_on_promoted_constructor_parameters(): void
+    {
+        $resolver = new AttributeResolver();
+
+        $attributes = $resolver->getAnnotationsForProperty(ClassWithPromotedConstructorParameterAttribute::class, 'aPromotedProperty');
+
+        self::assertEquals([new MessageEndpoint()], $attributes);
+    }
+}

--- a/packages/Ecotone/tests/Messaging/Unit/Handler/TypeResolverTest.php
+++ b/packages/Ecotone/tests/Messaging/Unit/Handler/TypeResolverTest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Test\Ecotone\Messaging\Unit\Handler;
+
+use Ecotone\Messaging\Handler\InterfaceParameter;
+use Ecotone\Messaging\Handler\TypeResolver;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use Test\Ecotone\AnnotationFinder\Fixture\Usage\Attribute\Annotation\ParameterAttribute;
+use Test\Ecotone\AnnotationFinder\Fixture\Usage\Attribute\TestingNamespace\Correct\ClassWithPromotedConstructorParameterAttribute;
+
+class TypeResolverTest extends TestCase
+{
+
+    public function test_it_can_resolve_promoted_properties(): void
+    {
+        $typeResolver = TypeResolver::create();
+        $reflectionClass = new ReflectionClass(ClassWithPromotedConstructorParameterAttribute::class);
+        /** @var InterfaceParameter $firstParameter */
+        [$firstParameter] = $typeResolver->getMethodParameters($reflectionClass, '__construct');
+
+        self::assertEquals([new ParameterAttribute()], $firstParameter->getAnnotations());
+    }
+}


### PR DESCRIPTION
## Description

Allow attributes targeting parameters to be used on php>8 promoted properties

Fixes #336 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

<!--
Please note that by submitting this pull request, you agree to the contribution terms defined in [CONTRIBUTING.md](https://github.com/ecotoneframework/ecotone-dev/blob/main/CONTRIBUTING.md). This part of the template must not be removed.
-->