### PR TITLE
Amqp get instead of consume

### DIFF
--- a/packages/Amqp/src/AmqpInboundChannelAdapter.php
+++ b/packages/Amqp/src/AmqpInboundChannelAdapter.php
@@ -16,6 +16,7 @@ use Ecotone\Messaging\Endpoint\PollingConsumer\ConnectionException;
 use Ecotone\Messaging\Handler\Logger\LoggingGateway;
 use Ecotone\Messaging\Message;
 use Ecotone\Messaging\Support\MessageBuilder;
+use Enqueue\AmqpExt\AmqpContext;
 use Interop\Amqp\AmqpMessage;
 use Interop\Queue\Consumer;
 use Interop\Queue\Message as EnqueueMessage;
@@ -72,7 +73,7 @@ class AmqpInboundChannelAdapter extends EnqueueInboundChannelAdapter
     }
 
     /**
-     * @inheritDoc This provides consume instead of get, which does not work well with pnctl extensions (signals are executored)
+     * @inheritDoc This provides consume instead of get, which does not work well with pnctl extensions (signals are not executored)
      */
     public function receiveWithTimeoutOff(int $timeout = 0): ?Message
     {
@@ -104,8 +105,8 @@ class AmqpInboundChannelAdapter extends EnqueueInboundChannelAdapter
         }
     }
 
-    public function connectionException(): string
+    public function connectionException(): array
     {
-        return AMQPConnectionException::class;
+        return [AMQPConnectionException::class, AMQPChannelException::class];
     }
 }

--- a/packages/Amqp/src/AmqpInboundChannelAdapter.php
+++ b/packages/Amqp/src/AmqpInboundChannelAdapter.php
@@ -71,7 +71,10 @@ class AmqpInboundChannelAdapter extends EnqueueInboundChannelAdapter
         return $targetMessage;
     }
 
-    public function receiveWithTimeout(int $timeout = 0): ?Message
+    /**
+     * @inheritDoc This provides consume instead of get, which does not work well with pnctl extensions (signals are executored)
+     */
+    public function receiveWithTimeoutOff(int $timeout = 0): ?Message
     {
         try {
             if ($this->declareOnStartup && $this->initialized === false) {

--- a/packages/Dbal/src/DbalInboundChannelAdapter.php
+++ b/packages/Dbal/src/DbalInboundChannelAdapter.php
@@ -19,8 +19,8 @@ class DbalInboundChannelAdapter extends EnqueueInboundChannelAdapter
         $context->createDataBaseTable();
     }
 
-    public function connectionException(): string
+    public function connectionException(): array
     {
-        return ConnectionException::class;
+        return [ConnectionException::class];
     }
 }

--- a/packages/Enqueue/src/EnqueueInboundChannelAdapter.php
+++ b/packages/Enqueue/src/EnqueueInboundChannelAdapter.php
@@ -80,11 +80,17 @@ abstract class EnqueueInboundChannelAdapter implements MessagePoller
         }
     }
 
-    abstract public function connectionException(): string;
+    abstract public function connectionException(): array;
 
     private function isConnectionException(Exception $exception): bool
     {
-        return is_subclass_of($exception, $this->connectionException()) || $exception::class === $this->connectionException();
+        foreach ($this->connectionException() as $connectionException) {
+            if (is_subclass_of($exception, $connectionException) || $exception::class === $connectionException) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     public function getQueueName(): string

--- a/packages/Redis/src/RedisInboundChannelAdapter.php
+++ b/packages/Redis/src/RedisInboundChannelAdapter.php
@@ -20,8 +20,8 @@ final class RedisInboundChannelAdapter extends EnqueueInboundChannelAdapter
         $context->createQueue($this->queueName);
     }
 
-    public function connectionException(): string
+    public function connectionException(): array
     {
-        return ConnectionException::class;
+        return [ConnectionException::class];
     }
 }

--- a/packages/Sqs/src/SqsInboundChannelAdapter.php
+++ b/packages/Sqs/src/SqsInboundChannelAdapter.php
@@ -21,8 +21,8 @@ final class SqsInboundChannelAdapter extends EnqueueInboundChannelAdapter
         $context->declareQueue($context->createQueue($this->queueName));
     }
 
-    public function connectionException(): string
+    public function connectionException(): array
     {
-        return ConnectException::class;
+        return [ConnectException::class];
     }
 }


### PR DESCRIPTION
## Why is this change proposed?

pnctl signals are not executed due to blocking consume, therefore we have to turn it off. 
The minus of this is consume is quicker in the consumption process, and it works with Streams. 
So if this will be fixed in the amqp extension, we can revert that back.

fixes #410 

## Pull Request Contribution Terms

- [X] I have read and agree to the contribution terms outlined in [CONTRIBUTING](https://github.com/ecotoneframework/ecotone-dev/blob/main/CONTRIBUTING.md).