### PR TITLE
Lower stack size of around interceptors

### DIFF
--- a/packages/Ecotone/src/Messaging/Handler/Processor/MethodInvoker/AroundMethodInterceptor.php
+++ b/packages/Ecotone/src/Messaging/Handler/Processor/MethodInvoker/AroundMethodInterceptor.php
@@ -40,7 +40,7 @@ class AroundMethodInterceptor
         return new self($referenceToCall, $interfaceToCall, $parameterConverters, $hasMethodInvocation);
     }
 
-    public function invoke(MethodInvocation $methodInvocation, Message $requestMessage)
+    public function getArguments(MethodInvocation $methodInvocation, Message $requestMessage): array
     {
         $argumentsToCall           = [];
 
@@ -52,12 +52,21 @@ class AroundMethodInterceptor
             );
         }
 
-        $returnValue = $this->referenceToCall->{$this->interceptorInterfaceToCall->getMethodName()}(...$argumentsToCall);
+        return $argumentsToCall;
+    }
 
-        if (! $this->hasMethodInvocation) {
-            return $methodInvocation->proceed();
-        }
+    public function getReferenceToCall(): object
+    {
+        return $this->referenceToCall;
+    }
 
-        return $returnValue;
+    public function getMethodName(): string
+    {
+        return $this->interceptorInterfaceToCall->getMethodName();
+    }
+
+    public function hasMethodInvocation(): bool
+    {
+        return $this->hasMethodInvocation;
     }
 }


### PR DESCRIPTION
## Description

Lower call stack for around interceptors.
Checked on my project, the stack size for calling a command handler in an aggregate went from 72 to 64.

## Type of change

- Optimization

<!--
By submitting this pull request, you agree to the contribution terms defined in [CONTRIBUTING.md](https://github.com/ecotoneframework/ecotone-dev/blob/main/CONTRIBUTING.md).
-->