### PR TITLE
Proxy generation fix

### DIFF
--- a/packages/Ecotone/src/Messaging/Handler/Gateway/ProxyFactory.php
+++ b/packages/Ecotone/src/Messaging/Handler/Gateway/ProxyFactory.php
@@ -64,14 +64,10 @@ class ProxyFactory
     private function loadProxyClass(GatewayProxyReference $proxyReference): string
     {
         if (! self::isLoaded($proxyReference)) {
-            if ($this->serviceCacheConfiguration->shouldUseCache()) {
-                $file = $this->generateCachedProxyFileFor($proxyReference, false);
-                require $file;
-            } else {
-                $code = $this->generateProxyCode($proxyReference);
-                eval($code);
-            }
+            $file = $this->generateCachedProxyFileFor($proxyReference, !$this->serviceCacheConfiguration->shouldUseCache());
+            require $file;
         }
+        
         return self::getFullClassNameFor($proxyReference);
     }
 


### PR DESCRIPTION
## Description

For some reason evaluating PHP class at run time ends up with errors for Laravel. It acts like it would be looking for a file, when there are none. Therefore it ends up failing.

Therefore instead of relying on in fly evaluation, we can dump the file and depend on this.


## What happens in Laravel

### loading Ecotone
![Screenshot from 2024-10-17 20-33-56](https://github.com/user-attachments/assets/ddf6ec8b-f307-4104-8144-8ad94b9f4d2e)

### adding dump
![Screenshot from 2024-10-17 20-35-27](https://github.com/user-attachments/assets/cd0f59b8-482c-4fee-9ad2-df0f4f472705)

### result
![Screenshot from 2024-10-17 20-35-32](https://github.com/user-attachments/assets/fa6480fe-c0cc-4fd6-b02f-791d82c47645)


## Type of change

- Bug fix (non-breaking change which fixes an issue)