### PR TITLE
Improve messaging configuration performance

### DIFF
--- a/Monorepo/ExampleApp/Lite/app.php
+++ b/Monorepo/ExampleApp/Lite/app.php
@@ -61,7 +61,7 @@ return function (bool $useCachedVersion = true): ConfiguredMessagingSystem {
             ->withFailFast(false)
             ->withDefaultErrorChannel('errorChannel')
             ->withNamespaces(['Monorepo\\ExampleApp\\Common\\'])
-            ->withSkippedModulePackageNames(\json_decode(\getenv('APP_SKIPPED_PACKAGES'), true)),
+            ->withSkippedModulePackageNames(\json_decode(\getenv('APP_SKIPPED_PACKAGES'), true) ?? []),
         useCachedVersion: $useCachedVersion,
         pathToRootCatalog: __DIR__.'/../Common',
     );

--- a/packages/Ecotone/src/Messaging/Config/MessagingSystemConfiguration.php
+++ b/packages/Ecotone/src/Messaging/Config/MessagingSystemConfiguration.php
@@ -247,6 +247,8 @@ final class MessagingSystemConfiguration implements Configuration
 
     private function prepareAndOptimizeConfiguration(InterfaceToCallRegistry $interfaceToCallRegistry, ServiceConfiguration $applicationConfiguration): void
     {
+        $this->verifyEndpointAndChannelNameUniqueness();
+
         foreach ($this->channelAdapters as $channelAdapter) {
             $channelAdapter->withEndpointAnnotations(array_merge($channelAdapter->getEndpointAnnotations(), [new AttributeDefinition(AsynchronousRunningEndpoint::class, [$channelAdapter->getEndpointId()])]));
         }
@@ -892,7 +894,6 @@ final class MessagingSystemConfiguration implements Configuration
 
         $this->messageHandlerBuilders[$messageHandlerBuilder->getEndpointId()] = $messageHandlerBuilder;
         $this->messageHandlerBuilderToChannel[$messageHandlerBuilder->getInputMessageChannelName()][] = $messageHandlerBuilder->getEndpointId();
-        $this->verifyEndpointAndChannelNameUniqueness();
 
         return $this;
     }
@@ -930,7 +931,6 @@ final class MessagingSystemConfiguration implements Configuration
         }
 
         $this->channelBuilders[$messageChannelBuilder->getMessageChannelName()] = $messageChannelBuilder;
-        $this->verifyEndpointAndChannelNameUniqueness();
 
         return $this;
     }
@@ -941,7 +941,6 @@ final class MessagingSystemConfiguration implements Configuration
     public function registerDefaultChannelFor(MessageChannelBuilder $messageChannelBuilder): Configuration
     {
         $this->defaultChannelBuilders[$messageChannelBuilder->getMessageChannelName()] = $messageChannelBuilder;
-        $this->verifyEndpointAndChannelNameUniqueness();
 
         return $this;
     }

--- a/packages/Ecotone/tests/Messaging/Unit/Config/MessagingSystemConfigurationTest.php
+++ b/packages/Ecotone/tests/Messaging/Unit/Config/MessagingSystemConfigurationTest.php
@@ -15,6 +15,7 @@ use Ecotone\Messaging\Channel\SimpleMessageChannelBuilder;
 use Ecotone\Messaging\Config\ConfigurationException;
 use Ecotone\Messaging\Config\ConsoleCommandConfiguration;
 use Ecotone\Messaging\Config\ConsoleCommandParameter;
+use Ecotone\Messaging\Config\Container\ContainerBuilder;
 use Ecotone\Messaging\Config\Container\GatewayProxyReference;
 use Ecotone\Messaging\Config\InMemoryModuleMessaging;
 use Ecotone\Messaging\Config\MessagingSystemConfiguration;
@@ -1749,7 +1750,9 @@ class MessagingSystemConfigurationTest extends MessagingTest
                     ->withInputChannelName('some')
                     ->withEndpointId('order.register')
             )
-            ->registerMessageChannel(SimpleMessageChannelBuilder::createDirectMessageChannel('order.register'));
+            ->registerMessageChannel(SimpleMessageChannelBuilder::createDirectMessageChannel('order.register'))
+            ->process(new ContainerBuilder())
+        ;
     }
 
     public function test_throwing_exception_if_registering_message_channel_name_with_same_name_as_endpoint_id()
@@ -1762,7 +1765,9 @@ class MessagingSystemConfigurationTest extends MessagingTest
                 ServiceActivatorBuilder::createWithDirectReference(new OrderService(), 'order')
                     ->withInputChannelName('some')
                     ->withEndpointId('order.register')
-            );
+            )
+            ->process(new ContainerBuilder())
+        ;
     }
 
     public function test_throwing_exception_if_registering_endpoint_with_id_same_as_default_message_channel()
@@ -1775,7 +1780,9 @@ class MessagingSystemConfigurationTest extends MessagingTest
                 ServiceActivatorBuilder::createWithDirectReference(new OrderService(), 'order')
                     ->withInputChannelName('some')
                     ->withEndpointId('order.register')
-            );
+            )
+            ->process(new ContainerBuilder())
+        ;
     }
 
     public function test_throwing_exception_if_message_handler_having_same_channel_and_endpoint_id()


### PR DESCRIPTION
## Description

Improve performance of Ecotone configuration phase.
For a medium sized repository using symfony, my cache:clear command went from **22 seconds** (92% of which is ecotone configuration processing)  to **8 seconds**.
This PR delays the endpoint uniqueness check at the compilation phase, so now the check is done only once
<img width="1114" alt="Capture d’écran 2024-07-21 à 13 40 35" src="https://github.com/user-attachments/assets/0f9f2030-56f6-489e-8bcf-6e6f76858791">

## Type of change

- Performance improvement

<!--
Please note that by submitting this pull request, you agree to the contribution terms defined in [CONTRIBUTING.md](https://github.com/ecotoneframework/ecotone-dev/blob/main/CONTRIBUTING.md). This part of the template must not be removed.
-->