### PR TITLE
Register polling metadata only for polled endpoints

### DIFF
--- a/packages/Ecotone/src/Messaging/Config/Container/ContainerBuilder.php
+++ b/packages/Ecotone/src/Messaging/Config/Container/ContainerBuilder.php
@@ -4,7 +4,7 @@ namespace Ecotone\Messaging\Config\Container;
 
 use Ecotone\Messaging\Config\Container\Compiler\CompilerPass;
 use Ecotone\Messaging\Config\DefinedObjectWrapper;
-use InvalidArgumentException;
+use Ecotone\Messaging\Support\InvalidArgumentException;
 
 /**
  * licence Apache-2.0
@@ -33,7 +33,7 @@ class ContainerBuilder
     public function register(string $id, DefinedObject|Definition|Reference $definition): Reference
     {
         if (isset($this->definitions[$id])) {
-            throw new InvalidArgumentException("Definition with id {$id} already exists");
+            throw InvalidArgumentException::create("Definition with id {$id} already exists");
         }
         return $this->replace($id, $definition);
     }
@@ -52,7 +52,7 @@ class ContainerBuilder
 
     public function getDefinition(string $id): Definition|Reference
     {
-        return $this->definitions[$id];
+        return $this->definitions[$id] ?? throw InvalidArgumentException::create("Definition with id {$id} not found");
     }
 
     /**

--- a/packages/Ecotone/src/Messaging/Config/MessagingSystemConfiguration.php
+++ b/packages/Ecotone/src/Messaging/Config/MessagingSystemConfiguration.php
@@ -28,7 +28,6 @@ use Ecotone\Messaging\Config\Container\ContainerConfig;
 use Ecotone\Messaging\Config\Container\Definition;
 use Ecotone\Messaging\Config\Container\GatewayProxyReference;
 use Ecotone\Messaging\Config\Container\MessagingContainerBuilder;
-use Ecotone\Messaging\Config\Container\PollingMetadataReference;
 use Ecotone\Messaging\Config\Container\Reference;
 use Ecotone\Messaging\ConfigurationVariableService;
 use Ecotone\Messaging\Conversion\AutoCollectionConversionService;
@@ -274,13 +273,6 @@ final class MessagingSystemConfiguration implements Configuration
         $this->configureDefaultMessageChannels();
         $this->configureAsynchronousEndpoints();
         $this->configureInterceptors($interfaceToCallRegistry);
-
-        foreach ($this->messageHandlerBuilders as $messageHandlerBuilder) {
-            $this->addDefaultPollingConfiguration($messageHandlerBuilder->getEndpointId());
-        }
-        foreach ($this->channelAdapters as $channelAdapter) {
-            $this->addDefaultPollingConfiguration($channelAdapter->getEndpointId());
-        }
 
         foreach ($this->requiredConsumerEndpointIds as $requiredConsumerEndpointId) {
             if (! array_key_exists($requiredConsumerEndpointId, $this->messageHandlerBuilders) && ! array_key_exists($requiredConsumerEndpointId, $this->channelAdapters)) {
@@ -601,29 +593,6 @@ final class MessagingSystemConfiguration implements Configuration
         $this->beforeCallMethodInterceptors = [];
         $this->aroundMethodInterceptors = [];
         $this->afterCallMethodInterceptors = [];
-    }
-
-    private function addDefaultPollingConfiguration($endpointId): void
-    {
-        $pollingMetadata = PollingMetadata::create((string)$endpointId);
-        if (array_key_exists($endpointId, $this->pollingMetadata)) {
-            $pollingMetadata = $this->pollingMetadata[$endpointId];
-        }
-
-        if ($this->applicationConfiguration->getDefaultErrorChannel() && $pollingMetadata->isErrorChannelEnabled() && ! $pollingMetadata->getErrorChannelName()) {
-            $pollingMetadata = $pollingMetadata
-                ->setErrorChannelName($this->applicationConfiguration->getDefaultErrorChannel());
-        }
-        if ($this->applicationConfiguration->getDefaultMemoryLimitInMegabytes() && ! $pollingMetadata->getMemoryLimitInMegabytes()) {
-            $pollingMetadata = $pollingMetadata
-                ->setMemoryLimitInMegaBytes($this->applicationConfiguration->getDefaultMemoryLimitInMegabytes());
-        }
-        if ($this->applicationConfiguration->getConnectionRetryTemplate() && ! $pollingMetadata->getConnectionRetryTemplate()) {
-            $pollingMetadata = $pollingMetadata
-                ->setConnectionRetryTemplate($this->applicationConfiguration->getConnectionRetryTemplate());
-        }
-
-        $this->pollingMetadata[$endpointId] = $pollingMetadata;
     }
 
     private function hasMessageHandlerWithName(PollingMetadata $pollingMetadata): bool
@@ -1058,7 +1027,7 @@ final class MessagingSystemConfiguration implements Configuration
     {
         $this->prepareAndOptimizeConfiguration($this->interfaceToCallRegistry, $this->applicationConfiguration);
 
-        $messagingBuilder = new MessagingContainerBuilder($builder, $this->interfaceToCallRegistry, $this->applicationConfiguration);
+        $messagingBuilder = new MessagingContainerBuilder($builder, $this->interfaceToCallRegistry, $this->applicationConfiguration, $this->pollingMetadata);
 
         foreach ($this->serviceDefinitions as $id => $definition) {
             $messagingBuilder->register($id, $definition);
@@ -1080,10 +1049,6 @@ final class MessagingSystemConfiguration implements Configuration
             foreach ($channelInterceptors as $channelInterceptor) {
                 $channelInterceptorsByChannelName[$channelInterceptor->relatedChannelName()][] = $channelInterceptor;
             }
-        }
-
-        foreach ($this->pollingMetadata as $pollingMetadata) {
-            $messagingBuilder->register(new PollingMetadataReference($pollingMetadata->getEndpointId()), $pollingMetadata);
         }
 
         foreach ($this->channelBuilders as $channelsBuilder) {

--- a/packages/Ecotone/src/Messaging/Endpoint/PollingConsumer/InterceptedPollingConsumerBuilder.php
+++ b/packages/Ecotone/src/Messaging/Endpoint/PollingConsumer/InterceptedPollingConsumerBuilder.php
@@ -126,11 +126,6 @@ abstract class InterceptedPollingConsumerBuilder implements MessageHandlerConsum
     public function registerConsumer(MessagingContainerBuilder $builder, MessageHandlerBuilder $messageHandlerBuilder): void
     {
         $endpointId = $messageHandlerBuilder->getEndpointId();
-        if ($this->withContinuesPolling()) {
-            $pollingMetadata = $builder->getPollingMetadata($endpointId);
-            $pollingMetadata = $pollingMetadata->setFixedRateInMilliseconds(1);
-            $builder->registerPollingMetadata($pollingMetadata);
-        }
         $requestChannelName = 'internal_inbound_gateway_channel.'.Uuid::uuid4()->toString();
         $connectionChannel = new Definition(DirectChannel::class, [
             $requestChannelName,
@@ -170,7 +165,7 @@ abstract class InterceptedPollingConsumerBuilder implements MessageHandlerConsum
             new Reference(LoggerInterface::class),
             new Reference(MessagingEntrypoint::class),
         ]);
-        $builder->registerPollingEndpoint($endpointId, $consumerRunner);
+        $builder->registerPollingEndpoint($endpointId, $consumerRunner, $this->withContinuesPolling());
     }
 
     private function getErrorInterceptorReference(MessagingContainerBuilder $builder): AroundInterceptorBuilder


### PR DESCRIPTION
## Description

Every endpoint has some default PollingMetadata registered in the container even if it is not a polled endpoint.
This PR registers PollingMetadata only for polled endpoints.
On a medium sized Symfony repository, I get a 10% speedup on cache:clear.

## Type of change

- Performance

<!--
Please note that by submitting this pull request, you agree to the contribution terms defined in [CONTRIBUTING.md](https://github.com/ecotoneframework/ecotone-dev/blob/main/CONTRIBUTING.md). This part of the template must not be removed.
-->