### PR TITLE
initializing aggregate in tests won't publish its events

### DIFF
--- a/packages/Ecotone/src/Lite/Test/FlowTestSupport.php
+++ b/packages/Ecotone/src/Lite/Test/FlowTestSupport.php
@@ -179,10 +179,10 @@ final class FlowTestSupport
                 AggregateMessage::RESULT_AGGREGATE_OBJECT => $aggregateClass,
                 AggregateMessage::RESULT_AGGREGATE_EVENTS => $events,
             ],
-            ModellingHandlerModule::getRegisterAggregateSaveRepositoryInputChannel($aggregateClass)
+            ModellingHandlerModule::getRegisterAggregateSaveRepositoryInputChannel($aggregateClass). '.test_setup_state'
         );
 
-        return $this->discardRecordedMessages();
+        return $this;
     }
 
     public function withStateFor(object $aggregate): self
@@ -192,7 +192,7 @@ final class FlowTestSupport
             [
                 AggregateMessage::RESULT_AGGREGATE_OBJECT => $aggregate,
             ],
-            ModellingHandlerModule::getRegisterAggregateSaveRepositoryInputChannel($aggregate::class)
+            ModellingHandlerModule::getRegisterAggregateSaveRepositoryInputChannel($aggregate::class). '.test_setup_state'
         );
 
         return $this;

--- a/packages/Ecotone/src/Messaging/Config/Configuration.php
+++ b/packages/Ecotone/src/Messaging/Config/Configuration.php
@@ -142,4 +142,6 @@ interface Configuration extends CompilerPass
     public function registerServiceAlias(string|Reference $id, Reference $aliasTo): Configuration;
 
     public function isRunningForEnterpriseLicence(): bool;
+
+    public function isRunningForTest(): bool;
 }

--- a/packages/Ecotone/src/Messaging/Config/MessagingSystemConfiguration.php
+++ b/packages/Ecotone/src/Messaging/Config/MessagingSystemConfiguration.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Ecotone\Messaging\Config;
 
+use Ecotone\Lite\Test\TestConfiguration;
 use function array_map;
 
 use Ecotone\AnnotationFinder\AnnotationFinder;
@@ -156,6 +157,8 @@ final class MessagingSystemConfiguration implements Configuration
 
     private bool $isRunningForEnterpriseLicence;
 
+    private bool $isRunningForTest = false;
+
     /**
      * @param object[] $extensionObjects
      */
@@ -197,6 +200,13 @@ final class MessagingSystemConfiguration implements Configuration
                 return ! ($extensionObject instanceof ServiceConfiguration);
             }
         );
+
+        foreach ($extensionObjects as $extensionObject) {
+            if ($extensionObject instanceof TestConfiguration) {
+                $this->isRunningForTest = true;
+            }
+        }
+
         $extensionObjects[] = $serviceConfiguration;
         $this->isRunningForEnterpriseLicence = $serviceConfiguration->hasEnterpriseLicence();
         $this->initialize($moduleConfigurationRetrievingService, $extensionObjects, $serviceConfiguration);
@@ -816,6 +826,11 @@ final class MessagingSystemConfiguration implements Configuration
     public function isRunningForEnterpriseLicence(): bool
     {
         return $this->isRunningForEnterpriseLicence;
+    }
+
+    public function isRunningForTest(): bool
+    {
+        return $this->isRunningForTest;
     }
 
     /**

--- a/packages/Ecotone/src/Messaging/Handler/Processor/ChainedMessageProcessorBuilder.php
+++ b/packages/Ecotone/src/Messaging/Handler/Processor/ChainedMessageProcessorBuilder.php
@@ -17,8 +17,7 @@ class ChainedMessageProcessorBuilder
 {
     private ?InterceptedMessageProcessorBuilder $interceptedProcessor = null;
 
-    private function __construct(private array $processors = []) {
-    }
+    private function __construct(private array $processors = []) {}
 
     public static function create(): self
     {

--- a/packages/Ecotone/src/Messaging/Handler/ServiceActivator/MessageProcessorActivatorBuilder.php
+++ b/packages/Ecotone/src/Messaging/Handler/ServiceActivator/MessageProcessorActivatorBuilder.php
@@ -30,6 +30,11 @@ class MessageProcessorActivatorBuilder extends InputOutputMessageHandlerBuilder
         $this->chainedMessageProcessorBuilder = ChainedMessageProcessorBuilder::create();
     }
 
+    public function __clone(): void
+    {
+        $this->chainedMessageProcessorBuilder = clone $this->chainedMessageProcessorBuilder;
+    }
+
     public static function create(): self
     {
         return new self();

--- a/packages/PdoEventSourcing/tests/Integration/MultiplePersistenceStrategiesTest.php
+++ b/packages/PdoEventSourcing/tests/Integration/MultiplePersistenceStrategiesTest.php
@@ -86,6 +86,13 @@ final class MultiplePersistenceStrategiesTest extends EventSourcingMessagingTest
                     new BasketCreated('basket-2'),
                 ]
             )
+        ;
+
+        $ecotone
+            ->publishEventWithRoutingKey(OrderCreated::NAME, new OrderCreated('order-1'))
+            ->publishEventWithRoutingKey(OrderCreated::NAME, new OrderCreated('order-2'))
+            ->publishEventWithRoutingKey(BasketCreated::NAME, new BasketCreated('basket-1'))
+            ->publishEventWithRoutingKey(BasketCreated::NAME, new BasketCreated('basket-2'))
             ->triggerProjection(BasketProjection::NAME)
             ->triggerProjection(OrderProjection::NAME)
         ;

--- a/quickstart-examples/BuildingBlocks/tests/ReadModel/UnapprovedProductListTest.php
+++ b/quickstart-examples/BuildingBlocks/tests/ReadModel/UnapprovedProductListTest.php
@@ -32,6 +32,8 @@ final class UnapprovedProductListTest extends TestCase
         $productName = 'Wooden table';
         $productPrice = 1000;
 
+        $productWasAdded = new ProductWasAdded(Uuid::fromString($productId), $productName, Money::EUR($productPrice));
+
         $this->assertEquals(
             [
                 [
@@ -41,9 +43,8 @@ final class UnapprovedProductListTest extends TestCase
                 ]
             ],
             EcotoneLite::bootstrapFlowTestingWithEventStore([UnapprovedProductList::class, Product::class, UuidConverter::class], [new UnapprovedProductList(), new UuidConverter()])
-                ->withEventsFor($productId, Product::class, [
-                    new ProductWasAdded(Uuid::fromString($productId), $productName, Money::EUR($productPrice))
-                ])
+                ->withEventsFor($productId, Product::class, [$productWasAdded])
+                ->publishEvent($productWasAdded)
                 ->sendQueryWithRouting('getUnapprovedProducts')
         );
     }


### PR DESCRIPTION
## Description

In tests, aggregates should be initialized without publishing its events. This helps to initialize complex aggregates without unwanted side-effects which may be subject for testing.

Fixes #364 

## Type of change

- New feature (can introduce breaking change for tests that rely on aggregate initialization side effects)
- This change may require a documentation update which will be propose separately
