### PR TITLE
CI: Better split testing with version constraints

### DIFF
--- a/.github/workflows/split-testing.yml
+++ b/.github/workflows/split-testing.yml
@@ -33,7 +33,7 @@ jobs:
       matrix: ${{ steps.get_json.outputs.json }}
 
   split_testing:
-    name: Testing ${{ matrix.package.name }} separately
+    name: Testing ${{ matrix.package.name }} separately (${{ matrix.stability }})
     needs: get_packages
     runs-on: ubuntu-latest
 
@@ -41,6 +41,7 @@ jobs:
       fail-fast: false
       matrix:
         package: ${{ fromJson(needs.get_packages.outputs.matrix) }}
+        stability: [ prefer-lowest, prefer-stable ]
 
     services:
       rabbitmq:
@@ -107,7 +108,7 @@ jobs:
         working-directory: ${{ matrix.package.directory }}
 
       - name: Install dependencies
-        run: composer update --no-interaction
+        run: composer update  --${{ matrix.stability }} --no-interaction
         working-directory: ${{ matrix.package.directory }}
         env:
           COMPOSER_ROOT_VERSION: 'dev-main'

--- a/.github/workflows/test-monorepo.yml
+++ b/.github/workflows/test-monorepo.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         operating-system: [ ubuntu-latest ]
         php-versions: [ '8.0', '8.3' ]
-        stability: [prefer-lowest, prefer-stable]
+        stability: [prefer-stable]
     services:
       rabbitmq:
         image: rabbitmq:3.11-management-alpine

--- a/_PackageTemplate/composer.json
+++ b/_PackageTemplate/composer.json
@@ -36,7 +36,7 @@
         "phpunit/phpunit": "^9.5",
         "phpstan/phpstan": "^1.8",
         "psr/container": "^2.0",
-        "wikimedia/composer-merge-plugin": "^2.0"
+        "wikimedia/composer-merge-plugin": "^2.1"
     },
     "scripts": {
         "tests:phpstan": "vendor/bin/phpstan",

--- a/composer.json
+++ b/composer.json
@@ -136,7 +136,7 @@
         "behat/behat": "^3.10",
         "doctrine/annotations": "^1.13",
         "doctrine/cache": "^1.0.0",
-        "doctrine/orm": "^2.0|^3.0",
+        "doctrine/orm": "^2.11|^3.0",
         "friends-of-behat/symfony-extension": "<=2.4.2|^2.5",
         "friendsofphp/php-cs-fixer": "^3.9",
         "guzzlehttp/psr7": "^2.0",

--- a/composer.json
+++ b/composer.json
@@ -143,7 +143,7 @@
         "orchestra/testbench": "^7.6|^8.0",
         "php-coveralls/php-coveralls": "^2.5",
         "phpstan/phpstan": "^1.8",
-        "phpunit/phpunit": "^9.5",
+        "phpunit/phpunit": "^9.6",
         "predis/predis": "^1.1.10",
         "symfony/expression-language": "^6.0|^7.0",
         "symplify/monorepo-builder": "11.1.21",

--- a/composer.json
+++ b/composer.json
@@ -127,7 +127,7 @@
         "symfony/console": "^5.4|^6.0|^7.0",
         "symfony/framework-bundle": "^5.4|^6.0|^7.0",
         "symfony/dependency-injection": ">=v5.4.19 <6.0.0 || >=v6.0.19 <6.1.0 || >=v6.1.11 <6.2.0 || >=v6.2.5 <7.0.0 || >=v7.0.0 <8.0.0",
-        "wikimedia/composer-merge-plugin": "^2.0",
+        "wikimedia/composer-merge-plugin": "^2.1",
         "php-di/php-di": "^7.0.1",
         "open-telemetry/sdk": "^1.0.0",
         "psr/container": "^1.1.1|^2.0.1"

--- a/composer.json
+++ b/composer.json
@@ -129,7 +129,8 @@
         "symfony/dependency-injection": ">=v5.4.19 <6.0.0 || >=v6.0.19 <6.1.0 || >=v6.1.11 <6.2.0 || >=v6.2.5 <7.0.0 || >=v7.0.0 <8.0.0",
         "wikimedia/composer-merge-plugin": "^2.0",
         "php-di/php-di": "^7.0.1",
-        "open-telemetry/sdk": "^1.0.0"
+        "open-telemetry/sdk": "^1.0.0",
+        "psr/container": "^1.1.1|^2.0.1"
     },
     "require-dev": {
         "behat/behat": "^3.10",

--- a/monorepo-builder.php
+++ b/monorepo-builder.php
@@ -30,7 +30,7 @@ return static function (MBConfig $containerConfigurator): void {
             "friendsofphp/php-cs-fixer" => "^3.9",
             "php-coveralls/php-coveralls" => "^2.5",
             "phpstan/phpstan" => "^1.8",
-            "phpunit/phpunit" => "^9.5",
+            "phpunit/phpunit" => "^9.6",
             "symfony/expression-language" => "^6.0|^7.0",
             "symplify/monorepo-builder" => "11.1.21"
         ],

--- a/packages/Amqp/composer.json
+++ b/packages/Amqp/composer.json
@@ -48,7 +48,7 @@
         "enqueue/enqueue": "^0.10.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.5",
+        "phpunit/phpunit": "^9.6",
         "phpstan/phpstan": "^1.8",
         "doctrine/annotations": "^1.13",
         "wikimedia/composer-merge-plugin": "^2.0"

--- a/packages/Amqp/composer.json
+++ b/packages/Amqp/composer.json
@@ -50,7 +50,6 @@
     "require-dev": {
         "phpunit/phpunit": "^9.5",
         "phpstan/phpstan": "^1.8",
-        "psr/container": "^2.0",
         "doctrine/annotations": "^1.13",
         "wikimedia/composer-merge-plugin": "^2.0"
     },

--- a/packages/Amqp/composer.json
+++ b/packages/Amqp/composer.json
@@ -51,7 +51,7 @@
         "phpunit/phpunit": "^9.6",
         "phpstan/phpstan": "^1.8",
         "doctrine/annotations": "^1.13",
-        "wikimedia/composer-merge-plugin": "^2.0"
+        "wikimedia/composer-merge-plugin": "^2.1"
     },
     "scripts": {
         "tests:phpstan": "vendor/bin/phpstan",

--- a/packages/Dbal/composer.json
+++ b/packages/Dbal/composer.json
@@ -38,10 +38,9 @@
         "doctrine/dbal": "^2.12.0|^3.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.5.10",
+        "phpunit/phpunit": "^9.5",
         "doctrine/persistence": "^2.5",
         "phpstan/phpstan": "^1.8",
-        "psr/container": "^2.0",
         "doctrine/orm": "^2.11|^3.0",
         "doctrine/cache": "^1.0.0",
         "doctrine/annotations": "^1.13",

--- a/packages/Dbal/composer.json
+++ b/packages/Dbal/composer.json
@@ -38,7 +38,7 @@
         "doctrine/dbal": "^2.12.0|^3.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.5",
+        "phpunit/phpunit": "^9.6",
         "doctrine/persistence": "^2.5",
         "phpstan/phpstan": "^1.8",
         "doctrine/orm": "^2.11|^3.0",

--- a/packages/Dbal/composer.json
+++ b/packages/Dbal/composer.json
@@ -38,11 +38,11 @@
         "doctrine/dbal": "^2.12.0|^3.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.5",
+        "phpunit/phpunit": "^9.5.10",
         "doctrine/persistence": "^2.5",
         "phpstan/phpstan": "^1.8",
         "psr/container": "^2.0",
-        "doctrine/orm": "^2.0|^3.0",
+        "doctrine/orm": "^2.11|^3.0",
         "doctrine/cache": "^1.0.0",
         "doctrine/annotations": "^1.13",
         "wikimedia/composer-merge-plugin": "^2.0",

--- a/packages/Dbal/composer.json
+++ b/packages/Dbal/composer.json
@@ -44,7 +44,7 @@
         "doctrine/orm": "^2.11|^3.0",
         "doctrine/cache": "^1.0.0",
         "doctrine/annotations": "^1.13",
-        "wikimedia/composer-merge-plugin": "^2.0",
+        "wikimedia/composer-merge-plugin": "^2.1",
         "ecotone/jms-converter": "~1.225.0",
         "symfony/expression-language": "^6.0|^7.0"
     },

--- a/packages/Ecotone/composer.json
+++ b/packages/Ecotone/composer.json
@@ -45,7 +45,7 @@
         "friendsofphp/proxy-manager-lts": "^1.0.12"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.5.10",
+        "phpunit/phpunit": "^9.5",
         "behat/behat": "^3.10",
         "phpstan/phpstan": "^1.8",
         "symfony/expression-language": "^6.0|^7.0"

--- a/packages/Ecotone/composer.json
+++ b/packages/Ecotone/composer.json
@@ -45,7 +45,7 @@
         "friendsofphp/proxy-manager-lts": "^1.0.12"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.5",
+        "phpunit/phpunit": "^9.5.10",
         "behat/behat": "^3.10",
         "phpstan/phpstan": "^1.8",
         "symfony/expression-language": "^6.0|^7.0"

--- a/packages/Ecotone/composer.json
+++ b/packages/Ecotone/composer.json
@@ -45,7 +45,7 @@
         "friendsofphp/proxy-manager-lts": "^1.0.12"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.5",
+        "phpunit/phpunit": "^9.6",
         "behat/behat": "^3.10",
         "phpstan/phpstan": "^1.8",
         "symfony/expression-language": "^6.0|^7.0"

--- a/packages/Ecotone/composer.json
+++ b/packages/Ecotone/composer.json
@@ -39,6 +39,7 @@
     },
     "require": {
         "php": "^8.0",
+        "psr/container": "^1.1.1|^2.0.1",
         "psr/log": "^2.0|^3.0",
         "ramsey/uuid": "^4.0",
         "friendsofphp/proxy-manager-lts": "^1.0.12"

--- a/packages/Enqueue/composer.json
+++ b/packages/Enqueue/composer.json
@@ -41,7 +41,7 @@
         "phpunit/phpunit": "^9.6",
         "behat/behat": "^3.10",
         "phpstan/phpstan": "^1.8",
-        "wikimedia/composer-merge-plugin": "^2.0",
+        "wikimedia/composer-merge-plugin": "^2.1",
         "enqueue/null": "^0.10.18"
     },
     "scripts": {

--- a/packages/Enqueue/composer.json
+++ b/packages/Enqueue/composer.json
@@ -38,7 +38,7 @@
         "enqueue/dsn": "^0.10.4"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.5",
+        "phpunit/phpunit": "^9.6",
         "behat/behat": "^3.10",
         "phpstan/phpstan": "^1.8",
         "wikimedia/composer-merge-plugin": "^2.0",

--- a/packages/JmsConverter/composer.json
+++ b/packages/JmsConverter/composer.json
@@ -43,7 +43,7 @@
         "symfony/cache": "^5.4|^6.1|^7.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.5",
+        "phpunit/phpunit": "^9.6",
         "behat/behat": "^3.10",
         "phpstan/phpstan": "^1.8",
         "wikimedia/composer-merge-plugin": "^2.0"

--- a/packages/JmsConverter/composer.json
+++ b/packages/JmsConverter/composer.json
@@ -46,7 +46,7 @@
         "phpunit/phpunit": "^9.6",
         "behat/behat": "^3.10",
         "phpstan/phpstan": "^1.8",
-        "wikimedia/composer-merge-plugin": "^2.0"
+        "wikimedia/composer-merge-plugin": "^2.1"
     },
     "scripts": {
         "tests:phpstan": "vendor/bin/phpstan",

--- a/packages/Laravel/composer.json
+++ b/packages/Laravel/composer.json
@@ -41,7 +41,7 @@
         "laravel/framework": "^9.5.2|^10.0|^11.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.5",
+        "phpunit/phpunit": "^9.6",
         "behat/behat": "^3.10",
         "guzzlehttp/psr7": "^2.0",
         "phpstan/phpstan": "^1.8",

--- a/packages/Laravel/composer.json
+++ b/packages/Laravel/composer.json
@@ -46,7 +46,7 @@
         "guzzlehttp/psr7": "^2.0",
         "phpstan/phpstan": "^1.8",
         "orchestra/testbench": "^7.6|^8.0",
-        "wikimedia/composer-merge-plugin": "^2.0",
+        "wikimedia/composer-merge-plugin": "^2.1",
         "symfony/expression-language": "^6.0|^7.0",
         "nesbot/carbon": "^2.71",
         "moneyphp/money": "^4.1.0",

--- a/packages/LiteApplication/composer.json
+++ b/packages/LiteApplication/composer.json
@@ -41,7 +41,7 @@
         "php-di/php-di": "^7.0.1"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.5",
+        "phpunit/phpunit": "^9.6",
         "behat/behat": "^3.10",
         "guzzlehttp/psr7": "^2.0",
         "phpstan/phpstan": "^1.8",

--- a/packages/LiteApplication/composer.json
+++ b/packages/LiteApplication/composer.json
@@ -46,7 +46,7 @@
         "guzzlehttp/psr7": "^2.0",
         "phpstan/phpstan": "^1.8",
         "orchestra/testbench": "^7.6|^8.0",
-        "wikimedia/composer-merge-plugin": "^2.0"
+        "wikimedia/composer-merge-plugin": "^2.1"
     },
     "extra": {
         "branch-alias": {

--- a/packages/OpenTelemetry/composer.json
+++ b/packages/OpenTelemetry/composer.json
@@ -38,7 +38,7 @@
         "open-telemetry/sdk": "^1.0.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.5",
+        "phpunit/phpunit": "^9.6",
         "behat/behat": "^3.10",
         "phpstan/phpstan": "^1.8",
         "wikimedia/composer-merge-plugin": "^2.0",

--- a/packages/OpenTelemetry/composer.json
+++ b/packages/OpenTelemetry/composer.json
@@ -41,7 +41,7 @@
         "phpunit/phpunit": "^9.6",
         "behat/behat": "^3.10",
         "phpstan/phpstan": "^1.8",
-        "wikimedia/composer-merge-plugin": "^2.0",
+        "wikimedia/composer-merge-plugin": "^2.1",
         "open-telemetry/transport-grpc": "^1.0.0",
         "open-telemetry/exporter-otlp": "^1.0.0",
         "symfony/http-client": "^5.4|^6.2|7.0",

--- a/packages/PdoEventSourcing/composer.json
+++ b/packages/PdoEventSourcing/composer.json
@@ -39,7 +39,6 @@
     "require-dev": {
         "phpunit/phpunit": "^9.5",
         "phpstan/phpstan": "^1.8",
-        "psr/container": "^2.0",
         "wikimedia/composer-merge-plugin": "^2.0"
     },
     "scripts": {

--- a/packages/PdoEventSourcing/composer.json
+++ b/packages/PdoEventSourcing/composer.json
@@ -37,7 +37,7 @@
         "prooph/pdo-event-store": "^1.15.1"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.5",
+        "phpunit/phpunit": "^9.6",
         "phpstan/phpstan": "^1.8",
         "wikimedia/composer-merge-plugin": "^2.0"
     },

--- a/packages/PdoEventSourcing/composer.json
+++ b/packages/PdoEventSourcing/composer.json
@@ -39,7 +39,7 @@
     "require-dev": {
         "phpunit/phpunit": "^9.6",
         "phpstan/phpstan": "^1.8",
-        "wikimedia/composer-merge-plugin": "^2.0"
+        "wikimedia/composer-merge-plugin": "^2.1"
     },
     "scripts": {
         "tests:phpstan": "vendor/bin/phpstan",

--- a/packages/PdoEventSourcing/tests/EventSourcingMessagingTestCase.php
+++ b/packages/PdoEventSourcing/tests/EventSourcingMessagingTestCase.php
@@ -86,7 +86,7 @@ abstract class EventSourcingMessagingTestCase extends TestCase
     {
         foreach (self::getSchemaManager($connection)->listTableNames() as $tableNames) {
             $sql = 'DROP TABLE ' . $tableNames;
-            $connection->prepare($sql)->executeStatement();
+            $connection->executeQuery($sql);
         }
     }
 
@@ -98,7 +98,7 @@ abstract class EventSourcingMessagingTestCase extends TestCase
     private static function deleteFromTableExists(string $tableName, Connection $connection): void
     {
         if (self::tableExists($connection, $tableName)) {
-            $connection->executeStatement('DELETE FROM ' . $tableName);
+            $connection->executeQuery('DELETE FROM ' . $tableName);
         }
     }
 

--- a/packages/Redis/composer.json
+++ b/packages/Redis/composer.json
@@ -46,7 +46,7 @@
         "phpstan/phpstan": "^1.8",
         "phpunit/phpunit": "^9.6",
         "predis/predis": "^1.1.10",
-        "wikimedia/composer-merge-plugin": "^2.0"
+        "wikimedia/composer-merge-plugin": "^2.1"
     },
     "scripts": {
         "tests:phpstan": "vendor/bin/phpstan",

--- a/packages/Redis/composer.json
+++ b/packages/Redis/composer.json
@@ -44,7 +44,7 @@
     "require-dev": {
         "behat/behat": "^3.10",
         "phpstan/phpstan": "^1.8",
-        "phpunit/phpunit": "^9.5",
+        "phpunit/phpunit": "^9.6",
         "predis/predis": "^1.1.10",
         "wikimedia/composer-merge-plugin": "^2.0"
     },

--- a/packages/Sqs/composer.json
+++ b/packages/Sqs/composer.json
@@ -41,7 +41,7 @@
         "phpunit/phpunit": "^9.6",
         "behat/behat": "^3.10",
         "phpstan/phpstan": "^1.8",
-        "wikimedia/composer-merge-plugin": "^2.0"
+        "wikimedia/composer-merge-plugin": "^2.1"
     },
     "conflict": {
         "guzzlehttp/promises": "<1.4.0"

--- a/packages/Sqs/composer.json
+++ b/packages/Sqs/composer.json
@@ -43,6 +43,9 @@
         "phpstan/phpstan": "^1.8",
         "wikimedia/composer-merge-plugin": "^2.0"
     },
+    "conflict": {
+        "guzzlehttp/promises": "<1.4.0"
+    },
     "scripts": {
         "tests:phpstan": "vendor/bin/phpstan",
         "tests:phpunit": "vendor/bin/phpunit",

--- a/packages/Sqs/composer.json
+++ b/packages/Sqs/composer.json
@@ -38,7 +38,7 @@
         "aws/aws-sdk-php": "<=3.269.5"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.5",
+        "phpunit/phpunit": "^9.6",
         "behat/behat": "^3.10",
         "phpstan/phpstan": "^1.8",
         "wikimedia/composer-merge-plugin": "^2.0"

--- a/packages/Symfony/composer.json
+++ b/packages/Symfony/composer.json
@@ -40,7 +40,7 @@
         "friends-of-behat/symfony-extension": "<=2.4.2|^2.5",
         "monolog/monolog": "^2.9|^3.3.1",
         "phpstan/phpstan": "^1.8",
-        "phpunit/phpunit": "^9.5",
+        "phpunit/phpunit": "^9.6",
         "symfony/amqp-messenger": "^5.4.31|^6.0|^7.0",
         "symfony/doctrine-messenger": "^5.4|^6.0|^7.0",
         "symfony/expression-language": "^6.0|^7.0",

--- a/packages/Symfony/composer.json
+++ b/packages/Symfony/composer.json
@@ -36,7 +36,7 @@
     "require-dev": {
         "behat/behat": "^3.10",
         "doctrine/doctrine-bundle": "^2.7.2",
-        "doctrine/orm": "^2.0|^3.0",
+        "doctrine/orm": "^2.11|^3.0",
         "friends-of-behat/symfony-extension": "<=2.4.2|^2.5",
         "monolog/monolog": "^2.9|^3.3.1",
         "phpstan/phpstan": "^1.8",

--- a/packages/Symfony/composer.json
+++ b/packages/Symfony/composer.json
@@ -45,7 +45,7 @@
         "symfony/doctrine-messenger": "^5.4|^6.0|^7.0",
         "symfony/expression-language": "^6.0|^7.0",
         "symfony/messenger": "^5.4|^6.0|^7.0",
-        "wikimedia/composer-merge-plugin": "^2.0",
+        "wikimedia/composer-merge-plugin": "^2.1",
         "ecotone/dbal": "~1.225.0"
     },
     "config": {

--- a/quickstart-examples/Asynchronous/composer.json
+++ b/quickstart-examples/Asynchronous/composer.json
@@ -17,7 +17,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^9.6",
-        "wikimedia/composer-merge-plugin": "^2.0"
+        "wikimedia/composer-merge-plugin": "^2.1"
     },
     "config": {
         "sort-packages": true,

--- a/quickstart-examples/Asynchronous/composer.json
+++ b/quickstart-examples/Asynchronous/composer.json
@@ -16,11 +16,9 @@
         "ecotone/lite-amqp-starter": "^1.0.1"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.5",
+        "phpunit/phpunit": "^9.6",
         "wikimedia/composer-merge-plugin": "^2.0"
     },
-    "minimum-stability": "dev",
-    "prefer-stable": true,
     "config": {
         "sort-packages": true,
         "allow-plugins": {
@@ -33,5 +31,7 @@
                 "../../packages/local_packages.json"
             ]
         }
-    }
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true
 }

--- a/quickstart-examples/BuildingBlocks/composer.json
+++ b/quickstart-examples/BuildingBlocks/composer.json
@@ -25,7 +25,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^9.6",
-        "wikimedia/composer-merge-plugin": "^2.0"
+        "wikimedia/composer-merge-plugin": "^2.1"
     },
     "config": {
         "sort-packages": true,

--- a/quickstart-examples/BuildingBlocks/composer.json
+++ b/quickstart-examples/BuildingBlocks/composer.json
@@ -24,11 +24,9 @@
         "moneyphp/money": "^4.1.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.5",
+        "phpunit/phpunit": "^9.6",
         "wikimedia/composer-merge-plugin": "^2.0"
     },
-    "minimum-stability": "dev",
-    "prefer-stable": true,
     "config": {
         "sort-packages": true,
         "allow-plugins": {
@@ -41,5 +39,7 @@
                 "../../packages/local_packages.json"
             ]
         }
-    }
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true
 }

--- a/quickstart-examples/BusinessInterface/Asynchronous/composer.json
+++ b/quickstart-examples/BusinessInterface/Asynchronous/composer.json
@@ -17,7 +17,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^9.6",
-        "wikimedia/composer-merge-plugin": "^2.0"
+        "wikimedia/composer-merge-plugin": "^2.1"
     },
     "config": {
         "sort-packages": true,

--- a/quickstart-examples/BusinessInterface/Asynchronous/composer.json
+++ b/quickstart-examples/BusinessInterface/Asynchronous/composer.json
@@ -16,11 +16,9 @@
         "ecotone/lite-dbal-starter": "^1.0.1"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.5",
+        "phpunit/phpunit": "^9.6",
         "wikimedia/composer-merge-plugin": "^2.0"
     },
-    "minimum-stability": "dev",
-    "prefer-stable": true,
     "config": {
         "sort-packages": true,
         "allow-plugins": {
@@ -33,5 +31,7 @@
                 "../../../packages/local_packages.json"
             ]
         }
-    }
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true
 }

--- a/quickstart-examples/BusinessInterface/Routing/composer.json
+++ b/quickstart-examples/BusinessInterface/Routing/composer.json
@@ -17,7 +17,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^9.6",
-        "wikimedia/composer-merge-plugin": "^2.0"
+        "wikimedia/composer-merge-plugin": "^2.1"
     },
     "config": {
         "sort-packages": true,

--- a/quickstart-examples/BusinessInterface/Routing/composer.json
+++ b/quickstart-examples/BusinessInterface/Routing/composer.json
@@ -16,11 +16,9 @@
         "ecotone/lite-dbal-starter": "^1.0.1"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.5",
+        "phpunit/phpunit": "^9.6",
         "wikimedia/composer-merge-plugin": "^2.0"
     },
-    "minimum-stability": "dev",
-    "prefer-stable": true,
     "config": {
         "sort-packages": true,
         "allow-plugins": {
@@ -33,5 +31,7 @@
                 "../../../packages/local_packages.json"
             ]
         }
-    }
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true
 }

--- a/quickstart-examples/BusinessInterface/ServiceActivator/composer.json
+++ b/quickstart-examples/BusinessInterface/ServiceActivator/composer.json
@@ -17,7 +17,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^9.6",
-        "wikimedia/composer-merge-plugin": "^2.0"
+        "wikimedia/composer-merge-plugin": "^2.1"
     },
     "config": {
         "sort-packages": true,

--- a/quickstart-examples/BusinessInterface/ServiceActivator/composer.json
+++ b/quickstart-examples/BusinessInterface/ServiceActivator/composer.json
@@ -16,11 +16,9 @@
         "ecotone/lite-dbal-starter": "^1.0.1"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.5",
+        "phpunit/phpunit": "^9.6",
         "wikimedia/composer-merge-plugin": "^2.0"
     },
-    "minimum-stability": "dev",
-    "prefer-stable": true,
     "config": {
         "sort-packages": true,
         "allow-plugins": {
@@ -33,5 +31,7 @@
                 "../../../packages/local_packages.json"
             ]
         }
-    }
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true
 }

--- a/quickstart-examples/CQRS/composer.json
+++ b/quickstart-examples/CQRS/composer.json
@@ -17,7 +17,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^9.6",
-        "wikimedia/composer-merge-plugin": "^2.0"
+        "wikimedia/composer-merge-plugin": "^2.1"
     },
     "config": {
         "sort-packages": true,

--- a/quickstart-examples/CQRS/composer.json
+++ b/quickstart-examples/CQRS/composer.json
@@ -16,11 +16,9 @@
         "ecotone/lite-application-starter": "^1.0.1"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.5",
+        "phpunit/phpunit": "^9.6",
         "wikimedia/composer-merge-plugin": "^2.0"
     },
-    "minimum-stability": "dev",
-    "prefer-stable": true,
     "config": {
         "sort-packages": true,
         "allow-plugins": {
@@ -33,5 +31,7 @@
                 "../../packages/local_packages.json"
             ]
         }
-    }
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true
 }

--- a/quickstart-examples/ConsoleCommand/Laravel/composer.json
+++ b/quickstart-examples/ConsoleCommand/Laravel/composer.json
@@ -20,7 +20,7 @@
     "require-dev": {
         "doctrine/orm": "^2.11|^3.0",
         "phpunit/phpunit": "^9.6",
-        "wikimedia/composer-merge-plugin": "^2.0"
+        "wikimedia/composer-merge-plugin": "^2.1"
     },
     "config": {
         "sort-packages": true,

--- a/quickstart-examples/ConsoleCommand/Laravel/composer.json
+++ b/quickstart-examples/ConsoleCommand/Laravel/composer.json
@@ -19,7 +19,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5",
-        "doctrine/orm": "^2.0|^3.0",
+        "doctrine/orm": "^2.11|^3.0",
         "wikimedia/composer-merge-plugin": "^2.0"
     },
     "minimum-stability": "dev",

--- a/quickstart-examples/ConsoleCommand/Laravel/composer.json
+++ b/quickstart-examples/ConsoleCommand/Laravel/composer.json
@@ -18,12 +18,10 @@
         "laravel/laravel": "^10.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.5",
         "doctrine/orm": "^2.11|^3.0",
+        "phpunit/phpunit": "^9.6",
         "wikimedia/composer-merge-plugin": "^2.0"
     },
-    "minimum-stability": "dev",
-    "prefer-stable": true,
     "config": {
         "sort-packages": true,
         "allow-plugins": {
@@ -36,5 +34,7 @@
                 "../../../packages/local_packages.json"
             ]
         }
-    }
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true
 }

--- a/quickstart-examples/ConsoleCommand/Symfony/composer.json
+++ b/quickstart-examples/ConsoleCommand/Symfony/composer.json
@@ -18,12 +18,10 @@
         "symfony/yaml": "^7.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.5",
         "doctrine/orm": "^2.11|^3.0",
+        "phpunit/phpunit": "^9.6",
         "wikimedia/composer-merge-plugin": "^2.0"
     },
-    "minimum-stability": "dev",
-    "prefer-stable": true,
     "config": {
         "sort-packages": true,
         "allow-plugins": {
@@ -36,5 +34,7 @@
                 "../../../packages/local_packages.json"
             ]
         }
-    }
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true
 }

--- a/quickstart-examples/ConsoleCommand/Symfony/composer.json
+++ b/quickstart-examples/ConsoleCommand/Symfony/composer.json
@@ -20,7 +20,7 @@
     "require-dev": {
         "doctrine/orm": "^2.11|^3.0",
         "phpunit/phpunit": "^9.6",
-        "wikimedia/composer-merge-plugin": "^2.0"
+        "wikimedia/composer-merge-plugin": "^2.1"
     },
     "config": {
         "sort-packages": true,

--- a/quickstart-examples/ConsoleCommand/Symfony/composer.json
+++ b/quickstart-examples/ConsoleCommand/Symfony/composer.json
@@ -19,7 +19,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5",
-        "doctrine/orm": "^2.0|^3.0",
+        "doctrine/orm": "^2.11|^3.0",
         "wikimedia/composer-merge-plugin": "^2.0"
     },
     "minimum-stability": "dev",

--- a/quickstart-examples/Conversion/composer.json
+++ b/quickstart-examples/Conversion/composer.json
@@ -17,7 +17,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^9.6",
-        "wikimedia/composer-merge-plugin": "^2.0"
+        "wikimedia/composer-merge-plugin": "^2.1"
     },
     "config": {
         "sort-packages": true,

--- a/quickstart-examples/Conversion/composer.json
+++ b/quickstart-examples/Conversion/composer.json
@@ -16,11 +16,9 @@
         "ecotone/lite-application-starter": "^1.0.1"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.5",
+        "phpunit/phpunit": "^9.6",
         "wikimedia/composer-merge-plugin": "^2.0"
     },
-    "minimum-stability": "dev",
-    "prefer-stable": true,
     "config": {
         "sort-packages": true,
         "allow-plugins": {
@@ -33,5 +31,7 @@
                 "../../packages/local_packages.json"
             ]
         }
-    }
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true
 }

--- a/quickstart-examples/EmittingEventsFromProjection/composer.json
+++ b/quickstart-examples/EmittingEventsFromProjection/composer.json
@@ -17,7 +17,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^9.6",
-        "wikimedia/composer-merge-plugin": "^2.0"
+        "wikimedia/composer-merge-plugin": "^2.1"
     },
     "config": {
         "sort-packages": true,

--- a/quickstart-examples/EmittingEventsFromProjection/composer.json
+++ b/quickstart-examples/EmittingEventsFromProjection/composer.json
@@ -16,11 +16,9 @@
         "ecotone/lite-event-sourcing-starter": "^1.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.5",
+        "phpunit/phpunit": "^9.6",
         "wikimedia/composer-merge-plugin": "^2.0"
     },
-    "minimum-stability": "dev",
-    "prefer-stable": true,
     "config": {
         "sort-packages": true,
         "allow-plugins": {
@@ -33,5 +31,7 @@
                 "../../packages/local_packages.json"
             ]
         }
-    }
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true
 }

--- a/quickstart-examples/ErrorHandling/composer.json
+++ b/quickstart-examples/ErrorHandling/composer.json
@@ -17,7 +17,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^9.6",
-        "wikimedia/composer-merge-plugin": "^2.0"
+        "wikimedia/composer-merge-plugin": "^2.1"
     },
     "config": {
         "sort-packages": true,

--- a/quickstart-examples/ErrorHandling/composer.json
+++ b/quickstart-examples/ErrorHandling/composer.json
@@ -16,11 +16,9 @@
         "ecotone/lite-dbal-starter": "^1.0.1"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.5",
+        "phpunit/phpunit": "^9.6",
         "wikimedia/composer-merge-plugin": "^2.0"
     },
-    "minimum-stability": "dev",
-    "prefer-stable": true,
     "config": {
         "sort-packages": true,
         "allow-plugins": {
@@ -33,5 +31,7 @@
                 "../../packages/local_packages.json"
             ]
         }
-    }
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true
 }

--- a/quickstart-examples/EventHandling/composer.json
+++ b/quickstart-examples/EventHandling/composer.json
@@ -17,7 +17,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^9.6",
-        "wikimedia/composer-merge-plugin": "^2.0"
+        "wikimedia/composer-merge-plugin": "^2.1"
     },
     "config": {
         "sort-packages": true,

--- a/quickstart-examples/EventHandling/composer.json
+++ b/quickstart-examples/EventHandling/composer.json
@@ -16,11 +16,9 @@
         "ecotone/lite-application-starter": "^1.0.1"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.5",
+        "phpunit/phpunit": "^9.6",
         "wikimedia/composer-merge-plugin": "^2.0"
     },
-    "minimum-stability": "dev",
-    "prefer-stable": true,
     "config": {
         "sort-packages": true,
         "allow-plugins": {
@@ -33,5 +31,7 @@
                 "../../packages/local_packages.json"
             ]
         }
-    }
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true
 }

--- a/quickstart-examples/EventSourcing/composer.json
+++ b/quickstart-examples/EventSourcing/composer.json
@@ -17,7 +17,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^9.6",
-        "wikimedia/composer-merge-plugin": "^2.0"
+        "wikimedia/composer-merge-plugin": "^2.1"
     },
     "config": {
         "sort-packages": true,

--- a/quickstart-examples/EventSourcing/composer.json
+++ b/quickstart-examples/EventSourcing/composer.json
@@ -16,11 +16,9 @@
         "ecotone/lite-event-sourcing-starter": "^1.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.5",
+        "phpunit/phpunit": "^9.6",
         "wikimedia/composer-merge-plugin": "^2.0"
     },
-    "minimum-stability": "dev",
-    "prefer-stable": true,
     "config": {
         "sort-packages": true,
         "allow-plugins": {
@@ -33,5 +31,7 @@
                 "../../packages/local_packages.json"
             ]
         }
-    }
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true
 }

--- a/quickstart-examples/Microservices/composer.json
+++ b/quickstart-examples/Microservices/composer.json
@@ -17,7 +17,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^9.6",
-        "wikimedia/composer-merge-plugin": "^2.0"
+        "wikimedia/composer-merge-plugin": "^2.1"
     },
     "config": {
         "sort-packages": true,

--- a/quickstart-examples/Microservices/composer.json
+++ b/quickstart-examples/Microservices/composer.json
@@ -16,11 +16,9 @@
         "ecotone/lite-amqp-starter": "^1.0.1"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.5",
+        "phpunit/phpunit": "^9.6",
         "wikimedia/composer-merge-plugin": "^2.0"
     },
-    "minimum-stability": "dev",
-    "prefer-stable": true,
     "config": {
         "sort-packages": true,
         "allow-plugins": {
@@ -33,5 +31,7 @@
                 "../../packages/local_packages.json"
             ]
         }
-    }
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true
 }

--- a/quickstart-examples/MicroservicesAdvanced/composer.json
+++ b/quickstart-examples/MicroservicesAdvanced/composer.json
@@ -19,7 +19,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^9.6",
-        "wikimedia/composer-merge-plugin": "^2.0"
+        "wikimedia/composer-merge-plugin": "^2.1"
     },
     "config": {
         "sort-packages": true,

--- a/quickstart-examples/MicroservicesAdvanced/composer.json
+++ b/quickstart-examples/MicroservicesAdvanced/composer.json
@@ -18,11 +18,9 @@
         "ecotone/lite-event-sourcing-starter": "^1.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.5",
+        "phpunit/phpunit": "^9.6",
         "wikimedia/composer-merge-plugin": "^2.0"
     },
-    "minimum-stability": "dev",
-    "prefer-stable": true,
     "config": {
         "sort-packages": true,
         "allow-plugins": {
@@ -35,5 +33,7 @@
                 "../../packages/local_packages.json"
             ]
         }
-    }
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true
 }

--- a/quickstart-examples/MultiTenant/General/HookIntoTenantSwitch/composer.json
+++ b/quickstart-examples/MultiTenant/General/HookIntoTenantSwitch/composer.json
@@ -16,11 +16,9 @@
         "ecotone/lite-dbal-starter": "^1.0.1"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.5",
+        "phpunit/phpunit": "^9.6",
         "wikimedia/composer-merge-plugin": "^2.0"
     },
-    "minimum-stability": "dev",
-    "prefer-stable": true,
     "config": {
         "sort-packages": true,
         "allow-plugins": {
@@ -33,5 +31,7 @@
                 "../../../../packages/local_packages.json"
             ]
         }
-    }
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true
 }

--- a/quickstart-examples/MultiTenant/General/HookIntoTenantSwitch/composer.json
+++ b/quickstart-examples/MultiTenant/General/HookIntoTenantSwitch/composer.json
@@ -17,7 +17,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^9.6",
-        "wikimedia/composer-merge-plugin": "^2.0"
+        "wikimedia/composer-merge-plugin": "^2.1"
     },
     "config": {
         "sort-packages": true,

--- a/quickstart-examples/MultiTenant/General/MessageBusForMultipleTenants/composer.json
+++ b/quickstart-examples/MultiTenant/General/MessageBusForMultipleTenants/composer.json
@@ -18,7 +18,7 @@
     "require-dev": {
         "doctrine/orm": "^2.11|^3.0",
         "phpunit/phpunit": "^9.6",
-        "wikimedia/composer-merge-plugin": "^2.0"
+        "wikimedia/composer-merge-plugin": "^2.1"
     },
     "config": {
         "sort-packages": true,

--- a/quickstart-examples/MultiTenant/General/MessageBusForMultipleTenants/composer.json
+++ b/quickstart-examples/MultiTenant/General/MessageBusForMultipleTenants/composer.json
@@ -17,7 +17,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5",
-        "doctrine/orm": "^2.0|^3.0",
+        "doctrine/orm": "^2.11|^3.0",
         "wikimedia/composer-merge-plugin": "^2.0"
     },
     "minimum-stability": "dev",

--- a/quickstart-examples/MultiTenant/General/MessageBusForMultipleTenants/composer.json
+++ b/quickstart-examples/MultiTenant/General/MessageBusForMultipleTenants/composer.json
@@ -16,12 +16,10 @@
         "ecotone/lite-dbal-starter": "^1.0.1"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.5",
         "doctrine/orm": "^2.11|^3.0",
+        "phpunit/phpunit": "^9.6",
         "wikimedia/composer-merge-plugin": "^2.0"
     },
-    "minimum-stability": "dev",
-    "prefer-stable": true,
     "config": {
         "sort-packages": true,
         "allow-plugins": {
@@ -34,5 +32,7 @@
                 "../../../../packages/local_packages.json"
             ]
         }
-    }
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true
 }

--- a/quickstart-examples/MultiTenant/General/RoundRobinWithSingleConsumer/composer.json
+++ b/quickstart-examples/MultiTenant/General/RoundRobinWithSingleConsumer/composer.json
@@ -18,7 +18,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^9.6",
-        "wikimedia/composer-merge-plugin": "^2.0"
+        "wikimedia/composer-merge-plugin": "^2.1"
     },
     "config": {
         "sort-packages": true,

--- a/quickstart-examples/MultiTenant/General/RoundRobinWithSingleConsumer/composer.json
+++ b/quickstart-examples/MultiTenant/General/RoundRobinWithSingleConsumer/composer.json
@@ -17,11 +17,9 @@
         "ecotone/lite-dbal-starter": "^1.0.1"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.5",
+        "phpunit/phpunit": "^9.6",
         "wikimedia/composer-merge-plugin": "^2.0"
     },
-    "minimum-stability": "dev",
-    "prefer-stable": true,
     "config": {
         "sort-packages": true,
         "allow-plugins": {
@@ -34,5 +32,7 @@
                 "../../../../packages/local_packages.json"
             ]
         }
-    }
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true
 }

--- a/quickstart-examples/MultiTenant/Laravel/Aggregate/composer.json
+++ b/quickstart-examples/MultiTenant/Laravel/Aggregate/composer.json
@@ -19,7 +19,7 @@
     "require-dev": {
         "doctrine/orm": "^2.11|^3.0",
         "phpunit/phpunit": "^9.6",
-        "wikimedia/composer-merge-plugin": "^2.0"
+        "wikimedia/composer-merge-plugin": "^2.1"
     },
     "config": {
         "sort-packages": true,

--- a/quickstart-examples/MultiTenant/Laravel/Aggregate/composer.json
+++ b/quickstart-examples/MultiTenant/Laravel/Aggregate/composer.json
@@ -17,12 +17,10 @@
         "laravel/laravel": "^10.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.5",
         "doctrine/orm": "^2.11|^3.0",
+        "phpunit/phpunit": "^9.6",
         "wikimedia/composer-merge-plugin": "^2.0"
     },
-    "minimum-stability": "dev",
-    "prefer-stable": true,
     "config": {
         "sort-packages": true,
         "allow-plugins": {
@@ -35,5 +33,7 @@
                 "../../../../packages/local_packages.json"
             ]
         }
-    }
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true
 }

--- a/quickstart-examples/MultiTenant/Laravel/Aggregate/composer.json
+++ b/quickstart-examples/MultiTenant/Laravel/Aggregate/composer.json
@@ -18,7 +18,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5",
-        "doctrine/orm": "^2.0|^3.0",
+        "doctrine/orm": "^2.11|^3.0",
         "wikimedia/composer-merge-plugin": "^2.0"
     },
     "minimum-stability": "dev",

--- a/quickstart-examples/MultiTenant/Laravel/AsynchronousEvents/composer.json
+++ b/quickstart-examples/MultiTenant/Laravel/AsynchronousEvents/composer.json
@@ -20,7 +20,7 @@
     "require-dev": {
         "doctrine/orm": "^2.11|^3.0",
         "phpunit/phpunit": "^9.6",
-        "wikimedia/composer-merge-plugin": "^2.0"
+        "wikimedia/composer-merge-plugin": "^2.1"
     },
     "config": {
         "sort-packages": true,

--- a/quickstart-examples/MultiTenant/Laravel/AsynchronousEvents/composer.json
+++ b/quickstart-examples/MultiTenant/Laravel/AsynchronousEvents/composer.json
@@ -19,7 +19,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5",
-        "doctrine/orm": "^2.0|^3.0",
+        "doctrine/orm": "^2.11|^3.0",
         "wikimedia/composer-merge-plugin": "^2.0"
     },
     "minimum-stability": "dev",

--- a/quickstart-examples/MultiTenant/Laravel/AsynchronousEvents/composer.json
+++ b/quickstart-examples/MultiTenant/Laravel/AsynchronousEvents/composer.json
@@ -13,17 +13,15 @@
         }
     },
     "require": {
-        "ecotone/lite-dbal-starter": "^1.0.1",
         "ecotone/laravel-starter": "^1.1.0",
+        "ecotone/lite-dbal-starter": "^1.0.1",
         "laravel/laravel": "^10.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.5",
         "doctrine/orm": "^2.11|^3.0",
+        "phpunit/phpunit": "^9.6",
         "wikimedia/composer-merge-plugin": "^2.0"
     },
-    "minimum-stability": "dev",
-    "prefer-stable": true,
     "config": {
         "sort-packages": true,
         "allow-plugins": {
@@ -36,5 +34,7 @@
                 "../../../../packages/local_packages.json"
             ]
         }
-    }
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true
 }

--- a/quickstart-examples/MultiTenant/Laravel/EventSourcing/composer.json
+++ b/quickstart-examples/MultiTenant/Laravel/EventSourcing/composer.json
@@ -20,7 +20,7 @@
     "require-dev": {
         "doctrine/orm": "^2.11|^3.0",
         "phpunit/phpunit": "^9.6",
-        "wikimedia/composer-merge-plugin": "^2.0"
+        "wikimedia/composer-merge-plugin": "^2.1"
     },
     "config": {
         "sort-packages": true,

--- a/quickstart-examples/MultiTenant/Laravel/EventSourcing/composer.json
+++ b/quickstart-examples/MultiTenant/Laravel/EventSourcing/composer.json
@@ -18,12 +18,10 @@
         "laravel/laravel": "^10.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.5",
         "doctrine/orm": "^2.11|^3.0",
+        "phpunit/phpunit": "^9.6",
         "wikimedia/composer-merge-plugin": "^2.0"
     },
-    "minimum-stability": "dev",
-    "prefer-stable": true,
     "config": {
         "sort-packages": true,
         "allow-plugins": {
@@ -36,5 +34,7 @@
                 "../../../../packages/local_packages.json"
             ]
         }
-    }
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true
 }

--- a/quickstart-examples/MultiTenant/Laravel/EventSourcing/composer.json
+++ b/quickstart-examples/MultiTenant/Laravel/EventSourcing/composer.json
@@ -19,7 +19,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5",
-        "doctrine/orm": "^2.0|^3.0",
+        "doctrine/orm": "^2.11|^3.0",
         "wikimedia/composer-merge-plugin": "^2.0"
     },
     "minimum-stability": "dev",

--- a/quickstart-examples/MultiTenant/Laravel/Events/composer.json
+++ b/quickstart-examples/MultiTenant/Laravel/Events/composer.json
@@ -19,7 +19,7 @@
     "require-dev": {
         "doctrine/orm": "^2.11|^3.0",
         "phpunit/phpunit": "^9.6",
-        "wikimedia/composer-merge-plugin": "^2.0"
+        "wikimedia/composer-merge-plugin": "^2.1"
     },
     "config": {
         "sort-packages": true,

--- a/quickstart-examples/MultiTenant/Laravel/Events/composer.json
+++ b/quickstart-examples/MultiTenant/Laravel/Events/composer.json
@@ -17,12 +17,10 @@
         "laravel/laravel": "^10.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.5",
         "doctrine/orm": "^2.11|^3.0",
+        "phpunit/phpunit": "^9.6",
         "wikimedia/composer-merge-plugin": "^2.0"
     },
-    "minimum-stability": "dev",
-    "prefer-stable": true,
     "config": {
         "sort-packages": true,
         "allow-plugins": {
@@ -35,5 +33,7 @@
                 "../../../../packages/local_packages.json"
             ]
         }
-    }
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true
 }

--- a/quickstart-examples/MultiTenant/Laravel/Events/composer.json
+++ b/quickstart-examples/MultiTenant/Laravel/Events/composer.json
@@ -18,7 +18,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5",
-        "doctrine/orm": "^2.0|^3.0",
+        "doctrine/orm": "^2.11|^3.0",
         "wikimedia/composer-merge-plugin": "^2.0"
     },
     "minimum-stability": "dev",

--- a/quickstart-examples/MultiTenant/Laravel/MessageBus/composer.json
+++ b/quickstart-examples/MultiTenant/Laravel/MessageBus/composer.json
@@ -19,7 +19,7 @@
     "require-dev": {
         "doctrine/orm": "^2.11|^3.0",
         "phpunit/phpunit": "^9.6",
-        "wikimedia/composer-merge-plugin": "^2.0"
+        "wikimedia/composer-merge-plugin": "^2.1"
     },
     "config": {
         "sort-packages": true,

--- a/quickstart-examples/MultiTenant/Laravel/MessageBus/composer.json
+++ b/quickstart-examples/MultiTenant/Laravel/MessageBus/composer.json
@@ -17,12 +17,10 @@
         "laravel/laravel": "^10.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.5",
         "doctrine/orm": "^2.11|^3.0",
+        "phpunit/phpunit": "^9.6",
         "wikimedia/composer-merge-plugin": "^2.0"
     },
-    "minimum-stability": "dev",
-    "prefer-stable": true,
     "config": {
         "sort-packages": true,
         "allow-plugins": {
@@ -35,5 +33,7 @@
                 "../../../../packages/local_packages.json"
             ]
         }
-    }
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true
 }

--- a/quickstart-examples/MultiTenant/Laravel/MessageBus/composer.json
+++ b/quickstart-examples/MultiTenant/Laravel/MessageBus/composer.json
@@ -18,7 +18,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5",
-        "doctrine/orm": "^2.0|^3.0",
+        "doctrine/orm": "^2.11|^3.0",
         "wikimedia/composer-merge-plugin": "^2.0"
     },
     "minimum-stability": "dev",

--- a/quickstart-examples/MultiTenant/Symfony/Aggregate/composer.json
+++ b/quickstart-examples/MultiTenant/Symfony/Aggregate/composer.json
@@ -21,7 +21,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5",
-        "doctrine/orm": "^2.0|^3.0",
+        "doctrine/orm": "^2.11|^3.0",
         "wikimedia/composer-merge-plugin": "^2.0"
     },
     "minimum-stability": "dev",

--- a/quickstart-examples/MultiTenant/Symfony/Aggregate/composer.json
+++ b/quickstart-examples/MultiTenant/Symfony/Aggregate/composer.json
@@ -22,7 +22,7 @@
     "require-dev": {
         "doctrine/orm": "^2.11|^3.0",
         "phpunit/phpunit": "^9.6",
-        "wikimedia/composer-merge-plugin": "^2.0"
+        "wikimedia/composer-merge-plugin": "^2.1"
     },
     "config": {
         "sort-packages": true,

--- a/quickstart-examples/MultiTenant/Symfony/Aggregate/composer.json
+++ b/quickstart-examples/MultiTenant/Symfony/Aggregate/composer.json
@@ -20,12 +20,10 @@
         "symfony/yaml": "^7.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.5",
         "doctrine/orm": "^2.11|^3.0",
+        "phpunit/phpunit": "^9.6",
         "wikimedia/composer-merge-plugin": "^2.0"
     },
-    "minimum-stability": "dev",
-    "prefer-stable": true,
     "config": {
         "sort-packages": true,
         "allow-plugins": {
@@ -38,5 +36,7 @@
                 "../../../../packages/local_packages.json"
             ]
         }
-    }
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true
 }

--- a/quickstart-examples/MultiTenant/Symfony/AsynchronousEvents/composer.json
+++ b/quickstart-examples/MultiTenant/Symfony/AsynchronousEvents/composer.json
@@ -23,7 +23,7 @@
     "require-dev": {
         "doctrine/orm": "^2.11|^3.0",
         "phpunit/phpunit": "^9.6",
-        "wikimedia/composer-merge-plugin": "^2.0"
+        "wikimedia/composer-merge-plugin": "^2.1"
     },
     "config": {
         "sort-packages": true,

--- a/quickstart-examples/MultiTenant/Symfony/AsynchronousEvents/composer.json
+++ b/quickstart-examples/MultiTenant/Symfony/AsynchronousEvents/composer.json
@@ -22,7 +22,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5",
-        "doctrine/orm": "^2.0|^3.0",
+        "doctrine/orm": "^2.11|^3.0",
         "wikimedia/composer-merge-plugin": "^2.0"
     },
     "minimum-stability": "dev",

--- a/quickstart-examples/MultiTenant/Symfony/AsynchronousEvents/composer.json
+++ b/quickstart-examples/MultiTenant/Symfony/AsynchronousEvents/composer.json
@@ -21,12 +21,10 @@
         "symfony/yaml": "^7.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.5",
         "doctrine/orm": "^2.11|^3.0",
+        "phpunit/phpunit": "^9.6",
         "wikimedia/composer-merge-plugin": "^2.0"
     },
-    "minimum-stability": "dev",
-    "prefer-stable": true,
     "config": {
         "sort-packages": true,
         "allow-plugins": {
@@ -39,5 +37,7 @@
                 "../../../../packages/local_packages.json"
             ]
         }
-    }
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true
 }

--- a/quickstart-examples/MultiTenant/Symfony/EventSourcing/composer.json
+++ b/quickstart-examples/MultiTenant/Symfony/EventSourcing/composer.json
@@ -23,7 +23,7 @@
     "require-dev": {
         "doctrine/orm": "^2.11|^3.0",
         "phpunit/phpunit": "^9.6",
-        "wikimedia/composer-merge-plugin": "^2.0"
+        "wikimedia/composer-merge-plugin": "^2.1"
     },
     "config": {
         "sort-packages": true,

--- a/quickstart-examples/MultiTenant/Symfony/EventSourcing/composer.json
+++ b/quickstart-examples/MultiTenant/Symfony/EventSourcing/composer.json
@@ -22,7 +22,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5",
-        "doctrine/orm": "^2.0|^3.0",
+        "doctrine/orm": "^2.11|^3.0",
         "wikimedia/composer-merge-plugin": "^2.0"
     },
     "minimum-stability": "dev",

--- a/quickstart-examples/MultiTenant/Symfony/EventSourcing/composer.json
+++ b/quickstart-examples/MultiTenant/Symfony/EventSourcing/composer.json
@@ -21,12 +21,10 @@
         "symfony/yaml": "^7.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.5",
         "doctrine/orm": "^2.11|^3.0",
+        "phpunit/phpunit": "^9.6",
         "wikimedia/composer-merge-plugin": "^2.0"
     },
-    "minimum-stability": "dev",
-    "prefer-stable": true,
     "config": {
         "sort-packages": true,
         "allow-plugins": {
@@ -39,5 +37,7 @@
                 "../../../../packages/local_packages.json"
             ]
         }
-    }
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true
 }

--- a/quickstart-examples/MultiTenant/Symfony/Events/composer.json
+++ b/quickstart-examples/MultiTenant/Symfony/Events/composer.json
@@ -21,7 +21,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5",
-        "doctrine/orm": "^2.0|^3.0",
+        "doctrine/orm": "^2.11|^3.0",
         "wikimedia/composer-merge-plugin": "^2.0"
     },
     "minimum-stability": "dev",

--- a/quickstart-examples/MultiTenant/Symfony/Events/composer.json
+++ b/quickstart-examples/MultiTenant/Symfony/Events/composer.json
@@ -22,7 +22,7 @@
     "require-dev": {
         "doctrine/orm": "^2.11|^3.0",
         "phpunit/phpunit": "^9.6",
-        "wikimedia/composer-merge-plugin": "^2.0"
+        "wikimedia/composer-merge-plugin": "^2.1"
     },
     "config": {
         "sort-packages": true,

--- a/quickstart-examples/MultiTenant/Symfony/Events/composer.json
+++ b/quickstart-examples/MultiTenant/Symfony/Events/composer.json
@@ -20,12 +20,10 @@
         "symfony/yaml": "^7.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.5",
         "doctrine/orm": "^2.11|^3.0",
+        "phpunit/phpunit": "^9.6",
         "wikimedia/composer-merge-plugin": "^2.0"
     },
-    "minimum-stability": "dev",
-    "prefer-stable": true,
     "config": {
         "sort-packages": true,
         "allow-plugins": {
@@ -38,5 +36,7 @@
                 "../../../../packages/local_packages.json"
             ]
         }
-    }
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true
 }

--- a/quickstart-examples/MultiTenant/Symfony/MessageBus/composer.json
+++ b/quickstart-examples/MultiTenant/Symfony/MessageBus/composer.json
@@ -21,7 +21,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5",
-        "doctrine/orm": "^2.0|^3.0",
+        "doctrine/orm": "^2.11|^3.0",
         "wikimedia/composer-merge-plugin": "^2.0"
     },
     "minimum-stability": "dev",

--- a/quickstart-examples/MultiTenant/Symfony/MessageBus/composer.json
+++ b/quickstart-examples/MultiTenant/Symfony/MessageBus/composer.json
@@ -22,7 +22,7 @@
     "require-dev": {
         "doctrine/orm": "^2.11|^3.0",
         "phpunit/phpunit": "^9.6",
-        "wikimedia/composer-merge-plugin": "^2.0"
+        "wikimedia/composer-merge-plugin": "^2.1"
     },
     "config": {
         "sort-packages": true,

--- a/quickstart-examples/MultiTenant/Symfony/MessageBus/composer.json
+++ b/quickstart-examples/MultiTenant/Symfony/MessageBus/composer.json
@@ -20,12 +20,10 @@
         "symfony/yaml": "^7.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.5",
         "doctrine/orm": "^2.11|^3.0",
+        "phpunit/phpunit": "^9.6",
         "wikimedia/composer-merge-plugin": "^2.0"
     },
-    "minimum-stability": "dev",
-    "prefer-stable": true,
     "config": {
         "sort-packages": true,
         "allow-plugins": {
@@ -38,5 +36,7 @@
                 "../../../../packages/local_packages.json"
             ]
         }
-    }
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true
 }

--- a/quickstart-examples/OutboxPattern/composer.json
+++ b/quickstart-examples/OutboxPattern/composer.json
@@ -17,7 +17,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^9.6",
-        "wikimedia/composer-merge-plugin": "^2.0"
+        "wikimedia/composer-merge-plugin": "^2.1"
     },
     "config": {
         "sort-packages": true,

--- a/quickstart-examples/OutboxPattern/composer.json
+++ b/quickstart-examples/OutboxPattern/composer.json
@@ -16,11 +16,9 @@
         "ecotone/lite-dbal-starter": "^1.0.1"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.5",
+        "phpunit/phpunit": "^9.6",
         "wikimedia/composer-merge-plugin": "^2.0"
     },
-    "minimum-stability": "dev",
-    "prefer-stable": true,
     "config": {
         "sort-packages": true,
         "allow-plugins": {
@@ -33,5 +31,7 @@
                 "../../packages/local_packages.json"
             ]
         }
-    }
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true
 }

--- a/quickstart-examples/RefactorToReactiveSystem/composer.json
+++ b/quickstart-examples/RefactorToReactiveSystem/composer.json
@@ -14,15 +14,13 @@
     },
     "require": {
         "ecotone/lite-dbal-starter": "^1.0.1",
-        "symfony/http-foundation": "^6.0|^7.0",
-        "moneyphp/money": "^4.1.0"
+        "moneyphp/money": "^4.1.0",
+        "symfony/http-foundation": "^6.0|^7.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.5",
+        "phpunit/phpunit": "^9.6",
         "wikimedia/composer-merge-plugin": "^2.0"
     },
-    "minimum-stability": "dev",
-    "prefer-stable": true,
     "config": {
         "sort-packages": true,
         "allow-plugins": {
@@ -35,5 +33,7 @@
                 "../../packages/local_packages.json"
             ]
         }
-    }
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true
 }

--- a/quickstart-examples/RefactorToReactiveSystem/composer.json
+++ b/quickstart-examples/RefactorToReactiveSystem/composer.json
@@ -19,7 +19,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^9.6",
-        "wikimedia/composer-merge-plugin": "^2.0"
+        "wikimedia/composer-merge-plugin": "^2.1"
     },
     "config": {
         "sort-packages": true,

--- a/quickstart-examples/Schedule/composer.json
+++ b/quickstart-examples/Schedule/composer.json
@@ -17,7 +17,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^9.6",
-        "wikimedia/composer-merge-plugin": "^2.0"
+        "wikimedia/composer-merge-plugin": "^2.1"
     },
     "config": {
         "sort-packages": true,

--- a/quickstart-examples/Schedule/composer.json
+++ b/quickstart-examples/Schedule/composer.json
@@ -16,11 +16,9 @@
         "ecotone/lite-dbal-starter": "^1.0.1"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.5",
+        "phpunit/phpunit": "^9.6",
         "wikimedia/composer-merge-plugin": "^2.0"
     },
-    "minimum-stability": "dev",
-    "prefer-stable": true,
     "config": {
         "sort-packages": true,
         "allow-plugins": {
@@ -33,5 +31,7 @@
                 "../../packages/local_packages.json"
             ]
         }
-    }
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true
 }

--- a/quickstart-examples/StatefulProjection/composer.json
+++ b/quickstart-examples/StatefulProjection/composer.json
@@ -17,7 +17,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^9.6",
-        "wikimedia/composer-merge-plugin": "^2.0"
+        "wikimedia/composer-merge-plugin": "^2.1"
     },
     "config": {
         "sort-packages": true,

--- a/quickstart-examples/StatefulProjection/composer.json
+++ b/quickstart-examples/StatefulProjection/composer.json
@@ -16,11 +16,9 @@
         "ecotone/lite-event-sourcing-starter": "^1.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.5",
+        "phpunit/phpunit": "^9.6",
         "wikimedia/composer-merge-plugin": "^2.0"
     },
-    "minimum-stability": "dev",
-    "prefer-stable": true,
     "config": {
         "sort-packages": true,
         "allow-plugins": {
@@ -33,5 +31,7 @@
                 "../../packages/local_packages.json"
             ]
         }
-    }
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true
 }

--- a/quickstart-examples/Testing/composer.json
+++ b/quickstart-examples/Testing/composer.json
@@ -18,15 +18,13 @@
         }
     },
     "require": {
-        "ecotone/lite-event-sourcing-starter": "^1.0",
-        "beberlei/assert": "^3.3.2"
+        "beberlei/assert": "^3.3.2",
+        "ecotone/lite-event-sourcing-starter": "^1.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.5",
+        "phpunit/phpunit": "^9.6",
         "wikimedia/composer-merge-plugin": "^2.0"
     },
-    "minimum-stability": "dev",
-    "prefer-stable": true,
     "config": {
         "sort-packages": true,
         "allow-plugins": {
@@ -39,5 +37,7 @@
                 "../../packages/local_packages.json"
             ]
         }
-    }
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true
 }

--- a/quickstart-examples/Testing/composer.json
+++ b/quickstart-examples/Testing/composer.json
@@ -23,7 +23,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^9.6",
-        "wikimedia/composer-merge-plugin": "^2.0"
+        "wikimedia/composer-merge-plugin": "^2.1"
     },
     "config": {
         "sort-packages": true,

--- a/quickstart-examples/Workflows/AsynchronousStateless/composer.json
+++ b/quickstart-examples/Workflows/AsynchronousStateless/composer.json
@@ -22,12 +22,10 @@
         "intervention/image": "^3.5.1"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.5",
         "doctrine/orm": "^2.11|^3.0",
+        "phpunit/phpunit": "^9.6",
         "wikimedia/composer-merge-plugin": "^2.0"
     },
-    "minimum-stability": "dev",
-    "prefer-stable": true,
     "config": {
         "sort-packages": true,
         "allow-plugins": {
@@ -40,5 +38,7 @@
                 "../../../packages/local_packages.json"
             ]
         }
-    }
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true
 }

--- a/quickstart-examples/Workflows/AsynchronousStateless/composer.json
+++ b/quickstart-examples/Workflows/AsynchronousStateless/composer.json
@@ -24,7 +24,7 @@
     "require-dev": {
         "doctrine/orm": "^2.11|^3.0",
         "phpunit/phpunit": "^9.6",
-        "wikimedia/composer-merge-plugin": "^2.0"
+        "wikimedia/composer-merge-plugin": "^2.1"
     },
     "config": {
         "sort-packages": true,

--- a/quickstart-examples/Workflows/AsynchronousStateless/composer.json
+++ b/quickstart-examples/Workflows/AsynchronousStateless/composer.json
@@ -23,7 +23,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5",
-        "doctrine/orm": "^2.0|^3.0",
+        "doctrine/orm": "^2.11|^3.0",
         "wikimedia/composer-merge-plugin": "^2.0"
     },
     "minimum-stability": "dev",

--- a/quickstart-examples/Workflows/Saga/composer.json
+++ b/quickstart-examples/Workflows/Saga/composer.json
@@ -25,7 +25,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5",
-        "doctrine/orm": "^2.0|^3.0",
+        "doctrine/orm": "^2.11|^3.0",
         "wikimedia/composer-merge-plugin": "^2.0"
     },
     "minimum-stability": "dev",

--- a/quickstart-examples/Workflows/Saga/composer.json
+++ b/quickstart-examples/Workflows/Saga/composer.json
@@ -26,7 +26,7 @@
     "require-dev": {
         "doctrine/orm": "^2.11|^3.0",
         "phpunit/phpunit": "^9.6",
-        "wikimedia/composer-merge-plugin": "^2.0"
+        "wikimedia/composer-merge-plugin": "^2.1"
     },
     "config": {
         "sort-packages": true,

--- a/quickstart-examples/Workflows/Saga/composer.json
+++ b/quickstart-examples/Workflows/Saga/composer.json
@@ -24,12 +24,10 @@
         "webmozart/assert": "^1.11"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.5",
         "doctrine/orm": "^2.11|^3.0",
+        "phpunit/phpunit": "^9.6",
         "wikimedia/composer-merge-plugin": "^2.0"
     },
-    "minimum-stability": "dev",
-    "prefer-stable": true,
     "config": {
         "sort-packages": true,
         "allow-plugins": {
@@ -42,5 +40,7 @@
                 "../../../packages/local_packages.json"
             ]
         }
-    }
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true
 }

--- a/quickstart-examples/Workflows/SynchronousStateless/composer.json
+++ b/quickstart-examples/Workflows/SynchronousStateless/composer.json
@@ -22,12 +22,10 @@
         "intervention/image": "^3.5.1"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.5",
         "doctrine/orm": "^2.11|^3.0",
+        "phpunit/phpunit": "^9.6",
         "wikimedia/composer-merge-plugin": "^2.0"
     },
-    "minimum-stability": "dev",
-    "prefer-stable": true,
     "config": {
         "sort-packages": true,
         "allow-plugins": {
@@ -40,5 +38,7 @@
                 "../../../packages/local_packages.json"
             ]
         }
-    }
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true
 }

--- a/quickstart-examples/Workflows/SynchronousStateless/composer.json
+++ b/quickstart-examples/Workflows/SynchronousStateless/composer.json
@@ -24,7 +24,7 @@
     "require-dev": {
         "doctrine/orm": "^2.11|^3.0",
         "phpunit/phpunit": "^9.6",
-        "wikimedia/composer-merge-plugin": "^2.0"
+        "wikimedia/composer-merge-plugin": "^2.1"
     },
     "config": {
         "sort-packages": true,

--- a/quickstart-examples/Workflows/SynchronousStateless/composer.json
+++ b/quickstart-examples/Workflows/SynchronousStateless/composer.json
@@ -23,7 +23,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5",
-        "doctrine/orm": "^2.0|^3.0",
+        "doctrine/orm": "^2.11|^3.0",
         "wikimedia/composer-merge-plugin": "^2.0"
     },
     "minimum-stability": "dev",

--- a/quickstart-examples/WorkingWithAggregateDirectly/composer.json
+++ b/quickstart-examples/WorkingWithAggregateDirectly/composer.json
@@ -17,7 +17,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^9.6",
-        "wikimedia/composer-merge-plugin": "^2.0"
+        "wikimedia/composer-merge-plugin": "^2.1"
     },
     "config": {
         "sort-packages": true,

--- a/quickstart-examples/WorkingWithAggregateDirectly/composer.json
+++ b/quickstart-examples/WorkingWithAggregateDirectly/composer.json
@@ -16,11 +16,9 @@
         "ecotone/lite-event-sourcing-starter": "^1.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.5",
+        "phpunit/phpunit": "^9.6",
         "wikimedia/composer-merge-plugin": "^2.0"
     },
-    "minimum-stability": "dev",
-    "prefer-stable": true,
     "config": {
         "sort-packages": true,
         "allow-plugins": {
@@ -33,5 +31,7 @@
                 "../../packages/local_packages.json"
             ]
         }
-    }
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true
 }


### PR DESCRIPTION
## Description

`prefer-lowest` on Monorepo is inconsistent because of the high number of packages conflicting with lowest versions. To get a more accurate test on version constraints, the `prefer-lowest` strategy is applied during split testing.

Some package dependencies have been updated to make tests pass

## Type of change

- CI

<!--
Please note that by submitting this pull request, you agree to the contribution terms defined in [CONTRIBUTING.md](https://github.com/ecotoneframework/ecotone-dev/blob/main/CONTRIBUTING.md). This part of the template must not be removed.
-->