### PR TITLE
Allow expression language for delaying and time to live

### DIFF
--- a/packages/Ecotone/src/Lite/Test/Configuration/DelayedMessageReleaseHandler.php
+++ b/packages/Ecotone/src/Lite/Test/Configuration/DelayedMessageReleaseHandler.php
@@ -7,6 +7,7 @@ namespace Ecotone\Lite\Test\Configuration;
 use Ecotone\Messaging\Channel\DelayableQueueChannel;
 use Ecotone\Messaging\Channel\MessageChannelInterceptorAdapter;
 use Ecotone\Messaging\Handler\ChannelResolver;
+use Ecotone\Messaging\Scheduling\TimeSpan;
 use Ecotone\Messaging\Support\Assert;
 
 /**
@@ -14,7 +15,7 @@ use Ecotone\Messaging\Support\Assert;
  */
 final class DelayedMessageReleaseHandler
 {
-    public function releaseMessagesAwaitingFor(string $channelName, int $timeInMilliseconds, ChannelResolver $channelResolver): void
+    public function releaseMessagesAwaitingFor(string $channelName, int|TimeSpan|\DateTimeInterface $timeInMillisecondsOrDateTime, ChannelResolver $channelResolver): void
     {
         /** @var DelayableQueueChannel|MessageChannelInterceptorAdapter $channel */
         $channel = $channelResolver->resolve($channelName);
@@ -24,6 +25,6 @@ final class DelayedMessageReleaseHandler
 
         Assert::isTrue($channel instanceof DelayableQueueChannel, sprintf('Used %s channel to release delayed message, use instead of %s.', $channel::class, DelayableQueueChannel::class));
 
-        $channel->releaseMessagesAwaitingFor($timeInMilliseconds);
+        $channel->releaseMessagesAwaitingFor($timeInMillisecondsOrDateTime);
     }
 }

--- a/packages/Ecotone/src/Lite/Test/Configuration/EcotoneTestSupportModule.php
+++ b/packages/Ecotone/src/Lite/Test/Configuration/EcotoneTestSupportModule.php
@@ -200,7 +200,7 @@ final class EcotoneTestSupportModule extends NoExternalConfigurationModule imple
             )
                 ->withMethodParameterConverters([
                     HeaderBuilder::create('channelName', 'ecotone.test_support_gateway.channel_name'),
-                    PayloadBuilder::create('timeInMilliseconds'),
+                    PayloadBuilder::create('timeInMillisecondsOrDateTime'),
                     ReferenceBuilder::create('channelResolver', ChannelResolver::class),
                 ])
                 ->withInputChannelName(self::inputChannelName(self::RELEASE_DELAYED_MESSAGES)))
@@ -211,7 +211,7 @@ final class EcotoneTestSupportModule extends NoExternalConfigurationModule imple
                 self::inputChannelName(self::RELEASE_DELAYED_MESSAGES)
             )->withParameterConverters([
                 GatewayHeaderBuilder::create('channelName', 'ecotone.test_support_gateway.channel_name'),
-                GatewayPayloadBuilder::create('timeInMilliseconds'),
+                GatewayPayloadBuilder::create('timeInMillisecondsOrDateTime'),
             ]));
     }
 

--- a/packages/Ecotone/src/Lite/Test/FlowTestSupport.php
+++ b/packages/Ecotone/src/Lite/Test/FlowTestSupport.php
@@ -90,12 +90,13 @@ final class FlowTestSupport
     }
 
     /**
-     * @param int $time Time in milliseconds or DelayedTime object
+     * @param int $time Time in milliseconds or TimeSpan object
+     *
+     * @deprecated use run instead
      */
-    public function releaseAwaitingMessagesAndRunConsumer(string $channelName, int|TimeSpan $time, ?ExecutionPollingMetadata $executionPollingMetadata = null): self
+    public function releaseAwaitingMessagesAndRunConsumer(string $channelName, int|TimeSpan|\DateTimeInterface $time, ?ExecutionPollingMetadata $executionPollingMetadata = null): self
     {
-        $this->testSupportGateway->releaseMessagesAwaitingFor($channelName, $time instanceof TimeSpan ? $time->toMilliseconds() : $time);
-        $this->run($channelName, $executionPollingMetadata);
+        $this->run($channelName, $executionPollingMetadata, is_int($time) ? TimeSpan::withMilliseconds($time) : $time);
 
         return $this;
     }
@@ -129,8 +130,14 @@ final class FlowTestSupport
         return $messageChannel->receive();
     }
 
-    public function run(string $name, ?ExecutionPollingMetadata $executionPollingMetadata = null): self
+    /**
+     * @param int|TimeSpan|\DateTimeInterface $releaseAwaitingFor will release messages which are delayed for given time
+     */
+    public function run(string $name, ?ExecutionPollingMetadata $executionPollingMetadata = null, TimeSpan|\DateTimeInterface|null $releaseAwaitingFor = null): self
     {
+        if ($releaseAwaitingFor) {
+            $this->testSupportGateway->releaseMessagesAwaitingFor($name, $releaseAwaitingFor);
+        }
         $this->configuredMessagingSystem->run($name, $executionPollingMetadata);
 
         return $this;

--- a/packages/Ecotone/src/Lite/Test/MessagingTestSupport.php
+++ b/packages/Ecotone/src/Lite/Test/MessagingTestSupport.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Ecotone\Lite\Test;
 
 use Ecotone\Messaging\Message;
+use Ecotone\Messaging\Scheduling\TimeSpan;
 
 /**
  * licence Apache-2.0
@@ -59,5 +60,5 @@ interface MessagingTestSupport
 
     public function discardRecordedMessages(): void;
 
-    public function releaseMessagesAwaitingFor(string $channelName, int $timeInMilliseconds): void;
+    public function releaseMessagesAwaitingFor(string $channelName, int|TimeSpan|\DateTimeInterface $timeInMillisecondsOrDateTime): void;
 }

--- a/packages/Ecotone/src/Messaging/Attribute/Endpoint/AddHeader.php
+++ b/packages/Ecotone/src/Messaging/Attribute/Endpoint/AddHeader.php
@@ -14,9 +14,14 @@ class AddHeader
     private string $headerName;
     private mixed $headerValue;
 
-    public function __construct(string $name, mixed $value)
+    public function __construct(string $name, mixed $value = null, private string|null $expression = null)
     {
         Assert::notNullAndEmpty($name, 'Name of the header can not be empty');
+        Assert::isTrue(
+            ($value === null && $expression !== null)
+            || ($value !== null && $expression === null),
+            'Either value or expression should be provided for attribute ' . static ::class
+        );
 
         $this->headerName  = $name;
         $this->headerValue = $value;
@@ -30,5 +35,15 @@ class AddHeader
     public function getHeaderValue(): mixed
     {
         return $this->headerValue;
+    }
+
+    public function isExpression(): bool
+    {
+        return false;
+    }
+
+    public function getExpression(): ?string
+    {
+        return $this->expression;
     }
 }

--- a/packages/Ecotone/src/Messaging/Attribute/Endpoint/Delayed.php
+++ b/packages/Ecotone/src/Messaging/Attribute/Endpoint/Delayed.php
@@ -7,6 +7,7 @@ namespace Ecotone\Messaging\Attribute\Endpoint;
 use Attribute;
 use Ecotone\Messaging\MessageHeaders;
 use Ecotone\Messaging\Scheduling\TimeSpan;
+use Ecotone\Messaging\Support\Assert;
 
 #[Attribute(Attribute::TARGET_CLASS | Attribute::TARGET_METHOD)]
 /**
@@ -15,10 +16,10 @@ use Ecotone\Messaging\Scheduling\TimeSpan;
 class Delayed extends AddHeader
 {
     /**
-     * @param int|TimeSpan $time if integer is provided it is treated as milliseconds
+     * @param int|TimeSpan|\DateTimeInterface $time if integer is provided it is treated as milliseconds
      */
-    public function __construct(int|TimeSpan $time)
+    public function __construct(int|TimeSpan|\DateTimeInterface|null $time = null, ?string $expression = null)
     {
-        parent::__construct(MessageHeaders::DELIVERY_DELAY, $time instanceof TimeSpan ? $time->toMilliseconds() : $time);
+        parent::__construct(MessageHeaders::DELIVERY_DELAY, $time, $expression);
     }
 }

--- a/packages/Ecotone/src/Messaging/Attribute/Endpoint/TimeToLive.php
+++ b/packages/Ecotone/src/Messaging/Attribute/Endpoint/TimeToLive.php
@@ -17,8 +17,8 @@ class TimeToLive extends AddHeader
     /**
      * @param int|TimeSpan $time if integer is provided it is treated as milliseconds
      */
-    public function __construct(int|TimeSpan $time)
+    public function __construct(int|TimeSpan|null $time = null, ?string $expression = null)
     {
-        parent::__construct(MessageHeaders::TIME_TO_LIVE, $time instanceof TimeSpan ? $time->toMilliseconds() : $time);
+        parent::__construct(MessageHeaders::TIME_TO_LIVE, $time instanceof TimeSpan ? $time->toMilliseconds() : $time, $expression);
     }
 }

--- a/packages/Ecotone/src/Messaging/Channel/DelayableQueueChannel.php
+++ b/packages/Ecotone/src/Messaging/Channel/DelayableQueueChannel.php
@@ -6,9 +6,14 @@ namespace Ecotone\Messaging\Channel;
 
 use Ecotone\Messaging\Config\Container\DefinedObject;
 use Ecotone\Messaging\Config\Container\Definition;
+use Ecotone\Messaging\Config\Container\Reference;
 use Ecotone\Messaging\Message;
 use Ecotone\Messaging\MessageHeaders;
 use Ecotone\Messaging\PollableChannel;
+use Ecotone\Messaging\Scheduling\Clock;
+use Ecotone\Messaging\Scheduling\EpochBasedClock;
+use Ecotone\Messaging\Scheduling\StubUTCClock;
+use Ecotone\Messaging\Scheduling\TimeSpan;
 use Ecotone\Messaging\Support\MessageBuilder;
 
 /**
@@ -19,13 +24,13 @@ final class DelayableQueueChannel implements PollableChannel, DefinedObject
     /**
      * @param Message[] $queue
      */
-    private function __construct(private string $name, private array $queue, private int $releaseMessagesAwaitingFor = 0)
+    public function __construct(private string $name, private array $queue = [], private int|\DateTimeInterface $releaseMessagesAwaitingFor = 0)
     {
     }
 
-    public static function create(string $name = 'unknown'): self
+    public static function create(string $name): self
     {
-        return new self($name, []);
+        return new self($name);
     }
 
     /**
@@ -44,7 +49,7 @@ final class DelayableQueueChannel implements PollableChannel, DefinedObject
         $message = array_shift($this->queue);
 
         if ($message !== null && $message->getHeaders()->containsKey(MessageHeaders::DELIVERY_DELAY)) {
-            if ($message->getHeaders()->get(MessageHeaders::DELIVERY_DELAY) > $this->releaseMessagesAwaitingFor) {
+            if ($message->getHeaders()->get(MessageHeaders::DELIVERY_DELAY) > $this->getCurrentDeliveryTimeShift($message)) {
                 $nextAvailableMessage = $this->receive();
                 array_unshift($this->queue, $message);
 
@@ -71,9 +76,9 @@ final class DelayableQueueChannel implements PollableChannel, DefinedObject
         return $this->receive();
     }
 
-    public function releaseMessagesAwaitingFor(int $milliseconds): void
+    public function releaseMessagesAwaitingFor(int|TimeSpan|\DateTimeInterface $time): void
     {
-        $this->releaseMessagesAwaitingFor = $milliseconds;
+        $this->releaseMessagesAwaitingFor = $time instanceof TimeSpan ? $time->toMilliseconds() : $time;
     }
 
     public function __toString()
@@ -84,5 +89,14 @@ final class DelayableQueueChannel implements PollableChannel, DefinedObject
     public function getDefinition(): Definition
     {
         return new Definition(self::class, [$this->name], 'create');
+    }
+
+    public function getCurrentDeliveryTimeShift(Message $message): int
+    {
+        if ($this->releaseMessagesAwaitingFor instanceof \DateTimeInterface) {
+            return EpochBasedClock::getTimestampWithMillisecondsFor($this->releaseMessagesAwaitingFor) - ($message->getHeaders()->getTimestamp() * 1000);
+        }
+
+        return $this->releaseMessagesAwaitingFor;
     }
 }

--- a/packages/Ecotone/src/Messaging/Channel/PollableChannel/Serialization/OutboundMessageConverter.php
+++ b/packages/Ecotone/src/Messaging/Channel/PollableChannel/Serialization/OutboundMessageConverter.php
@@ -10,6 +10,8 @@ use Ecotone\Messaging\Handler\TypeDescriptor;
 use Ecotone\Messaging\Message;
 use Ecotone\Messaging\MessageConverter\HeaderMapper;
 use Ecotone\Messaging\MessageHeaders;
+use Ecotone\Messaging\Scheduling\Clock;
+use Ecotone\Messaging\Scheduling\EpochBasedClock;
 
 /**
  * licence Apache-2.0
@@ -91,11 +93,21 @@ class OutboundMessageConverter
         }
         $applicationHeaders[MessageHeaders::CONTENT_TYPE] = $sourceMediaType?->toString();
 
+        $deliveryDelay = $messageToConvert->getHeaders()->containsKey(MessageHeaders::DELIVERY_DELAY) ? $messageToConvert->getHeaders()->get(MessageHeaders::DELIVERY_DELAY) : $this->defaultDeliveryDelay;
+
+        if ($deliveryDelay instanceof \DateTimeInterface) {
+            $deliveryDelay = EpochBasedClock::getTimestampWithMillisecondsFor($deliveryDelay) - ($messageToConvert->getHeaders()->getTimestamp() * 1000);
+
+            if ($deliveryDelay < 0) {
+                $deliveryDelay = null;
+            }
+        }
+
         return new OutboundMessage(
             $messagePayload,
             array_merge($applicationHeaders, $this->staticHeadersToAdd),
             $applicationHeaders[MessageHeaders::CONTENT_TYPE],
-            $messageToConvert->getHeaders()->containsKey(MessageHeaders::DELIVERY_DELAY) ? $messageToConvert->getHeaders()->get(MessageHeaders::DELIVERY_DELAY) : $this->defaultDeliveryDelay,
+            $deliveryDelay,
             $messageToConvert->getHeaders()->containsKey(MessageHeaders::TIME_TO_LIVE) ? $messageToConvert->getHeaders()->get(MessageHeaders::TIME_TO_LIVE) : $this->defaultTimeToLive,
             $messageToConvert->getHeaders()->containsKey(MessageHeaders::PRIORITY) ? $messageToConvert->getHeaders()->get(MessageHeaders::PRIORITY) : $this->defaultPriority,
         );

--- a/packages/Ecotone/src/Messaging/Config/Annotation/ModuleConfiguration/EndpointHeaders/EndpointHeadersInterceptor.php
+++ b/packages/Ecotone/src/Messaging/Config/Annotation/ModuleConfiguration/EndpointHeaders/EndpointHeadersInterceptor.php
@@ -9,9 +9,18 @@ use Ecotone\Messaging\Attribute\Endpoint\Delayed;
 use Ecotone\Messaging\Attribute\Endpoint\Priority;
 use Ecotone\Messaging\Attribute\Endpoint\RemoveHeader;
 use Ecotone\Messaging\Attribute\Endpoint\TimeToLive;
+use Ecotone\Messaging\Config\ConfigurationException;
 use Ecotone\Messaging\Config\Container\DefinedObject;
 use Ecotone\Messaging\Config\Container\Definition;
+use Ecotone\Messaging\Config\Container\Reference;
+use Ecotone\Messaging\Handler\ExpressionEvaluationService;
+use Ecotone\Messaging\Handler\TypeDescriptor;
+use Ecotone\Messaging\Handler\UnionTypeDescriptor;
 use Ecotone\Messaging\MessageHeaders;
+use Ecotone\Messaging\Message;
+use Ecotone\Messaging\MessagingException;
+use Ecotone\Messaging\Scheduling\TimeSpan;
+use Nette\Utils\Type;
 
 /**
  * Class EndpointHeadersInterceptor
@@ -23,24 +32,74 @@ use Ecotone\Messaging\MessageHeaders;
  */
 class EndpointHeadersInterceptor implements DefinedObject
 {
-    public function addMetadata(?AddHeader $addHeader, ?Delayed $delayed, ?Priority $priority, ?TimeToLive $timeToLive, ?RemoveHeader $removeHeader): array
+    public function __construct(private ExpressionEvaluationService $expressionEvaluationService)
+    {
+
+    }
+
+    public function addMetadata(Message $message, ?AddHeader $addHeader, ?Delayed $delayed, ?Priority $priority, ?TimeToLive $timeToLive, ?RemoveHeader $removeHeader): array
     {
         $metadata = [];
 
         if ($addHeader) {
             $metadata[$addHeader->getHeaderName()] = $addHeader->getHeaderValue();
+
+            if ($addHeader->getExpression()) {
+                $metadata[$addHeader->getHeaderName()] = $this->expressionEvaluationService->evaluate($addHeader->getExpression(), [
+                    'payload' => $message->getPayload(),
+                    'headers' => $message->getHeaders()->headers()
+                ]);
+            }
         }
 
         if ($delayed) {
             $metadata[MessageHeaders::DELIVERY_DELAY] = $delayed->getHeaderValue();
+
+            if ($delayed->getExpression()) {
+                $metadata[MessageHeaders::DELIVERY_DELAY] = $this->expressionEvaluationService->evaluate($delayed->getExpression(), [
+                    'payload' => $message->getPayload(),
+                    'headers' => $message->getHeaders()->headers()
+                ]);
+            }
+
+            $type = TypeDescriptor::createFromVariable($metadata[MessageHeaders::DELIVERY_DELAY]);
+            if (!$type->isCompatibleWith(UnionTypeDescriptor::createWith([
+                TypeDescriptor::createIntegerType(),
+                TypeDescriptor::create(TimeSpan::class),
+                TypeDescriptor::create(\DateTimeInterface::class)
+            ]))) {
+                throw ConfigurationException::create("Delivery delay should be either integer, TimeSpan or DateTimeInterface, but got {$type->toString()}");
+            }
         }
 
         if ($priority) {
             $metadata[MessageHeaders::PRIORITY] = $priority->getHeaderValue();
+
+            if ($priority->getExpression()) {
+                $metadata[MessageHeaders::PRIORITY] = $this->expressionEvaluationService->evaluate($priority->getExpression(), [
+                    'payload' => $message->getPayload(),
+                    'headers' => $message->getHeaders()->headers()
+                ]);
+            }
         }
 
         if ($timeToLive) {
             $metadata[MessageHeaders::TIME_TO_LIVE] = $timeToLive->getHeaderValue();
+
+            if ($timeToLive->getExpression()) {
+                $metadata[MessageHeaders::TIME_TO_LIVE] = $this->expressionEvaluationService->evaluate($timeToLive->getExpression(), [
+                    'payload' => $message->getPayload(),
+                    'headers' => $message->getHeaders()->headers()
+                ]);
+            }
+
+            $type = TypeDescriptor::createFromVariable($metadata[MessageHeaders::TIME_TO_LIVE]);
+            if (!$type->isCompatibleWith(UnionTypeDescriptor::createWith([
+                TypeDescriptor::createIntegerType(),
+                TypeDescriptor::create(TimeSpan::class)
+            ]))) {
+                throw ConfigurationException::create("Delivery delay should be either integer or TimeSpan, but got {$type->toString()}");
+            }
         }
 
         if ($removeHeader) {
@@ -52,6 +111,8 @@ class EndpointHeadersInterceptor implements DefinedObject
 
     public function getDefinition(): Definition
     {
-        return new Definition(self::class);
+        return new Definition(self::class, [
+            Reference::to(ExpressionEvaluationService::REFERENCE)
+        ]);
     }
 }

--- a/packages/Ecotone/src/Messaging/Config/Annotation/ModuleConfiguration/EndpointHeaders/EndpointHeadersInterceptorModule.php
+++ b/packages/Ecotone/src/Messaging/Config/Annotation/ModuleConfiguration/EndpointHeaders/EndpointHeadersInterceptorModule.php
@@ -10,8 +10,10 @@ use Ecotone\Messaging\Config\Annotation\AnnotationModule;
 use Ecotone\Messaging\Config\Annotation\ModuleConfiguration\NoExternalConfigurationModule;
 use Ecotone\Messaging\Config\Configuration;
 use Ecotone\Messaging\Config\Container\Definition;
+use Ecotone\Messaging\Config\Container\Reference;
 use Ecotone\Messaging\Config\ModulePackageList;
 use Ecotone\Messaging\Config\ModuleReferenceSearchService;
+use Ecotone\Messaging\Handler\ExpressionEvaluationService;
 use Ecotone\Messaging\Handler\InterfaceToCallRegistry;
 use Ecotone\Messaging\Handler\Processor\MethodInvoker\MethodInterceptorBuilder;
 use Ecotone\Messaging\Precedence;
@@ -38,7 +40,7 @@ class EndpointHeadersInterceptorModule extends NoExternalConfigurationModule imp
         $interfaceToCall = $interfaceToCallRegistry->getFor(EndpointHeadersInterceptor::class, 'addMetadata');
         $messagingConfiguration->registerBeforeSendInterceptor(
             MethodInterceptorBuilder::create(
-                new Definition(EndpointHeadersInterceptor::class),
+                new Definition(EndpointHeadersInterceptor::class, [Reference::to(ExpressionEvaluationService::REFERENCE)]),
                 $interfaceToCall,
                 Precedence::ENDPOINT_HEADERS_PRECEDENCE,
                 AddHeader::class . '||' . RemoveHeader::class,

--- a/packages/Ecotone/src/Messaging/Scheduling/EpochBasedClock.php
+++ b/packages/Ecotone/src/Messaging/Scheduling/EpochBasedClock.php
@@ -19,6 +19,21 @@ class EpochBasedClock implements Clock
      */
     public function unixTimeInMilliseconds(): int
     {
+        return $this->getCurrentTimeInMilliseconds();
+    }
+
+    public static function getCurrentTimeInMilliseconds(): int
+    {
         return (int)round(microtime(true) * 1000);
+    }
+
+    public static function getTimestampWithMillisecondsFor(\DateTimeInterface $dateTime): int
+    {
+        return (int)round($dateTime->format('U.u') * 1000);
+    }
+
+    public static function getTimestampFor(\DateTimeInterface $dateTime): int
+    {
+        return (int)$dateTime->format('U');
     }
 }

--- a/packages/Ecotone/src/Messaging/Scheduling/StubUTCClock.php
+++ b/packages/Ecotone/src/Messaging/Scheduling/StubUTCClock.php
@@ -17,15 +17,11 @@ use DateTimeZone;
  */
 class StubUTCClock implements Clock
 {
-    private int $currentTime;
-
-    /**
-     * StubClock constructor.
-     * @param int $currentTime
-     */
-    private function __construct(int $currentTime)
+    public function __construct(
+        private ?int $currentTime = null
+    )
     {
-        $this->currentTime = $currentTime;
+
     }
 
     /**
@@ -37,12 +33,17 @@ class StubUTCClock implements Clock
         return new self(self::createEpochTimeInMilliseconds($currentTime));
     }
 
+    public static function createNow(): self
+    {
+        return new self();
+    }
+
     /**
      * @inheritDoc
      */
     public function unixTimeInMilliseconds(): int
     {
-        return $this->currentTime;
+        return $this->currentTime !== null ? $this->currentTime : self::createEpochTimeInMilliseconds('now');
     }
 
     public function sleep(int $seconds): void
@@ -55,13 +56,14 @@ class StubUTCClock implements Clock
         $this->currentTime += (int)round($microseconds / 1000);
     }
 
-    /**
-     * @param string $newCurrentTime
-     * @return void
-     */
-    public function changeCurrentTime(string $newCurrentTime): void
+    public function changeCurrentTime(string|\DateTimeInterface $newCurrentTime): void
     {
         $this->currentTime = self::createEpochTimeInMilliseconds($newCurrentTime);
+    }
+
+    public function changeCurrentTimeWithMillisecondsTimestamp(int $milliseconds): void
+    {
+        $this->currentTime = $milliseconds;
     }
 
     /**
@@ -73,12 +75,19 @@ class StubUTCClock implements Clock
         return self::createEpochTimeInMilliseconds($dateTimeAsString);
     }
 
-    /**
-     * @param string $dateTimeAsString
-     * @return int
-     */
-    private static function createEpochTimeInMilliseconds(string $dateTimeAsString): int
+    public function isTimeAlreadyChanged(): bool
     {
-        return (int)round((new DateTime($dateTimeAsString, new DateTimeZone('UTC')))->format('U') * 1000);
+        return $this->currentTime !== null;
+    }
+
+    private static function createEpochTimeInMilliseconds(string|\DateTimeInterface $dateTime): int
+    {
+        if ($dateTime === 'now') {
+            return EpochBasedClock::getCurrentTimeInMilliseconds();
+        }
+
+        return EpochBasedClock::getTimestampWithMillisecondsFor(
+            is_string($dateTime) ? new DateTime($dateTime, new DateTimeZone('UTC')) : $dateTime
+        );
     }
 }

--- a/packages/Ecotone/src/Messaging/Scheduling/TimeSpan.php
+++ b/packages/Ecotone/src/Messaging/Scheduling/TimeSpan.php
@@ -22,6 +22,31 @@ final class TimeSpan implements DefinedObject
 
     }
 
+    public static function withMilliseconds(int $milliseconds): self
+    {
+        return new self(milliseconds: $milliseconds);
+    }
+
+    public static function withSeconds(int $seconds): self
+    {
+        return new self(seconds: $seconds);
+    }
+
+    public static function withMinutes(int $minutes): self
+    {
+        return new self(minutes: $minutes);
+    }
+
+    public static function withHours(int $hours): self
+    {
+        return new self(hours: $hours);
+    }
+
+    public static function withDays(int $days): self
+    {
+        return new self(days: $days);
+    }
+
     public function toMilliseconds(): int
     {
         return $this->milliseconds + $this->seconds * 1000 + $this->minutes * 60 * 1000 + $this->hours * 60 * 60 * 1000 + $this->days * 24 * 60 * 60 * 1000;

--- a/packages/Ecotone/tests/Lite/Test/MessagingTestSupportFrameworkTest.php
+++ b/packages/Ecotone/tests/Lite/Test/MessagingTestSupportFrameworkTest.php
@@ -14,6 +14,7 @@ use Ecotone\Messaging\Conversion\MediaType;
 use Ecotone\Messaging\Endpoint\PollingMetadata;
 use Ecotone\Messaging\Handler\DestinationResolutionException;
 use Ecotone\Messaging\MessageHeaders;
+use Ecotone\Messaging\Scheduling\EpochBasedClock;
 use Ecotone\Messaging\Scheduling\TimeSpan;
 use Ecotone\Modelling\CommandBus;
 use PHPUnit\Framework\TestCase;
@@ -462,32 +463,7 @@ final class MessagingTestSupportFrameworkTest extends TestCase
         $this->assertNotEmpty($ecotoneLite->getQueryBus()->sendWithRouting('order.getOrders'));
     }
 
-    public function test_releasing_delayed_message_with_passed_milliseconds()
-    {
-        $ecotoneTestSupport = EcotoneLite::bootstrapFlowTesting(
-            [OrderService::class, PlaceOrderConverter::class, OrderWasPlacedConverter::class],
-            [new OrderService(), new PlaceOrderConverter(), new OrderWasPlacedConverter()],
-            enableAsynchronousProcessing: [
-                SimpleMessageChannelBuilder::createQueueChannel('orders', true, MediaType::createApplicationXPHPArray()),
-            ]
-        );
-
-        $orderId = 'someId';
-        $ecotoneTestSupport->sendCommandWithRoutingKey('order.register', new PlaceOrder($orderId), metadata: [
-            MessageHeaders::DELIVERY_DELAY => 100,
-        ]);
-
-        $ecotoneTestSupport->run('orders');
-        $this->assertEquals([], $ecotoneTestSupport->sendQueryWithRouting('order.getNotifiedOrders'));
-
-        $ecotoneTestSupport->releaseAwaitingMessagesAndRunConsumer('orders', 10);
-        $this->assertEquals([], $ecotoneTestSupport->sendQueryWithRouting('order.getNotifiedOrders'));
-
-        $ecotoneTestSupport->releaseAwaitingMessagesAndRunConsumer('orders', 100);
-        $this->assertEquals([$orderId], $ecotoneTestSupport->sendQueryWithRouting('order.getNotifiedOrders'));
-    }
-
-    public function test_releasing_delayed_message()
+    public function test_releasing_delayed_message_time_time_span_object()
     {
         $ecotoneTestSupport = EcotoneLite::bootstrapFlowTesting(
             [OrderService::class, PlaceOrderConverter::class, OrderWasPlacedConverter::class],
@@ -505,10 +481,55 @@ final class MessagingTestSupportFrameworkTest extends TestCase
         $ecotoneTestSupport->run('orders');
         $this->assertEquals([], $ecotoneTestSupport->sendQueryWithRouting('order.getNotifiedOrders'));
 
-        $ecotoneTestSupport->releaseAwaitingMessagesAndRunConsumer('orders', new TimeSpan(milliseconds: 10));
+        $ecotoneTestSupport->run('orders', releaseAwaitingFor: new TimeSpan(milliseconds: 10));
         $this->assertEquals([], $ecotoneTestSupport->sendQueryWithRouting('order.getNotifiedOrders'));
 
-        $ecotoneTestSupport->releaseAwaitingMessagesAndRunConsumer('orders', new TimeSpan(100));
+        $ecotoneTestSupport->run('orders', releaseAwaitingFor: new TimeSpan(100));
+        $this->assertEquals([$orderId], $ecotoneTestSupport->sendQueryWithRouting('order.getNotifiedOrders'));
+    }
+
+    public function test_delaying_till_specific_moment_in_time()
+    {
+        $ecotoneTestSupport = EcotoneLite::bootstrapFlowTesting(
+            [OrderService::class, PlaceOrderConverter::class, OrderWasPlacedConverter::class],
+            [new OrderService(), new PlaceOrderConverter(), new OrderWasPlacedConverter()],
+            enableAsynchronousProcessing: [
+                SimpleMessageChannelBuilder::createQueueChannel('orders', true, MediaType::createApplicationXPHPArray()),
+            ],
+        );
+
+        $orderId = 'someId';
+        $ecotoneTestSupport->sendCommandWithRoutingKey('order.register', new PlaceOrder($orderId), metadata: [
+            MessageHeaders::DELIVERY_DELAY => $delayTime = new \DateTimeImmutable('+1 hour'),
+        ]);
+
+        $ecotoneTestSupport->run('orders');
+        $this->assertEquals([], $ecotoneTestSupport->sendQueryWithRouting('order.getNotifiedOrders'));
+
+        $ecotoneTestSupport->run('orders', releaseAwaitingFor: $delayTime->modify('-1 seconds'));
+        $this->assertEquals([], $ecotoneTestSupport->sendQueryWithRouting('order.getNotifiedOrders'));
+
+        $ecotoneTestSupport->run('orders', releaseAwaitingFor: $delayTime);
+        $this->assertEquals([$orderId], $ecotoneTestSupport->sendQueryWithRouting('order.getNotifiedOrders'));
+    }
+
+    public function test_delaying_with_past_date_make_it_available_right_away(): void
+    {
+        $ecotoneTestSupport = EcotoneLite::bootstrapFlowTesting(
+            [OrderService::class, PlaceOrderConverter::class, OrderWasPlacedConverter::class],
+            [new OrderService(), new PlaceOrderConverter(), new OrderWasPlacedConverter()],
+            enableAsynchronousProcessing: [
+                SimpleMessageChannelBuilder::createQueueChannel('orders', true, MediaType::createApplicationXPHPArray()),
+            ],
+        );
+
+        $orderId = 'someId';
+        $ecotoneTestSupport->sendCommandWithRoutingKey('order.register', new PlaceOrder($orderId), metadata: [
+            MessageHeaders::TIMESTAMP => EpochBasedClock::getTimestampFor($time = new \DateTimeImmutable('2020-01-01 12:00:00')),
+            MessageHeaders::DELIVERY_DELAY => $time->modify('-1 hour'),
+        ]);
+
+        $ecotoneTestSupport->run('orders');
         $this->assertEquals([$orderId], $ecotoneTestSupport->sendQueryWithRouting('order.getNotifiedOrders'));
     }
 }

--- a/packages/Ecotone/tests/Messaging/Fixture/AddHeaders/AddingMultipleHeaders.php
+++ b/packages/Ecotone/tests/Messaging/Fixture/AddHeaders/AddingMultipleHeaders.php
@@ -28,4 +28,14 @@ final class AddingMultipleHeaders
     {
 
     }
+
+    #[Delayed(expression: 'payload.delay')]
+    #[AddHeader('token', expression: 'headers["token"]')]
+    #[TimeToLive(expression: 'payload.timeToLive')]
+    #[Asynchronous('async')]
+    #[CommandHandler('addHeadersWithExpression', endpointId: 'addHeadersEndpointWithExpression')]
+    public function withExpression(): void
+    {
+
+    }
 }

--- a/packages/Ecotone/tests/Messaging/Unit/Channel/DelayableQueueChannelTest.php
+++ b/packages/Ecotone/tests/Messaging/Unit/Channel/DelayableQueueChannelTest.php
@@ -4,6 +4,9 @@ namespace Test\Ecotone\Messaging\Unit\Channel;
 
 use Ecotone\Messaging\Channel\DelayableQueueChannel;
 use Ecotone\Messaging\MessageHeaders;
+use Ecotone\Messaging\Scheduling\EpochBasedClock;
+use Ecotone\Messaging\Scheduling\StubUTCClock;
+use Ecotone\Messaging\Scheduling\TimeSpan;
 use Ecotone\Messaging\Support\MessageBuilder;
 use PHPUnit\Framework\TestCase;
 
@@ -18,7 +21,7 @@ class DelayableQueueChannelTest extends TestCase
 {
     public function test_sending_and_receiving_message_in_last_in_first_out_order()
     {
-        $queueChannel = DelayableQueueChannel::create();
+        $queueChannel = new DelayableQueueChannel('test');
 
         $firstMessage = MessageBuilder::withPayload('first')->build();
         $secondMessage = MessageBuilder::withPayload('second')->build();
@@ -32,28 +35,29 @@ class DelayableQueueChannelTest extends TestCase
 
     public function test_returning_null_when_queue_is_empty()
     {
-        $queueChannel = DelayableQueueChannel::create();
+        $queueChannel = new DelayableQueueChannel('test');
 
         $this->assertNull($queueChannel->receive());
     }
 
     public function test_releasing_delayed_message()
     {
-        $queueChannel = DelayableQueueChannel::create();
+        $queueChannel = new DelayableQueueChannel('test');
 
         $message = MessageBuilder::withPayload('a')
-                        ->setHeader(MessageHeaders::DELIVERY_DELAY, 100)
+                        ->setHeader(MessageHeaders::TIMESTAMP, EpochBasedClock::getTimestampFor(new \DateTimeImmutable('2020-01-01 00:00:10.000')))
+                        ->setHeader(MessageHeaders::DELIVERY_DELAY, 10_000)
                         ->build();
 
         $queueChannel->send($message);
 
         $this->assertNull($queueChannel->receive());
 
-        $queueChannel->releaseMessagesAwaitingFor(99);
+        $queueChannel->releaseMessagesAwaitingFor(TimeSpan::withSeconds(9));
 
         $this->assertNull($queueChannel->receive());
 
-        $queueChannel->releaseMessagesAwaitingFor(100);
+        $queueChannel->releaseMessagesAwaitingFor(TimeSpan::withSeconds(10));
 
         $this->assertEquals(
             MessageBuilder::fromMessage($message)
@@ -65,25 +69,28 @@ class DelayableQueueChannelTest extends TestCase
 
     public function test_releasing_delayed_message_in_order()
     {
-        $queueChannel = DelayableQueueChannel::create();
+        $queueChannel = new DelayableQueueChannel('test');
 
         $firstMessage = MessageBuilder::withPayload('first')
-            ->setHeader(MessageHeaders::DELIVERY_DELAY, 100)
+            ->setHeader(MessageHeaders::TIMESTAMP, EpochBasedClock::getTimestampFor(new \DateTimeImmutable('2020-01-01 00:00:10.000')))
+            ->setHeader(MessageHeaders::DELIVERY_DELAY, 3000)
             ->build();
 
         $secondMessage = MessageBuilder::withPayload('second')
-            ->setHeader(MessageHeaders::DELIVERY_DELAY, 99)
+            ->setHeader(MessageHeaders::TIMESTAMP, EpochBasedClock::getTimestampFor(new \DateTimeImmutable('2020-01-01 00:00:10.000')))
+            ->setHeader(MessageHeaders::DELIVERY_DELAY, 2000)
             ->build();
 
         $thirdMessage = MessageBuilder::withPayload('third')
-            ->setHeader(MessageHeaders::DELIVERY_DELAY, 98)
+            ->setHeader(MessageHeaders::TIMESTAMP, EpochBasedClock::getTimestampFor(new \DateTimeImmutable('2020-01-01 00:00:10.000')))
+            ->setHeader(MessageHeaders::DELIVERY_DELAY, 1000)
             ->build();
 
         $queueChannel->send($firstMessage);
         $queueChannel->send($secondMessage);
         $queueChannel->send($thirdMessage);
 
-        $queueChannel->releaseMessagesAwaitingFor(98);
+        $queueChannel->releaseMessagesAwaitingFor(TimeSpan::withSeconds(1));
         $this->assertEquals(
             MessageBuilder::fromMessage($thirdMessage)
                 ->removeHeader(MessageHeaders::DELIVERY_DELAY)
@@ -91,7 +98,7 @@ class DelayableQueueChannelTest extends TestCase
             $queueChannel->receive()
         );
 
-        $queueChannel->releaseMessagesAwaitingFor(99);
+        $queueChannel->releaseMessagesAwaitingFor(TimeSpan::withSeconds(2));
         $this->assertEquals(
             MessageBuilder::fromMessage($secondMessage)
                 ->removeHeader(MessageHeaders::DELIVERY_DELAY)
@@ -99,7 +106,7 @@ class DelayableQueueChannelTest extends TestCase
             $queueChannel->receive()
         );
 
-        $queueChannel->releaseMessagesAwaitingFor(100);
+        $queueChannel->releaseMessagesAwaitingFor(TimeSpan::withSeconds(3));
         $this->assertEquals(
             MessageBuilder::fromMessage($firstMessage)
                 ->removeHeader(MessageHeaders::DELIVERY_DELAY)
@@ -110,25 +117,28 @@ class DelayableQueueChannelTest extends TestCase
 
     public function test_releasing_delayed_message_in_order_when_have_same_delay()
     {
-        $queueChannel = DelayableQueueChannel::create();
+        $queueChannel = new DelayableQueueChannel('test');
 
         $firstMessage = MessageBuilder::withPayload('first')
-            ->setHeader(MessageHeaders::DELIVERY_DELAY, 99)
+            ->setHeader(MessageHeaders::TIMESTAMP, EpochBasedClock::getTimestampFor(new \DateTimeImmutable('2020-01-01 00:00:10.000')))
+            ->setHeader(MessageHeaders::DELIVERY_DELAY, 1000)
             ->build();
 
         $secondMessage = MessageBuilder::withPayload('second')
-            ->setHeader(MessageHeaders::DELIVERY_DELAY, 100)
+            ->setHeader(MessageHeaders::TIMESTAMP, EpochBasedClock::getTimestampFor(new \DateTimeImmutable('2020-01-01 00:00:10.000')))
+            ->setHeader(MessageHeaders::DELIVERY_DELAY, 2000)
             ->build();
 
         $thirdMessage = MessageBuilder::withPayload('third')
-            ->setHeader(MessageHeaders::DELIVERY_DELAY, 99)
+            ->setHeader(MessageHeaders::TIMESTAMP, EpochBasedClock::getTimestampFor(new \DateTimeImmutable('2020-01-01 00:00:10.000')))
+            ->setHeader(MessageHeaders::DELIVERY_DELAY, 1000)
             ->build();
 
         $queueChannel->send($firstMessage);
         $queueChannel->send($secondMessage);
         $queueChannel->send($thirdMessage);
 
-        $queueChannel->releaseMessagesAwaitingFor(99);
+        $queueChannel->releaseMessagesAwaitingFor(TimeSpan::withSeconds(1));
         $this->assertEquals(
             MessageBuilder::fromMessage($firstMessage)
                 ->removeHeader(MessageHeaders::DELIVERY_DELAY)
@@ -143,7 +153,54 @@ class DelayableQueueChannelTest extends TestCase
             $queueChannel->receive()
         );
 
-        $queueChannel->releaseMessagesAwaitingFor(100);
+        $queueChannel->releaseMessagesAwaitingFor(TimeSpan::withSeconds(2));
+        $this->assertEquals(
+            MessageBuilder::fromMessage($secondMessage)
+                ->removeHeader(MessageHeaders::DELIVERY_DELAY)
+                ->build(),
+            $queueChannel->receive()
+        );
+    }
+
+    public function test_releasing_delayed_based_on_datetime()
+    {
+        $queueChannel = new DelayableQueueChannel('test');
+
+        $firstMessage = MessageBuilder::withPayload('first')
+            ->setHeader(MessageHeaders::TIMESTAMP, EpochBasedClock::getTimestampFor(new \DateTimeImmutable('2020-01-01 00:00:10.000')))
+            ->setHeader(MessageHeaders::DELIVERY_DELAY, 1000)
+            ->build();
+
+        $secondMessage = MessageBuilder::withPayload('second')
+            ->setHeader(MessageHeaders::TIMESTAMP, EpochBasedClock::getTimestampFor(new \DateTimeImmutable('2020-01-01 00:00:10.000')))
+            ->setHeader(MessageHeaders::DELIVERY_DELAY, 2000)
+            ->build();
+
+        $thirdMessage = MessageBuilder::withPayload('third')
+            ->setHeader(MessageHeaders::TIMESTAMP, EpochBasedClock::getTimestampFor(new \DateTimeImmutable('2020-01-01 00:00:10.000')))
+            ->setHeader(MessageHeaders::DELIVERY_DELAY, 1000)
+            ->build();
+
+        $queueChannel->send($firstMessage);
+        $queueChannel->send($secondMessage);
+        $queueChannel->send($thirdMessage);
+
+        $queueChannel->releaseMessagesAwaitingFor(new \DateTimeImmutable('2020-01-01 00:00:11.000'));
+        $this->assertEquals(
+            MessageBuilder::fromMessage($firstMessage)
+                ->removeHeader(MessageHeaders::DELIVERY_DELAY)
+                ->build(),
+            $queueChannel->receive()
+        );
+
+        $this->assertEquals(
+            MessageBuilder::fromMessage($thirdMessage)
+                ->removeHeader(MessageHeaders::DELIVERY_DELAY)
+                ->build(),
+            $queueChannel->receive()
+        );
+
+        $queueChannel->releaseMessagesAwaitingFor(new \DateTimeImmutable('2020-01-01 00:00:12.000'));
         $this->assertEquals(
             MessageBuilder::fromMessage($secondMessage)
                 ->removeHeader(MessageHeaders::DELIVERY_DELAY)

--- a/packages/Ecotone/tests/Messaging/Unit/Config/Annotation/ModuleConfiguration/EndpointHeadersInterceptorTest.php
+++ b/packages/Ecotone/tests/Messaging/Unit/Config/Annotation/ModuleConfiguration/EndpointHeadersInterceptorTest.php
@@ -7,7 +7,10 @@ namespace Test\Ecotone\Messaging\Unit\Config\Annotation\ModuleConfiguration;
 use Ecotone\Lite\EcotoneLite;
 use Ecotone\Lite\Test\TestConfiguration;
 use Ecotone\Messaging\Channel\SimpleMessageChannelBuilder;
+use Ecotone\Messaging\Config\ConfigurationException;
 use Ecotone\Messaging\MessageHeaders;
+use Ecotone\Messaging\Scheduling\EpochBasedClock;
+use Ecotone\Messaging\Scheduling\TimeSpan;
 use PHPUnit\Framework\TestCase;
 use Test\Ecotone\Messaging\Fixture\AddHeaders\AddingMultipleHeaders;
 
@@ -50,5 +53,98 @@ class EndpointHeadersInterceptorTest extends TestCase
         $this->assertEquals(1, $headers[MessageHeaders::PRIORITY]);
         $this->assertEquals(123, $headers['token']);
         $this->assertArrayNotHasKey('user', $headers);
+    }
+
+    public function test_evaluating_with_expressions()
+    {
+        $ecotoneLite = EcotoneLite::bootstrapFlowTesting(
+            [
+                AddingMultipleHeaders::class,
+            ],
+            [
+                AddingMultipleHeaders::class => new AddingMultipleHeaders(),
+            ],
+            enableAsynchronousProcessing: [
+                SimpleMessageChannelBuilder::createQueueChannel('async'),
+            ],
+            testConfiguration: TestConfiguration::createWithDefaults()->withSpyOnChannel('async')
+        );
+
+        $command = new \stdClass();
+        $command->delay = (new \DateTimeImmutable())->modify('+1 day');
+        $command->timeToLive = 1001;
+
+        $headers = $ecotoneLite
+            ->sendCommandWithRoutingKey('addHeadersWithExpression',
+                command: $command,
+                metadata: [
+                    'token' => 123,
+                ]
+            )
+            ->getRecordedEcotoneMessagesFrom('async')[0]->getHeaders()->headers();
+
+        $this->assertEquals(1001, $headers[MessageHeaders::TIME_TO_LIVE]);
+        $this->assertNotEmpty($headers[MessageHeaders::DELIVERY_DELAY]);
+        $this->assertEquals(123, $headers['token']);
+    }
+
+    public function test_throwing_exception_when_wrong_type_passed_to_delivery_delay(): void
+    {
+        $ecotoneLite = EcotoneLite::bootstrapFlowTesting(
+            [
+                AddingMultipleHeaders::class,
+            ],
+            [
+                AddingMultipleHeaders::class => new AddingMultipleHeaders(),
+            ],
+            enableAsynchronousProcessing: [
+                SimpleMessageChannelBuilder::createQueueChannel('async'),
+            ],
+            testConfiguration: TestConfiguration::createWithDefaults()->withSpyOnChannel('async')
+        );
+
+        $command = new \stdClass();
+        $command->delay = new \stdClass();
+        $command->timeToLive = 1001;
+
+        $this->expectException(ConfigurationException::class);
+
+        $ecotoneLite
+            ->sendCommandWithRoutingKey('addHeadersWithExpression',
+                command: $command,
+                metadata: [
+                    'token' => 123,
+                ]
+            );
+    }
+
+    public function test_throwing_exception_when_wrong_type_passed_to_delivery_time_to_live(): void
+    {
+        $ecotoneLite = EcotoneLite::bootstrapFlowTesting(
+            [
+                AddingMultipleHeaders::class,
+            ],
+            [
+                AddingMultipleHeaders::class => new AddingMultipleHeaders(),
+            ],
+            enableAsynchronousProcessing: [
+                SimpleMessageChannelBuilder::createQueueChannel('async'),
+            ],
+            testConfiguration: TestConfiguration::createWithDefaults()->withSpyOnChannel('async')
+        );
+
+        $command = new \stdClass();
+        $command->delay = TimeSpan::withSeconds(1);
+        $command->timeToLive = new \stdClass();
+
+        $this->expectException(ConfigurationException::class);
+
+        $ecotoneLite
+            ->sendCommandWithRoutingKey('addHeadersWithExpression',
+                command: $command,
+                metadata: [
+                    'token' => 123,
+                ]
+            );
     }
 }


### PR DESCRIPTION
## Why is this change proposed?

This allows to use expression language for delaying and time to live.

![image](https://github.com/user-attachments/assets/2f32692a-be5c-4534-812f-ff8d32e2028c)
![image](https://github.com/user-attachments/assets/c60943df-6431-41f1-8123-0efffd8c17d4)


## Pull Request Contribution Terms

- [X] I have read and agree to the contribution terms outlined in [CONTRIBUTING](https://github.com/ecotoneframework/ecotone-dev/blob/main/CONTRIBUTING.md).