### PR TITLE
In process channel

### DIFF
--- a/packages/Ecotone/src/Messaging/Channel/InProcessChannel.php
+++ b/packages/Ecotone/src/Messaging/Channel/InProcessChannel.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace Ecotone\Messaging\Channel;
+
+use Ecotone\Messaging\Config\Container\DefinedObject;
+use Ecotone\Messaging\Config\Container\Definition;
+use Ecotone\Messaging\Message;
+use Ecotone\Messaging\MessageChannel;
+use Ecotone\Messaging\MessageHandler;
+use Ecotone\Messaging\MessageHeaders;
+use Ecotone\Messaging\SubscribableChannel;
+use Ecotone\Messaging\Support\MessageBuilder;
+
+class InProcessChannel implements SubscribableChannel, DefinedObject
+{
+    private array $messageStack = [];
+    private string|MessageChannel|null $currentReplyChannel = null;
+
+    public function __construct(private string $messageChannelName, private ?MessageHandler $messageHandler = null)
+    {
+    }
+
+    public static function create(string $messageChannelName = ''): self
+    {
+        return new self($messageChannelName);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function send(Message $message): void
+    {
+        if (! $this->messageHandler) {
+            throw MessageDispatchingException::create("There is no message handler registered for dispatching Message {$message}");
+        }
+        if ($message->getHeaders()->containsKey(MessageHeaders::IN_PROCESS_EXECUTOR)) {
+            $executor = $message->getHeaders()->get(MessageHeaders::IN_PROCESS_EXECUTOR);
+            if ($executor->canHandleMessage($message)) {
+                $executor->push($this->messageHandler, $message);
+                return;
+            }
+        }
+
+        if ($message->getHeaders()->containsKey(MessageHeaders::REPLY_CHANNEL)) {
+            $this->currentReplyChannel = $message->getHeaders()->get(MessageHeaders::REPLY_CHANNEL);
+        }
+        $message = MessageBuilder::fromMessage($message)
+            ->setHeader(MessageHeaders::IN_PROCESS_EXECUTOR, $this)
+            ->build();
+        $this->messageHandler->handle($message);
+        while ([$messageHandler, $message] = array_shift($this->messageStack)) {
+            $messageHandler->handle($message);
+        }
+    }
+
+    public function push(MessageHandler $messageHandler, Message $message): void
+    {
+        $this->messageStack[] = [$messageHandler, $message];
+    }
+
+    public function canHandleMessage(Message $message): bool
+    {
+        if ($message->getHeaders()->containsKey(MessageHeaders::REPLY_CHANNEL)) {
+            return $this->currentReplyChannel === $message->getHeaders()->get(MessageHeaders::REPLY_CHANNEL);
+        }
+        return true;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function subscribe(MessageHandler $messageHandler): void
+    {
+        if ($this->messageHandler) {
+            throw WrongHandlerAmountException::create("Direct channel {$this->messageChannelName} have registered more than one handler. {$messageHandler} can't be registered as second handler for unicasting dispatcher. The first is {$this->messageHandler}");
+        }
+
+        $this->messageHandler = $messageHandler;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function unsubscribe(MessageHandler $messageHandler): void
+    {
+        $this->messageHandler = null;
+    }
+
+    public function __toString()
+    {
+        return 'direct: ' . $this->messageChannelName;
+    }
+
+    public function getDefinition(): Definition
+    {
+        return new Definition(self::class, [$this->messageChannelName]);
+    }
+}

--- a/packages/Ecotone/src/Messaging/Channel/SimpleMessageChannelBuilder.php
+++ b/packages/Ecotone/src/Messaging/Channel/SimpleMessageChannelBuilder.php
@@ -44,12 +44,12 @@ class SimpleMessageChannelBuilder implements MessageChannelWithSerializationBuil
 
     public static function createDirectMessageChannel(string $messageChannelName): self
     {
-        return self::create($messageChannelName, DirectChannel::create($messageChannelName), null);
+        return self::create($messageChannelName, InProcessChannel::createDirectChannel($messageChannelName));
     }
 
     public static function createPublishSubscribeChannel(string $messageChannelName): self
     {
-        return self::create($messageChannelName, PublishSubscribeChannel::create($messageChannelName), null);
+        return self::create($messageChannelName, InProcessChannel::createPublishSubscribeChannel($messageChannelName));
     }
 
     public static function createQueueChannel(string $messageChannelName, bool $delayable = false, string|MediaType|null $conversionMediaType = null): self

--- a/packages/Ecotone/src/Messaging/Config/Annotation/ModuleConfiguration/MethodInterceptor/BeforeSendChannelInterceptorBuilder.php
+++ b/packages/Ecotone/src/Messaging/Config/Annotation/ModuleConfiguration/MethodInterceptor/BeforeSendChannelInterceptorBuilder.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Ecotone\Messaging\Config\Annotation\ModuleConfiguration\MethodInterceptor;
 
 use Ecotone\Messaging\Channel\ChannelInterceptorBuilder;
-use Ecotone\Messaging\Channel\DirectChannel;
+use Ecotone\Messaging\Channel\InProcessChannel;
 use Ecotone\Messaging\Config\Container\ChannelReference;
 use Ecotone\Messaging\Config\Container\Definition;
 use Ecotone\Messaging\Config\Container\MessagingContainerBuilder;
@@ -54,7 +54,7 @@ class BeforeSendChannelInterceptorBuilder implements ChannelInterceptorBuilder
     public function compile(MessagingContainerBuilder $builder): Definition
     {
         $messageHandler = $this->methodInterceptor->getInterceptingObject()->compile($builder);
-        $builder->register(new ChannelReference($this->internalRequestChannelName), new Definition(DirectChannel::class, [$this->internalRequestChannelName, $messageHandler]));
+        $builder->register(new ChannelReference($this->internalRequestChannelName), new Definition(InProcessChannel::class, [$this->internalRequestChannelName, $messageHandler], factory: [InProcessChannel::class, 'createDirectChannel']));
         $gateway = $this->gateway->compile($builder);
 
         return new Definition(BeforeSendChannelInterceptor::class, [$gateway]);

--- a/packages/Ecotone/src/Messaging/Endpoint/PollingConsumer/InterceptedPollingConsumerBuilder.php
+++ b/packages/Ecotone/src/Messaging/Endpoint/PollingConsumer/InterceptedPollingConsumerBuilder.php
@@ -3,7 +3,7 @@
 namespace Ecotone\Messaging\Endpoint\PollingConsumer;
 
 use Ecotone\Messaging\Attribute\AsynchronousRunningEndpoint;
-use Ecotone\Messaging\Channel\DirectChannel;
+use Ecotone\Messaging\Channel\InProcessChannel;
 use Ecotone\Messaging\Channel\MessageChannelBuilder;
 use Ecotone\Messaging\Config\Container\AttributeDefinition;
 use Ecotone\Messaging\Config\Container\ChannelReference;
@@ -127,10 +127,10 @@ abstract class InterceptedPollingConsumerBuilder implements MessageHandlerConsum
     {
         $endpointId = $messageHandlerBuilder->getEndpointId();
         $requestChannelName = 'internal_inbound_gateway_channel.'.Uuid::uuid4()->toString();
-        $connectionChannel = new Definition(DirectChannel::class, [
+        $connectionChannel = new Definition(InProcessChannel::class, [
             $requestChannelName,
             $messageHandlerBuilder->compile($builder),
-        ]);
+        ], factory: [InProcessChannel::class, 'createDirectChannel']);
         $builder->register(new ChannelReference($requestChannelName), $connectionChannel);
         $gatewayBuilder = GatewayProxyBuilder::create(
             'handler',

--- a/packages/Ecotone/src/Messaging/Handler/Chain/ChainMessageHandlerBuilder.php
+++ b/packages/Ecotone/src/Messaging/Handler/Chain/ChainMessageHandlerBuilder.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Ecotone\Messaging\Handler\Chain;
 
-use Ecotone\Messaging\Channel\DirectChannel;
 use Ecotone\Messaging\Channel\InProcessChannel;
 use Ecotone\Messaging\Config\Container\ChannelReference;
 use Ecotone\Messaging\Config\Container\Definition;
@@ -123,14 +122,10 @@ class ChainMessageHandlerBuilder extends InputOutputMessageHandlerBuilder
                 $messageHandlerBuilder = $messageHandlerBuilder->withOutputMessageChannel($this->inputMessageChannelName . '_chain.' . $baseKey . $nextHandlerKey);
             }
             $messageHandlerReference = $messageHandlerBuilder->compile($builder);
-            if (! $messageHandlerReference) {
-                // Cant compile
-                throw InvalidArgumentException::create("Can't compile {$messageHandlerBuilder}");
-            }
-            $builder->register(new ChannelReference($currentChannelName), new Definition(DirectChannel::class, [
+            $builder->register(new ChannelReference($currentChannelName), new Definition(InProcessChannel::class, [
                 $currentChannelName,
                 $messageHandlerReference,
-            ]));
+            ], factory: [InProcessChannel::class, 'createDirectChannel']));
         }
 
         $chainForwardPublisherReference = new Definition(ChainForwardPublisher::class, [

--- a/packages/Ecotone/src/Messaging/Handler/Chain/ChainMessageHandlerBuilder.php
+++ b/packages/Ecotone/src/Messaging/Handler/Chain/ChainMessageHandlerBuilder.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Ecotone\Messaging\Handler\Chain;
 
-use Ecotone\Messaging\Channel\DirectChannel;
+use Ecotone\Messaging\Channel\InProcessChannel;
 use Ecotone\Messaging\Config\Container\ChannelReference;
 use Ecotone\Messaging\Config\Container\Definition;
 use Ecotone\Messaging\Config\Container\MessagingContainerBuilder;
@@ -126,7 +126,7 @@ class ChainMessageHandlerBuilder extends InputOutputMessageHandlerBuilder
                 // Cant compile
                 throw InvalidArgumentException::create("Can't compile {$messageHandlerBuilder}");
             }
-            $builder->register(new ChannelReference($currentChannelName), new Definition(DirectChannel::class, [
+            $builder->register(new ChannelReference($currentChannelName), new Definition(InProcessChannel::class, [
                 $currentChannelName,
                 $messageHandlerReference,
             ]));

--- a/packages/Ecotone/src/Messaging/Handler/Chain/ChainMessageHandlerBuilder.php
+++ b/packages/Ecotone/src/Messaging/Handler/Chain/ChainMessageHandlerBuilder.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Ecotone\Messaging\Handler\Chain;
 
+use Ecotone\Messaging\Channel\DirectChannel;
 use Ecotone\Messaging\Channel\InProcessChannel;
 use Ecotone\Messaging\Config\Container\ChannelReference;
 use Ecotone\Messaging\Config\Container\Definition;
@@ -126,7 +127,7 @@ class ChainMessageHandlerBuilder extends InputOutputMessageHandlerBuilder
                 // Cant compile
                 throw InvalidArgumentException::create("Can't compile {$messageHandlerBuilder}");
             }
-            $builder->register(new ChannelReference($currentChannelName), new Definition(InProcessChannel::class, [
+            $builder->register(new ChannelReference($currentChannelName), new Definition(DirectChannel::class, [
                 $currentChannelName,
                 $messageHandlerReference,
             ]));

--- a/packages/Ecotone/src/Messaging/MessageHeaders.php
+++ b/packages/Ecotone/src/Messaging/MessageHeaders.php
@@ -115,6 +115,8 @@ final class MessageHeaders
 
     public const TEMPORARY_SPAN_CONTEXT_HEADER = 'ecotone.temporarySpanContext';
 
+    const IN_PROCESS_EXECUTOR = "ecotone.in-process-channel.executor";
+
     private array $headers;
 
     /**
@@ -172,6 +174,7 @@ final class MessageHeaders
             self::STREAM_BASED_SOURCED,
             MessagingEntrypoint::ENTRYPOINT,
             self::CHANNEL_SEND_RETRY_NUMBER,
+            self::IN_PROCESS_EXECUTOR,
         ];
     }
 
@@ -246,6 +249,7 @@ final class MessageHeaders
             $metadata[self::POLLED_CHANNEL_NAME],
             $metadata[self::CONSUMER_POLLING_METADATA],
             $metadata[self::REPLY_CHANNEL],
+            $metadata[self::IN_PROCESS_EXECUTOR],
             $metadata[self::TEMPORARY_SPAN_CONTEXT_HEADER]
         );
 

--- a/packages/Ecotone/src/Messaging/MessageHeaders.php
+++ b/packages/Ecotone/src/Messaging/MessageHeaders.php
@@ -116,6 +116,7 @@ final class MessageHeaders
     public const TEMPORARY_SPAN_CONTEXT_HEADER = 'ecotone.temporarySpanContext';
 
     const IN_PROCESS_EXECUTOR = "ecotone.in-process-channel.executor";
+    const IN_PROCESS_EXECUTOR_INTERCEPTING = "ecotone.in-process-channel.intercepting";
 
     private array $headers;
 

--- a/packages/Ecotone/src/Messaging/MessageHeaders.php
+++ b/packages/Ecotone/src/Messaging/MessageHeaders.php
@@ -251,6 +251,7 @@ final class MessageHeaders
             $metadata[self::CONSUMER_POLLING_METADATA],
             $metadata[self::REPLY_CHANNEL],
             $metadata[self::IN_PROCESS_EXECUTOR],
+            $metadata[self::IN_PROCESS_EXECUTOR_INTERCEPTING],
             $metadata[self::TEMPORARY_SPAN_CONTEXT_HEADER]
         );
 

--- a/packages/Ecotone/src/Messaging/Support/MessageBuilder.php
+++ b/packages/Ecotone/src/Messaging/Support/MessageBuilder.php
@@ -164,6 +164,9 @@ final class MessageBuilder
     public function removeHeader(string $headerName): self
     {
         $this->headerAccessor->removeHeader($headerName);
+        if ($headerName === MessageHeaders::REPLY_CHANNEL) {
+            $this->headerAccessor->removeHeader(MessageHeaders::IN_PROCESS_EXECUTOR);
+        }
 
         return $this;
     }

--- a/packages/Ecotone/tests/Messaging/Fixture/Handler/HandlerRedirectingToChannel.php
+++ b/packages/Ecotone/tests/Messaging/Fixture/Handler/HandlerRedirectingToChannel.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Test\Ecotone\Messaging\Fixture\Handler;
+
+use Ecotone\Messaging\Channel\InProcessChannel;
+use Ecotone\Messaging\Message;
+use Ecotone\Messaging\MessageChannel;
+use Ecotone\Messaging\MessageHandler;
+use Ecotone\Messaging\Support\MessageBuilder;
+use Ramsey\Uuid\Uuid;
+
+class HandlerRedirectingToChannel implements MessageHandler
+{
+    public function __construct(private MessageChannel $channel, private bool $requestInProcessReply = false)
+    {
+    }
+
+    public function handle(Message $message): void
+    {
+        if ($this->requestInProcessReply) {
+            $message = MessageBuilder::fromMessage($message)
+                ->setHeader(InProcessChannel::MESSAGE_HEADER_REPLY_ID, Uuid::uuid4()->toString())
+                ->build();
+            $this->channel->send($message);
+        }
+        $this->channel->send($message);
+    }
+}

--- a/packages/Ecotone/tests/Messaging/Unit/Channel/InProcessChannelTest.php
+++ b/packages/Ecotone/tests/Messaging/Unit/Channel/InProcessChannelTest.php
@@ -12,7 +12,7 @@ class InProcessChannelTest extends TestCase
 {
     public function test_publishing_message()
     {
-        $directChannel = InProcessChannel::create();
+        $directChannel = InProcessChannel::createDirectChannel();
 
         $messageHandler = NoReturnMessageHandler::create();
         $directChannel->subscribe($messageHandler);
@@ -24,9 +24,9 @@ class InProcessChannelTest extends TestCase
 
     public function test_it_can_send_message_handler_with_output_channel()
     {
-        $executorChannel = InProcessChannel::create();
-        $inProcessChannel1 = InProcessChannel::create();
-        $inProcessChannel2 = InProcessChannel::create();
+        $executorChannel = InProcessChannel::createDirectChannel();
+        $inProcessChannel1 = InProcessChannel::createDirectChannel();
+        $inProcessChannel2 = InProcessChannel::createDirectChannel();
         $messageHandler1 = new HandlerRedirectingToChannel($inProcessChannel1);
         $messageHandler2 = new HandlerRedirectingToChannel($inProcessChannel2);
         $lastHandler = NoReturnMessageHandler::create();

--- a/packages/Ecotone/tests/Messaging/Unit/Channel/InProcessChannelTest.php
+++ b/packages/Ecotone/tests/Messaging/Unit/Channel/InProcessChannelTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Test\Ecotone\Messaging\Unit\Channel;
+
+use Ecotone\Messaging\Channel\InProcessChannel;
+use Ecotone\Messaging\Support\MessageBuilder;
+use PHPUnit\Framework\TestCase;
+use Test\Ecotone\Messaging\Fixture\Handler\HandlerRedirectingToChannel;
+use Test\Ecotone\Messaging\Fixture\Handler\NoReturnMessageHandler;
+
+class InProcessChannelTest extends TestCase
+{
+    public function test_publishing_message()
+    {
+        $directChannel = InProcessChannel::create();
+
+        $messageHandler = NoReturnMessageHandler::create();
+        $directChannel->subscribe($messageHandler);
+
+        $directChannel->send(MessageBuilder::withPayload('test')->build());
+
+        $this->assertTrue($messageHandler->wasCalled(), 'Message handler for direct channel was not called');
+    }
+
+    public function test_it_can_send_message_handler_with_output_channel()
+    {
+        $executorChannel = InProcessChannel::create();
+        $inProcessChannel1 = InProcessChannel::create();
+        $inProcessChannel2 = InProcessChannel::create();
+        $messageHandler1 = new HandlerRedirectingToChannel($inProcessChannel1);
+        $messageHandler2 = new HandlerRedirectingToChannel($inProcessChannel2);
+        $lastHandler = NoReturnMessageHandler::create();
+        $executorChannel->subscribe($messageHandler1);
+        $inProcessChannel1->subscribe($messageHandler2);
+        $inProcessChannel2->subscribe($lastHandler);
+
+        $executorChannel->send(MessageBuilder::withPayload('some')->build());
+
+
+        $this->assertTrue($lastHandler->wasCalled(), 'Message handler for direct channel was not called');
+    }
+}

--- a/packages/Ecotone/tests/Messaging/Unit/Config/MessagingSystemConfigurationTest.php
+++ b/packages/Ecotone/tests/Messaging/Unit/Config/MessagingSystemConfigurationTest.php
@@ -7,8 +7,8 @@ namespace Test\Ecotone\Messaging\Unit\Config;
 use Ecotone\Lite\EcotoneLite;
 use Ecotone\Messaging\Channel\ChannelInterceptor;
 use Ecotone\Messaging\Channel\DirectChannel;
+use Ecotone\Messaging\Channel\InProcessChannel;
 use Ecotone\Messaging\Channel\MessageChannelInterceptorAdapter;
-use Ecotone\Messaging\Channel\PublishSubscribeChannel;
 use Ecotone\Messaging\Channel\QueueChannel;
 use Ecotone\Messaging\Channel\SimpleChannelInterceptorBuilder;
 use Ecotone\Messaging\Channel\SimpleMessageChannelBuilder;
@@ -1122,7 +1122,7 @@ class MessagingSystemConfigurationTest extends MessagingTest
         $messagingSystem->getMessageChannelByName($inputMessageChannelName)
             ->send(MessageBuilder::withPayload('some')->build());
 
-        $this->assertInstanceOf(PublishSubscribeChannel::class, $messagingSystem->getMessageChannelByName($inputMessageChannelName));
+        $this->assertInstanceOf(InProcessChannel::class, $messagingSystem->getMessageChannelByName($inputMessageChannelName));
     }
 
     /**


### PR DESCRIPTION
## Description

This is a proposal to lower the stack trace of message handling.
It replaces direct and public subscribe channels with an "InProcessChannel" that will manage an internal stack of [handler, message] , and process them one by one.
It is particularly effective for before and after interceptors :
on main the stack is like this: `before -> before -> before -> intercepted handler -> after -> after -> after`
with this PR there will be multiple stack from the in process channel:
```
channel -> before
channel -> before
channel -> before
channel -> intercepted handler around
channel -> after
channel -> after
channel -> after
```

It has no impact on performance but I think it helps developer experience and debugging, at the cost of a more complex implementation.
For a simple aggregate command handler, the stack size is 51 on main and 41 after this PR (From gateway proxy to service)
I expected more, but I think the difference could be higher in more complex scenarios.
WDYT ?

For the mention, while working on this PR, I noticed that 'after' interceptors are called inside 'around' interceptors:
`before -> around ( intercepted -> after )`
while I was expecting: `before -> around( intercepted ) -> after`
Is it the way it should be ?

## Type of change

- DX Proposal

<!--
By submitting this pull request, you agree to the contribution terms defined in [CONTRIBUTING.md](https://github.com/ecotoneframework/ecotone-dev/blob/main/CONTRIBUTING.md).
-->