### PR TITLE
Speedup event sourced projection reset

### DIFF
--- a/packages/PdoEventSourcing/src/ProjectionRunningConfiguration.php
+++ b/packages/PdoEventSourcing/src/ProjectionRunningConfiguration.php
@@ -24,7 +24,7 @@ class ProjectionRunningConfiguration implements DefinedObject
     public const DEFAULT_WAIT_BEFORE_CALLING_ES_WHEN_NO_EVENTS_FOUND = 0;
 
     public const OPTION_PERSIST_CHANGES_AFTER_AMOUNT_OF_OPERATIONS = 'persist_block_size';
-    public const DEFAULT_PERSIST_CHANGES_AFTER_AMOUNT_OF_OPERATIONS = 1;
+    public const DEFAULT_PERSIST_CHANGES_AFTER_AMOUNT_OF_OPERATIONS = 1000;
 
     public const OPTION_PROJECTION_LOCK_TIMEOUT = 'lock_timeout_ms';
     public const DEFAULT_PROJECTION_LOCK_TIMEOUT = 1000;


### PR DESCRIPTION
## Description

Projection reset is sloooow.
This PR change the default block size before persisting projection state. It is now 1000 (this is the default value of Prooph) so it will send to db the projection state after handling 1000 events.

This change lower by more than 2 the projection reset time in my production tests.

## Type of change

- Performance

<!--
By submitting this pull request, you agree to the contribution terms defined in [CONTRIBUTING.md](https://github.com/ecotoneframework/ecotone-dev/blob/main/CONTRIBUTING.md).
-->