### PR TITLE
Performance: logging without message gateway

### DIFF
--- a/packages/Ecotone/src/Messaging/Config/ModuleClassList.php
+++ b/packages/Ecotone/src/Messaging/Config/ModuleClassList.php
@@ -92,8 +92,6 @@ class ModuleClassList
         DynamicMessageChannelModule::class,
 
         /** Attribute based configurations */
-        LoggingGateway::class,
-        LoggingService::class,
         MessageHeadersPropagatorInterceptor::class,
         MessageHandlerLogger::class,
     ];

--- a/packages/Ecotone/src/Messaging/Handler/Logger/Config/LoggingModule.php
+++ b/packages/Ecotone/src/Messaging/Handler/Logger/Config/LoggingModule.php
@@ -19,6 +19,7 @@ use Ecotone\Messaging\Handler\InterfaceToCallRegistry;
 use Ecotone\Messaging\Handler\Logger\Annotation\LogAfter;
 use Ecotone\Messaging\Handler\Logger\Annotation\LogBefore;
 use Ecotone\Messaging\Handler\Logger\Annotation\LogError;
+use Ecotone\Messaging\Handler\Logger\LoggingGateway;
 use Ecotone\Messaging\Handler\Logger\LoggingHandlerBuilder;
 use Ecotone\Messaging\Handler\Logger\LoggingInterceptor;
 use Ecotone\Messaging\Handler\Logger\LoggingService;
@@ -46,9 +47,8 @@ class LoggingModule extends NoExternalConfigurationModule implements AnnotationM
      */
     public function prepare(Configuration $messagingConfiguration, array $extensionObjects, ModuleReferenceSearchService $moduleReferenceSearchService, InterfaceToCallRegistry $interfaceToCallRegistry): void
     {
-        $messagingConfiguration->registerServiceDefinition(LoggingInterceptor::class, [
-            new Definition(LoggingService::class, [Reference::to(ConversionService::REFERENCE_NAME), Reference::to(LoggerInterface::class)]),
-        ]);
+        $messagingConfiguration->registerServiceDefinition(LoggingGateway::class, new Definition(LoggingService::class, [Reference::to(ConversionService::REFERENCE_NAME), Reference::to(LoggerInterface::class)]));
+        $messagingConfiguration->registerServiceDefinition(LoggingInterceptor::class, [Reference::to(LoggingGateway::class)]);
 
         $messagingConfiguration->registerBeforeMethodInterceptor(
             MethodInterceptor::create(

--- a/packages/Ecotone/src/Messaging/Handler/Logger/LoggingGateway.php
+++ b/packages/Ecotone/src/Messaging/Handler/Logger/LoggingGateway.php
@@ -16,21 +16,17 @@ use Throwable;
  */
 interface LoggingGateway
 {
-    #[MessageGateway(LoggingService::INFO_LOGGING_CHANNEL)]
-    #[PropagateHeaders(false)]
     public function info(
-        #[Payload] string                                              $text,
-        #[Header(LoggingService::CONTEXT_MESSAGE_HEADER)] ?Message     $message = null,
-        #[Header(LoggingService::CONTEXT_EXCEPTION_HEADER)] ?Throwable $exception = null,
-        #[Header(LoggingService::CONTEXT_DATA_HEADER)] array           $contextData = [],
+        string $text,
+        ?Message $message = null,
+        ?Throwable $exception = null,
+        array $contextData = [],
     ): void;
 
-    #[MessageGateway(LoggingService::ERROR_LOGGING_CHANNEL)]
-    #[PropagateHeaders(false)]
     public function error(
-        #[Payload] string                                              $text,
-        #[Header(LoggingService::CONTEXT_MESSAGE_HEADER)] Message      $message,
-        #[Header(LoggingService::CONTEXT_EXCEPTION_HEADER)] ?Throwable $exception = null,
-        #[Header(LoggingService::CONTEXT_DATA_HEADER)] array           $contextData = [],
+        string $text,
+        Message $message,
+        ?Throwable $exception = null,
+        array $contextData = [],
     ): void;
 }

--- a/packages/Ecotone/src/Messaging/Handler/Logger/LoggingService.php
+++ b/packages/Ecotone/src/Messaging/Handler/Logger/LoggingService.php
@@ -25,14 +25,8 @@ use Throwable;
 /**
  * licence Apache-2.0
  */
-class LoggingService
+class LoggingService implements LoggingGateway
 {
-    public const CONTEXT_MESSAGE_HEADER = 'ecotone.logging.contextMessage';
-    public const CONTEXT_EXCEPTION_HEADER = 'ecotone.logging.exceptionMessage';
-    public const CONTEXT_DATA_HEADER = 'ecotone.logging.contextData';
-    public const INFO_LOGGING_CHANNEL = 'infoLoggingChannel';
-    public const ERROR_LOGGING_CHANNEL = 'errorLoggingChannel';
-
     private ConversionService $conversionService;
     private LoggerInterface $logger;
 
@@ -47,12 +41,11 @@ class LoggingService
         $this->logger = $logger;
     }
 
-    #[ServiceActivator(self::INFO_LOGGING_CHANNEL)]
     public function info(
-        #[Payload] string $text,
-        #[Header(self::CONTEXT_MESSAGE_HEADER)] ?Message $message,
-        #[Header(self::CONTEXT_EXCEPTION_HEADER)] ?Throwable $exception,
-        #[Header(self::CONTEXT_DATA_HEADER)] array $contextData,
+        string $text,
+        ?Message $message = null,
+        ?Throwable $exception = null,
+        array $contextData = [],
     ): void {
         if ($message === null) {
             $this->logger->info($text, $contextData);
@@ -72,12 +65,11 @@ class LoggingService
         );
     }
 
-    #[ServiceActivator(self::ERROR_LOGGING_CHANNEL)]
     public function error(
-        #[Payload] string $text,
-        #[Header(self::CONTEXT_MESSAGE_HEADER)] Message $message,
-        #[Header(self::CONTEXT_EXCEPTION_HEADER)] ?Throwable $exception,
-        #[Header(self::CONTEXT_DATA_HEADER)] array $contextData,
+        string $text,
+        Message $message,
+        ?Throwable $exception = null,
+        array $contextData = [],
     ): void {
         $this->logger->critical(
             $text,

--- a/packages/OpenTelemetry/src/Configuration/OpenTelemetryModule.php
+++ b/packages/OpenTelemetry/src/Configuration/OpenTelemetryModule.php
@@ -77,7 +77,6 @@ final class OpenTelemetryModule extends NoExternalConfigurationModule implements
         $this->registerTracerFor('traceQueryBus', QueryBus::class, $messagingConfiguration, $interfaceToCallRegistry);
         $this->registerTracerFor('traceEventBus', EventBus::class, $messagingConfiguration, $interfaceToCallRegistry);
         $this->registerTracerFor('traceAsynchronousEndpoint', AsynchronousRunningEndpoint::class, $messagingConfiguration, $interfaceToCallRegistry);
-        $this->registerTracerFor('traceLogs', LoggingGateway::class, $messagingConfiguration, $interfaceToCallRegistry);
         $this->registerTracerFor('traceDistributedBus', DistributedBus::class, $messagingConfiguration, $interfaceToCallRegistry);
 
         $messagingConfiguration->registerBeforeMethodInterceptor(

--- a/packages/OpenTelemetry/src/TracerInterceptor.php
+++ b/packages/OpenTelemetry/src/TracerInterceptor.php
@@ -148,37 +148,6 @@ final class TracerInterceptor
         );
     }
 
-    public function traceLogs(MethodInvocation $methodInvocation, Message $message)
-    {
-        $logMessage = $message->getPayload();
-
-        $attributes = [];
-        if ($message->getHeaders()->containsKey(LoggingService::CONTEXT_MESSAGE_HEADER)) {
-            /** @var Message $contextMessage */
-            $contextMessage = $message->getHeaders()->get(LoggingService::CONTEXT_MESSAGE_HEADER);
-            $attributes = [
-                MessageHeaders::MESSAGE_ID => $contextMessage->getHeaders()->getMessageId(),
-                MessageHeaders::MESSAGE_CORRELATION_ID => $contextMessage->getHeaders()->getCorrelationId(),
-                MessageHeaders::PARENT_MESSAGE_ID => $contextMessage->getHeaders()->getParentId(),
-            ];
-        }
-
-        if ($message->getHeaders()->containsKey(LoggingService::CONTEXT_EXCEPTION_HEADER)) {
-            /** @var Exception $exception */
-            $exception = $message->getHeaders()->get(LoggingService::CONTEXT_EXCEPTION_HEADER);
-            $attributes['exceptionMessage'] = $exception->getMessage();
-            $attributes['exceptionClass'] = $exception::class;
-            $attributes['exceptionTrace'] = $exception->getTraceAsString();
-        }
-
-        Span::getCurrent()->addEvent(
-            $logMessage,
-            $attributes
-        );
-
-        return $methodInvocation->proceed();
-    }
-
     public function trace(
         string $type,
         MethodInvocation $methodInvocation,

--- a/packages/OpenTelemetry/tests/Integration/CorrelatedHeadersPropagationTest.php
+++ b/packages/OpenTelemetry/tests/Integration/CorrelatedHeadersPropagationTest.php
@@ -214,13 +214,13 @@ final class CorrelatedHeadersPropagationTest extends TracingTest
 
         /** Command Handler */
         $this->assertSame(StatusCode::STATUS_ERROR, $spans[0]->getStatus()->getCode());
-        $event = $spans[0]->getEvents()[1];
+        $event = $spans[0]->getEvents()[0];
         $this->assertSame('exception', $event->getName());
         $this->assertSame('User already registered', $event->getAttributes()->get('exception.message'));
 
         /** Command Bus */
         $this->assertSame(StatusCode::STATUS_ERROR, $spans[1]->getStatus()->getCode());
-        $event = $spans[1]->getEvents()[1];
+        $event = $spans[1]->getEvents()[0];
         $this->assertSame('exception', $event->getName());
         $this->assertSame('User already registered', $event->getAttributes()->get('exception.message'));
     }


### PR DESCRIPTION
## Description

Make `LoggingGateway` a registered service instead of a `Gateway` for performance: a logger should not have impact on performance :)

The `TracerInterceptor` from opentelemetry module will not intercept logs anymore:
1. it is strange to trace logs :)
2. converting logs to trace events is typically managed at the logger level for the whole application, including outside ecotone, so all logs can be converted to events (that is what I do in my application). It should not be handled by Ecotone.

## Type of change

- performance

<!--
By submitting this pull request, you agree to the contribution terms defined in [CONTRIBUTING.md](https://github.com/ecotoneframework/ecotone-dev/blob/main/CONTRIBUTING.md).
-->