### PR TITLE
ci: fix main ci by installing laminas/laminas-zendframework-bridge

### DIFF
--- a/.github/workflows/split-testing.yml
+++ b/.github/workflows/split-testing.yml
@@ -107,6 +107,11 @@ jobs:
         run: composer global config --no-interaction allow-plugins.wikimedia/composer-merge-plugin true && composer global require wikimedia/composer-merge-plugin
         working-directory: ${{ matrix.package.directory }}
 
+      - name: Install laminas/laminas-zendframework-bridge if necessary
+        working-directory: ${{ matrix.package.directory }}
+        if: "matrix.stability == 'prefer-lowest' &&  matrix.package.name == 'symfony-bundle'"
+        run: composer require laminas/laminas-zendframework-bridge:^1.0.0 --no-interaction --no-update
+
       - name: Install dependencies
         run: composer update  --${{ matrix.stability }} --no-interaction
         working-directory: ${{ matrix.package.directory }}


### PR DESCRIPTION
## Description

Install `laminas/laminas-zendframework-bridge` on `prefer-lowest` for symfony-bundle

## Type of change

- CI

<!--
Please note that by submitting this pull request, you agree to the contribution terms defined in [CONTRIBUTING.md](https://github.com/ecotoneframework/ecotone-dev/blob/main/CONTRIBUTING.md). This part of the template must not be removed.
-->