### PR TITLE
Improve SymfonyConfigurationVariableService: resolve env variables in parameters

### DIFF
--- a/packages/Symfony/DependencyInjection/Compiler/SymfonyConfigurationVariableService.php
+++ b/packages/Symfony/DependencyInjection/Compiler/SymfonyConfigurationVariableService.php
@@ -4,6 +4,7 @@ namespace Ecotone\SymfonyBundle\DependencyInjection\Compiler;
 
 use Ecotone\Messaging\ConfigurationVariableService;
 use Psr\Container\ContainerInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 /**
  * licence Apache-2.0
@@ -16,7 +17,15 @@ class SymfonyConfigurationVariableService implements ConfigurationVariableServic
 
     public function getByName(string $name)
     {
-        return $this->container->getParameter($name);
+        $value = $this->container->getParameter($name);
+        if ($this->container instanceof ContainerBuilder
+            && is_string($value)
+            && str_starts_with($value, '%env(')
+        ) {
+            $value = $this->container->resolveEnvPlaceholders($value, true);
+        }
+
+        return $value;
     }
 
     public function hasName(string $name): bool

--- a/packages/Symfony/DependencyInjection/Compiler/SymfonyConfigurationVariableService.php
+++ b/packages/Symfony/DependencyInjection/Compiler/SymfonyConfigurationVariableService.php
@@ -20,7 +20,8 @@ class SymfonyConfigurationVariableService implements ConfigurationVariableServic
         $value = $this->container->getParameter($name);
         if ($this->container instanceof ContainerBuilder
             && is_string($value)
-            && str_starts_with($value, '%env(')
+            && str_starts_with($value, '%')
+            && str_ends_with($value, '%')
         ) {
             $value = $this->container->resolveEnvPlaceholders($value, true);
         }

--- a/packages/Symfony/tests/phpunit/Kernel.php
+++ b/packages/Symfony/tests/phpunit/Kernel.php
@@ -3,6 +3,7 @@
 namespace Test;
 
 use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 /**
  * licence Apache-2.0
@@ -14,5 +15,12 @@ class Kernel extends \Symfony\Component\HttpKernel\Kernel
     public function getProjectDir(): string
     {
         return __DIR__;
+    }
+
+    public function createContainerBuilder(): ContainerBuilder
+    {
+        $this->initializeBundles();
+
+        return $this->buildContainer();
     }
 }

--- a/packages/Symfony/tests/phpunit/Kernel.php
+++ b/packages/Symfony/tests/phpunit/Kernel.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Test;
+
+use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;
+
+/**
+ * licence Apache-2.0
+ */
+class Kernel extends \Symfony\Component\HttpKernel\Kernel
+{
+    use MicroKernelTrait;
+
+    public function getProjectDir(): string
+    {
+        return __DIR__;
+    }
+}

--- a/packages/Symfony/tests/phpunit/SymfonyApplicationTest.php
+++ b/packages/Symfony/tests/phpunit/SymfonyApplicationTest.php
@@ -66,6 +66,7 @@ class SymfonyApplicationTest extends KernelTestCase
 
         $service = new SymfonyConfigurationVariableService($containerBuilder);
         self::assertEquals($testVar, $service->getByName('test_var'));
+        self::assertEquals($testVar, $service->getByName('test_var_alias'));
 
         $kernel = new Kernel('dev', true);
         $kernel->boot();

--- a/packages/Symfony/tests/phpunit/SymfonyApplicationTest.php
+++ b/packages/Symfony/tests/phpunit/SymfonyApplicationTest.php
@@ -62,6 +62,12 @@ class SymfonyApplicationTest extends KernelTestCase
         putenv('TEST_VAR=' . $testVar);
 
         $kernel = new Kernel('dev', true);
+        $containerBuilder = $kernel->createContainerBuilder();
+
+        $service = new SymfonyConfigurationVariableService($containerBuilder);
+        self::assertEquals($testVar, $service->getByName('test_var'));
+
+        $kernel = new Kernel('dev', true);
         $kernel->boot();
         $container = $kernel->getContainer();
 

--- a/packages/Symfony/tests/phpunit/SymfonyApplicationTest.php
+++ b/packages/Symfony/tests/phpunit/SymfonyApplicationTest.php
@@ -5,6 +5,7 @@ namespace Test;
 use Ecotone\Lite\Test\MessagingTestSupport;
 use Ecotone\Messaging\Config\ConfiguredMessagingSystem;
 use Ecotone\Messaging\Handler\Logger\LoggingGateway;
+use Ecotone\SymfonyBundle\DependencyInjection\Compiler\SymfonyConfigurationVariableService;
 use Monolog\Handler\TestHandler;
 use Monolog\LogRecord;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
@@ -53,7 +54,19 @@ class SymfonyApplicationTest extends KernelTestCase
             self::assertEquals('test', $logRecord['message']);
             self::assertEquals('ecotone', $logRecord['channel']);
         }
+    }
 
+    public function test_configuration_variable_service(): void
+    {
+        $testVar = 'foo';
+        putenv('TEST_VAR=' . $testVar);
+
+        $kernel = new Kernel('dev', true);
+        $kernel->boot();
+        $container = $kernel->getContainer();
+
+        $service = new SymfonyConfigurationVariableService($container);
+        self::assertEquals($testVar, $service->getByName('test_var'));
     }
 
     protected static function getMessagingSystem(): ConfiguredMessagingSystem

--- a/packages/Symfony/tests/phpunit/config/bundles.php
+++ b/packages/Symfony/tests/phpunit/config/bundles.php
@@ -1,0 +1,5 @@
+<?php
+
+return [
+    Symfony\Bundle\FrameworkBundle\FrameworkBundle::class => ['all' => true],
+];

--- a/packages/Symfony/tests/phpunit/config/services.yaml
+++ b/packages/Symfony/tests/phpunit/config/services.yaml
@@ -1,0 +1,2 @@
+parameters:
+  test_var: '%env(TEST_VAR)%'

--- a/packages/Symfony/tests/phpunit/config/services.yaml
+++ b/packages/Symfony/tests/phpunit/config/services.yaml
@@ -1,2 +1,3 @@
 parameters:
   test_var: '%env(TEST_VAR)%'
+  test_var_alias: '%test_var%'


### PR DESCRIPTION
… parameter values

## Description

This fix allows to use ConfigurationVariable with value from env variable for Symfony applications.

Fixes #399

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)