### PR TITLE
Drop unnecessary interfaceToCall in ES aggregate and header converters

### DIFF
--- a/packages/Ecotone/src/Messaging/Handler/Processor/MethodInvoker/Converter/HeaderBuilder.php
+++ b/packages/Ecotone/src/Messaging/Handler/Processor/MethodInvoker/Converter/HeaderBuilder.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Ecotone\Messaging\Handler\Processor\MethodInvoker\Converter;
 
 use Ecotone\Messaging\Config\Container\Definition;
-use Ecotone\Messaging\Config\Container\InterfaceParameterReference;
 use Ecotone\Messaging\Config\Container\Reference;
 use Ecotone\Messaging\Conversion\ConversionService;
 use Ecotone\Messaging\Handler\InterfaceParameter;
@@ -51,8 +50,12 @@ class HeaderBuilder implements ParameterConverterBuilder
 
     public function compile(InterfaceToCall $interfaceToCall): Definition
     {
+        $parameter = $interfaceToCall->getParameterWithName($this->parameterName);
         return new Definition(HeaderConverter::class, [
-            InterfaceParameterReference::fromInstance($interfaceToCall, $this->parameterName),
+            $parameter->getTypeDescriptor(),
+            $parameter->hasDefaultValue()
+                ? new Definition(ParameterDefaultValue::class, [$parameter->getDefaultValue()])
+                : null,
             $this->headerName,
             $this->isRequired,
             new Reference(ConversionService::REFERENCE_NAME),

--- a/packages/Ecotone/src/Messaging/Handler/Processor/MethodInvoker/Converter/HeaderConverter.php
+++ b/packages/Ecotone/src/Messaging/Handler/Processor/MethodInvoker/Converter/HeaderConverter.php
@@ -25,7 +25,7 @@ use Ecotone\Messaging\MessageConverter\DefaultHeaderMapper;
  */
 class HeaderConverter implements ParameterConverter
 {
-    public function __construct(private InterfaceParameter $parameter, private string $headerName, private bool $isRequired, private ConversionService $conversionService)
+    public function __construct(private ?Type $parameterType, private ?ParameterDefaultValue $defaultValue, private string $headerName, private bool $isRequired, private ConversionService $conversionService)
     {
     }
 
@@ -35,8 +35,8 @@ class HeaderConverter implements ParameterConverter
     public function getArgumentFrom(Message $message)
     {
         if (! $message->getHeaders()->containsKey($this->headerName)) {
-            if ($this->parameter->hasDefaultValue()) {
-                return $this->parameter->getDefaultValue();
+            if ($this->defaultValue) {
+                return $this->defaultValue->getValue();
             }
 
             if (! $this->isRequired) {
@@ -46,7 +46,7 @@ class HeaderConverter implements ParameterConverter
 
         $headerValue = $message->getHeaders()->get($this->headerName);
 
-        $targetType = $this->parameter->getTypeDescriptor();
+        $targetType = $this->parameterType;
 
         $sourceValueType = TypeDescriptor::createFromVariable($headerValue);
         if (! $sourceValueType->isCompatibleWith($targetType)) {

--- a/packages/Ecotone/src/Messaging/Handler/Processor/MethodInvoker/Converter/ParameterDefaultValue.php
+++ b/packages/Ecotone/src/Messaging/Handler/Processor/MethodInvoker/Converter/ParameterDefaultValue.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Ecotone\Messaging\Handler\Processor\MethodInvoker\Converter;
+
+class ParameterDefaultValue
+{
+    public function __construct(private mixed $value)
+    {
+    }
+
+    public function getValue(): mixed
+    {
+        return $this->value;
+    }
+}

--- a/packages/Ecotone/src/Modelling/EventSourcingExecutor/AggregateMethodInvoker.php
+++ b/packages/Ecotone/src/Modelling/EventSourcingExecutor/AggregateMethodInvoker.php
@@ -13,5 +13,5 @@ use Ecotone\Modelling\EventSourcingHandlerMethod;
  */
 interface AggregateMethodInvoker
 {
-    public function executeMethod(mixed $aggregate, InterfaceToCall $eventSourcingHandlerInterface, EventSourcingHandlerMethod $eventSourcingHandler, Message $message): void;
+    public function executeMethod(mixed $aggregate, EventSourcingHandlerMethod $eventSourcingHandler, Message $message): void;
 }

--- a/packages/Ecotone/src/Modelling/EventSourcingExecutor/EnterpriseAggregateMethodInvoker.php
+++ b/packages/Ecotone/src/Modelling/EventSourcingExecutor/EnterpriseAggregateMethodInvoker.php
@@ -14,13 +14,13 @@ use Ecotone\Modelling\EventSourcingHandlerMethod;
  */
 final class EnterpriseAggregateMethodInvoker implements AggregateMethodInvoker
 {
-    public function executeMethod(mixed $aggregate, InterfaceToCall $eventSourcingHandlerInterface, EventSourcingHandlerMethod $eventSourcingHandler, Message $message): void
+    public function executeMethod(mixed $aggregate, EventSourcingHandlerMethod $eventSourcingHandler, Message $message): void
     {
         (new MethodInvoker(
             $aggregate,
-            $eventSourcingHandlerInterface->getMethodName(),
+            $eventSourcingHandler->getMethodName(),
             $eventSourcingHandler->getParameterConverters(),
-            $eventSourcingHandlerInterface->getInterfaceParametersNames(),
+            $eventSourcingHandler->getInterfaceParametersNames(),
         ))->executeEndpoint($message);
     }
 }

--- a/packages/Ecotone/src/Modelling/EventSourcingExecutor/EventSourcingHandlerExecutor.php
+++ b/packages/Ecotone/src/Modelling/EventSourcingExecutor/EventSourcingHandlerExecutor.php
@@ -51,9 +51,8 @@ final class EventSourcingHandlerExecutor
                 ->setMultipleHeaders($metadata)
                 ->build();
             foreach ($this->eventSourcingHandlerMethods as $eventSourcingHandler) {
-                $eventSourcingHandlerInterface = $eventSourcingHandler->getInterfaceToCall();
-                if ($eventSourcingHandlerInterface->getFirstParameter()->canBePassedIn($eventType)) {
-                    $this->aggregateMethodInvoker->executeMethod($aggregate, $eventSourcingHandlerInterface, $eventSourcingHandler, $message);
+                if ($eventSourcingHandler->canHandle($eventType)) {
+                    $this->aggregateMethodInvoker->executeMethod($aggregate, $eventSourcingHandler, $message);
                 }
             }
         }

--- a/packages/Ecotone/src/Modelling/EventSourcingExecutor/OpenCoreAggregateMethodInvoker.php
+++ b/packages/Ecotone/src/Modelling/EventSourcingExecutor/OpenCoreAggregateMethodInvoker.php
@@ -14,12 +14,12 @@ use Ecotone\Modelling\EventSourcingHandlerMethod;
  */
 final class OpenCoreAggregateMethodInvoker implements AggregateMethodInvoker
 {
-    public function executeMethod(mixed $aggregate, InterfaceToCall $eventSourcingHandlerInterface, EventSourcingHandlerMethod $eventSourcingHandler, Message $message): void
+    public function executeMethod(mixed $aggregate, EventSourcingHandlerMethod $eventSourcingHandler, Message $message): void
     {
-        if (count($eventSourcingHandlerInterface->getInterfaceParameters()) > 1) {
-            throw InvalidArgumentException::create("Using multiple parameters for Event Sourcing Handler: {$eventSourcingHandlerInterface} is part of Enterprise features. To use this feature obtain Enterprise.");
+        if ($eventSourcingHandler->parametersCount() > 1) {
+            throw InvalidArgumentException::create("Using multiple parameters for Event Sourcing Handler: {$eventSourcingHandler} is part of Enterprise features. To use this feature obtain Enterprise.");
         }
 
-        $aggregate->{$eventSourcingHandlerInterface->getMethodName()}($message->getPayload());
+        $aggregate->{$eventSourcingHandler->getMethodName()}($message->getPayload());
     }
 }

--- a/packages/Ecotone/src/Modelling/EventSourcingHandlerMethod.php
+++ b/packages/Ecotone/src/Modelling/EventSourcingHandlerMethod.php
@@ -9,15 +9,20 @@ use Ecotone\Messaging\Config\Container\Reference;
 use Ecotone\Messaging\Handler\InterfaceToCall;
 use Ecotone\Messaging\Handler\ParameterConverter;
 use Ecotone\Messaging\Handler\ParameterConverterBuilder;
+use Ecotone\Messaging\Handler\Type;
+use Ecotone\Messaging\Handler\TypeDescriptor;
 
 final class EventSourcingHandlerMethod
 {
     /**
-     * @param InterfaceToCall $interfaceToCall
+     * @param array<string> $interfaceParametersNames
      * @param array<ParameterConverter> $parameterConverters
      */
     public function __construct(
-        private InterfaceToCall $interfaceToCall,
+        private string $interfaceName,
+        private string $methodName,
+        private Type  $handledEventType,
+        private array $interfaceParametersNames,
         private array $parameterConverters,
     ) {
     }
@@ -32,7 +37,10 @@ final class EventSourcingHandlerMethod
         return new Definition(
             EventSourcingHandlerMethod::class,
             [
-                Reference::toInterface($interfaceToCall->getInterfaceName(), $interfaceToCall->getMethodName()),
+                $interfaceToCall->getInterfaceName(),
+                $interfaceToCall->getMethodName(),
+                $interfaceToCall->getFirstParameter()->getTypeDescriptor(),
+                $interfaceToCall->getInterfaceParametersNames(),
                 array_map(
                     fn (ParameterConverterBuilder $parameterConverterBuilder) => $parameterConverterBuilder->compile($interfaceToCall),
                     $parameterConverters
@@ -41,9 +49,9 @@ final class EventSourcingHandlerMethod
         );
     }
 
-    public function getInterfaceToCall(): InterfaceToCall
+    public function canHandle(TypeDescriptor $eventType): bool
     {
-        return $this->interfaceToCall;
+        return $eventType->isCompatibleWith($this->handledEventType);
     }
 
     /**
@@ -52,5 +60,25 @@ final class EventSourcingHandlerMethod
     public function getParameterConverters(): array
     {
         return $this->parameterConverters;
+    }
+
+    public function getInterfaceParametersNames(): array
+    {
+        return $this->interfaceParametersNames;
+    }
+
+    public function parametersCount(): int
+    {
+        return count($this->parameterConverters);
+    }
+
+    public function getMethodName(): string
+    {
+        return $this->methodName;
+    }
+
+    public function __toString(): string
+    {
+        return "{$this->interfaceName}::{$this->methodName}";
     }
 }


### PR DESCRIPTION
## Description

continues #348 

## Type of change

- Performance

<!--
By submitting this pull request, you agree to the contribution terms defined in [CONTRIBUTING.md](https://github.com/ecotoneframework/ecotone-dev/blob/main/CONTRIBUTING.md).
-->