### PR TITLE
Interceptors are called multiple times on aggregates with factory and action method

### DIFF
--- a/packages/Ecotone/src/Modelling/Config/ModellingHandlerModule.php
+++ b/packages/Ecotone/src/Modelling/Config/ModellingHandlerModule.php
@@ -526,7 +526,7 @@ class ModellingHandlerModule implements AnnotationModule
                 ChainMessageHandlerBuilder::create()
                     ->withInputChannelName($messageChannelName)
                     ->chain(AggregateIdentifierRetrevingServiceBuilder::createWith($aggregateClassDefinition, $factoryIdentifierMetadataMapping, $factoryIdentifierMapping, $factoryHandledPayloadType, $interfaceToCallRegistry))
-                    ->chainInterceptedHandler(
+                    ->chain(
                         LoadAggregateServiceBuilder::create($aggregateClassDefinition, $registration->getMethodName(), $factoryHandledPayloadType, LoadAggregateMode::createContinueOnNotFound(), $interfaceToCallRegistry)
                             ->withAggregateRepositoryFactories($aggregateRepositoryReferenceNames)
                     )

--- a/packages/Ecotone/tests/Modelling/Fixture/InterceptedCommandAggregate/AddExecutorId/AddExecutorId.php
+++ b/packages/Ecotone/tests/Modelling/Fixture/InterceptedCommandAggregate/AddExecutorId/AddExecutorId.php
@@ -12,6 +12,7 @@ use Test\Ecotone\Modelling\Fixture\InterceptedCommandAggregate\Logger;
 class AddExecutorId
 {
     private string $executorId = '';
+    private int $calledCount = 0;
 
     #[CommandHandler('changeExecutorId')]
     public function addExecutorId(string $executorId): void
@@ -22,6 +23,7 @@ class AddExecutorId
     #[Before(pointcut: Logger::class)]
     public function add(array $payload): array
     {
+        $this->calledCount += 1;
         if (isset($payload['executorId'])) {
             return $payload;
         }
@@ -30,5 +32,10 @@ class AddExecutorId
             $payload,
             ['executorId' => $this->executorId]
         );
+    }
+
+    public function getCalledCount(): int
+    {
+        return $this->calledCount;
     }
 }

--- a/packages/Ecotone/tests/Modelling/Unit/AggregateWithFactoryAndActionTest.php
+++ b/packages/Ecotone/tests/Modelling/Unit/AggregateWithFactoryAndActionTest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Test\Ecotone\Modelling\Unit;
+
+use Ecotone\Lite\EcotoneLite;
+use PHPUnit\Framework\TestCase;
+use Test\Ecotone\Modelling\Fixture\InterceptedCommandAggregate\AddExecutorId\AddExecutorId;
+use Test\Ecotone\Modelling\Fixture\InterceptedCommandAggregate\AddNotificationTimestamp\AddNotificationTimestamp;
+use Test\Ecotone\Modelling\Fixture\InterceptedCommandAggregate\Logger;
+use Test\Ecotone\Modelling\Fixture\InterceptedCommandAggregate\LoggerRepository;
+
+class AggregateWithFactoryAndActionTest extends TestCase
+{
+    public function test_interceptors_on_aggregate_with_factory_and_action_are_called_once(): void
+    {
+        $addExecutorIdInterceptor = new AddExecutorId();
+        $ecotone = EcotoneLite::bootstrapFlowTestingWithEventStore(
+            [Logger::class, AddNotificationTimestamp::class, LoggerRepository::class, AddExecutorId::class],
+            [new AddNotificationTimestamp(), new LoggerRepository(), $addExecutorIdInterceptor]
+        );
+
+        $ecotone->sendCommandWithRoutingKey('log', ['loggerId' => 1, 'data' => 'some data']);
+
+        self::assertSame(1, $addExecutorIdInterceptor->getCalledCount());
+    }
+}


### PR DESCRIPTION
## Description

Interceptors are called 2 times on aggregates with factory and action method.

Fixes #(issue)

## Type of change

- Bug fix (non-breaking change which fixes an issue)

<!--
By submitting this pull request, you agree to the contribution terms defined in [CONTRIBUTING.md](https://github.com/ecotoneframework/ecotone-dev/blob/main/CONTRIBUTING.md).
-->