### PR TITLE
Allow to use env variables in Ecotone's Symfony Config

### DIFF
--- a/packages/Laravel/tests/Licence/LicenceTest.php
+++ b/packages/Laravel/tests/Licence/LicenceTest.php
@@ -6,6 +6,7 @@ namespace Test\Ecotone\Laravel\Licence;
 
 use Ecotone\Modelling\CommandBus;
 use Ecotone\Modelling\QueryBus;
+use Ecotone\Test\LicenceTesting;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Http\Kernel;
 use PHPUnit\Framework\TestCase;
@@ -22,11 +23,18 @@ final class LicenceTest extends TestCase
 
     public function setUp(): void
     {
+        putenv('LARAVEL_LICENCE_KEY=' . LicenceTesting::VALID_LICENCE);
+
         $app = require __DIR__ . '/bootstrap/app.php';
         $app->make(Kernel::class)->bootstrap();
         $this->app = $app;
         $this->queryBus = $app->get(QueryBus::class);
         $this->commandBus = $app->get(CommandBus::class);
+    }
+
+    protected function tearDown(): void
+    {
+        putenv('LARAVEL_LICENCE_KEY');
     }
 
     public function test_triggering_laravel_with_licence_key(): void

--- a/packages/Laravel/tests/Licence/config/ecotone.php
+++ b/packages/Laravel/tests/Licence/config/ecotone.php
@@ -7,5 +7,5 @@ return [
         ModulePackageList::LARAVEL_PACKAGE,
         ModulePackageList::ASYNCHRONOUS_PACKAGE,
     ]),
-    'licenceKey' => Ecotone\Test\LicenceTesting::VALID_LICENCE,
+    'licenceKey' => env('LARAVEL_LICENCE_KEY'),
 ];

--- a/packages/Symfony/DependencyInjection/EcotoneExtension.php
+++ b/packages/Symfony/DependencyInjection/EcotoneExtension.php
@@ -3,6 +3,7 @@
 namespace Ecotone\SymfonyBundle\DependencyInjection;
 
 use Ecotone\Messaging\Config\Container\Compiler\RegisterInterfaceToCallReferences;
+use Ecotone\Messaging\Config\EnvironmentVariable;
 use Ecotone\Messaging\Config\MessagingSystemConfiguration;
 use Ecotone\Messaging\Config\ModulePackageList;
 use Ecotone\Messaging\Config\ServiceCacheConfiguration;
@@ -15,6 +16,7 @@ use Ecotone\SymfonyBundle\DependencyInjection\Compiler\SymfonyConfigurationVaria
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Extension\Extension;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
 use Symfony\Component\DependencyInjection\Reference;
 
 /**
@@ -26,6 +28,7 @@ class EcotoneExtension extends Extension
     {
         $configuration = new Configuration();
         $config = $this->processConfiguration($configuration, $configs);
+        $config = $container->resolveEnvPlaceholders($config, true);
 
         $skippedModules = $config['skippedModulePackageNames'] ?? [];
         if (! $config['test']) {

--- a/packages/Symfony/tests/phpunit/Licence/LicenceTest.php
+++ b/packages/Symfony/tests/phpunit/Licence/LicenceTest.php
@@ -6,6 +6,7 @@ namespace Test\Licence;
 
 use Ecotone\Modelling\CommandBus;
 use Ecotone\Modelling\QueryBus;
+use Ecotone\Test\LicenceTesting;
 use PHPUnit\Framework\TestCase;
 use Symfony\App\Licence\Configuration\Kernel;
 
@@ -21,6 +22,7 @@ final class LicenceTest extends TestCase
 
     public function setUp(): void
     {
+        putenv('SYMFONY_LICENCE_KEY=' . LicenceTesting::VALID_LICENCE);
         $kernel = new Kernel('dev', true);
         $kernel->boot();
         $app = $kernel->getContainer();
@@ -30,7 +32,13 @@ final class LicenceTest extends TestCase
         $this->kernel = $kernel;
     }
 
-    public function test_using_enterprise_feature(): void
+    protected function tearDown(): void
+    {
+        putenv('SYMFONY_LICENCE_KEY');
+    }
+
+
+    public function test_triggering_symfony_with_licence_key(): void
     {
         $this->commandBus->sendWithRouting('sendNotification');
 

--- a/packages/Symfony/tests/phpunit/Licence/config/services.php
+++ b/packages/Symfony/tests/phpunit/Licence/config/services.php
@@ -9,7 +9,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             ModulePackageList::SYMFONY_PACKAGE,
             ModulePackageList::ASYNCHRONOUS_PACKAGE,
         ]),
-        'licenceKey' => Ecotone\Test\LicenceTesting::VALID_LICENCE,
+        'licenceKey' => '%env(SYMFONY_LICENCE_KEY)%',
     ]);
 
     $services = $containerConfigurator->services();


### PR DESCRIPTION
## Description

Allow to use env variables in Ecotone config for Symfony.
It will now work for Symfony, just like it does for Laravel. 
Therefore the environment variables will be resolved during container build and use for preparing Ecotone's configuration.

---
Using environment variables is safe as long as container is build with expected variables. If we will for example build the container, dump it into Docker Image, and the run it in container with different environment variables - only the envs used during build will be used. 

## Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)