### PR TITLE
remove laminas/laminas-zendframework-bridge dependency

### DIFF
--- a/packages/Symfony/composer.json
+++ b/packages/Symfony/composer.json
@@ -28,7 +28,6 @@
     "description": "Extends Ecotone with Symfony integration",
     "require": {
         "ecotone/ecotone": "~1.225.0",
-        "laminas/laminas-zendframework-bridge": "^1.0.0",
         "symfony/console": "^5.4|^6.0|^7.0",
         "symfony/dependency-injection": ">=v5.4.19 <6.0.0 || >=v6.0.19 <6.1.0 || >=v6.1.11 <6.2.0 || >=v6.2.5 <7.0.0 || >=v7.0.0 <8.0.0",
         "symfony/framework-bundle": "^5.4|^6.0|^7.0"


### PR DESCRIPTION
## Description

Remove unneeded and deprecated dependency `laminas/laminas-zendframework-bridge`

## Type of change

- Bug fix (non-breaking change which fixes an issue)

<!--
Please note that by submitting this pull request, you agree to the contribution terms defined in [CONTRIBUTING.md](https://github.com/ecotoneframework/ecotone-dev/blob/main/CONTRIBUTING.md). This part of the template must not be removed.
-->