### PR TITLE
fix gateways fqcn in container definition

### DIFF
--- a/Monorepo/CrossModuleTests/Tests/FullAppTestCase.php
+++ b/Monorepo/CrossModuleTests/Tests/FullAppTestCase.php
@@ -12,9 +12,14 @@ abstract class FullAppTestCase extends FullAppBenchmarkCase
         $this->bench_symfony_prod();
     }
 
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
     public function test_symfony_dev()
     {
         self::clearSymfonyCache();
+        \ini_set("error_log", "/dev/null");
         $this->bench_symfony_dev();
     }
 

--- a/packages/Ecotone/src/Messaging/Handler/Gateway/ProxyFactory.php
+++ b/packages/Ecotone/src/Messaging/Handler/Gateway/ProxyFactory.php
@@ -35,7 +35,7 @@ class ProxyFactory
 
     public static function getGatewayProxyDefinitionFor(GatewayProxyReference $proxyReference): Definition
     {
-        return new Definition(self::getClassNameFor($proxyReference), [
+        return new Definition(self::getFullClassNameFor($proxyReference), [
             new Definition(GatewayProxyReference::class, [
                 $proxyReference->getReferenceName(),
                 $proxyReference->getInterfaceName(),


### PR DESCRIPTION
## Description

Gateway proxies are registered without their namespace in containers (`Ecotone_Modelling_CommandBus` instead of `Ecotone\__Proxy__\Ecotone_Modelling_CommandBus`). It actually works because the service is built from the `ProxyFactory`, but it can have weird side effects, for instance false alerts from phpstan using the symfony extension.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

<!--
By submitting this pull request, you agree to the contribution terms defined in [CONTRIBUTING.md](https://github.com/ecotoneframework/ecotone-dev/blob/main/CONTRIBUTING.md).
-->