### PR TITLE
Default test channels

### DIFF
--- a/packages/Amqp/src/Configuration/AmqpModule.php
+++ b/packages/Amqp/src/Configuration/AmqpModule.php
@@ -17,6 +17,7 @@ use Ecotone\Messaging\Config\Configuration;
 use Ecotone\Messaging\Config\Container\DefinitionHelper;
 use Ecotone\Messaging\Config\ModulePackageList;
 use Ecotone\Messaging\Config\ModuleReferenceSearchService;
+use Ecotone\Messaging\Config\ServiceConfiguration;
 use Ecotone\Messaging\Handler\InterfaceToCallRegistry;
 
 #[ModuleAnnotation]
@@ -86,7 +87,7 @@ class AmqpModule implements AnnotationModule
             || $this->amqpDistributionModule->canHandle($extensionObject);
     }
 
-    public function getModuleExtensions(array $serviceExtensions): array
+    public function getModuleExtensions(ServiceConfiguration $serviceConfiguration, array $serviceExtensions): array
     {
         return [];
     }

--- a/packages/Amqp/src/Publisher/AmqpMessagePublisherModule.php
+++ b/packages/Amqp/src/Publisher/AmqpMessagePublisherModule.php
@@ -102,7 +102,7 @@ class AmqpMessagePublisherModule implements AnnotationModule
             || $extensionObject instanceof ServiceConfiguration;
     }
 
-    public function getModuleExtensions(array $serviceExtensions): array
+    public function getModuleExtensions(ServiceConfiguration $serviceConfiguration, array $serviceExtensions): array
     {
         return [];
     }

--- a/packages/Amqp/src/Transaction/AmqpTransactionModule.php
+++ b/packages/Amqp/src/Transaction/AmqpTransactionModule.php
@@ -2,6 +2,7 @@
 
 namespace Ecotone\Amqp\Transaction;
 
+use Ecotone\Messaging\Config\ServiceConfiguration;
 use function array_map;
 
 use Ecotone\Amqp\Configuration\AmqpConfiguration;
@@ -83,7 +84,7 @@ class AmqpTransactionModule implements AnnotationModule
             );
     }
 
-    public function getModuleExtensions(array $serviceExtensions): array
+    public function getModuleExtensions(ServiceConfiguration $serviceConfiguration, array $serviceExtensions): array
     {
         return [];
     }

--- a/packages/Dbal/src/Configuration/DbalPublisherModule.php
+++ b/packages/Dbal/src/Configuration/DbalPublisherModule.php
@@ -112,7 +112,7 @@ class DbalPublisherModule implements AnnotationModule
             || $extensionObject instanceof ServiceConfiguration;
     }
 
-    public function getModuleExtensions(array $serviceExtensions): array
+    public function getModuleExtensions(ServiceConfiguration $serviceConfiguration, array $serviceExtensions): array
     {
         return [];
     }

--- a/packages/Dbal/src/DbaBusinessMethod/DbaBusinessMethodModule.php
+++ b/packages/Dbal/src/DbaBusinessMethod/DbaBusinessMethodModule.php
@@ -17,6 +17,7 @@ use Ecotone\Messaging\Config\Container\Definition;
 use Ecotone\Messaging\Config\Container\Reference;
 use Ecotone\Messaging\Config\ModulePackageList;
 use Ecotone\Messaging\Config\ModuleReferenceSearchService;
+use Ecotone\Messaging\Config\ServiceConfiguration;
 use Ecotone\Messaging\Conversion\ConversionService;
 use Ecotone\Messaging\Handler\ExpressionEvaluationService;
 use Ecotone\Messaging\Handler\Gateway\GatewayProxyBuilder;
@@ -233,7 +234,7 @@ final class DbaBusinessMethodModule implements AnnotationModule
         return $parameterConverters;
     }
 
-    public function getModuleExtensions(array $serviceExtensions): array
+    public function getModuleExtensions(ServiceConfiguration $serviceConfiguration, array $serviceExtensions): array
     {
         return [];
     }

--- a/packages/Dbal/src/DbalTransaction/DbalTransactionModule.php
+++ b/packages/Dbal/src/DbalTransaction/DbalTransactionModule.php
@@ -13,6 +13,7 @@ use Ecotone\Messaging\Config\Configuration;
 use Ecotone\Messaging\Config\Container\Reference;
 use Ecotone\Messaging\Config\ModulePackageList;
 use Ecotone\Messaging\Config\ModuleReferenceSearchService;
+use Ecotone\Messaging\Config\ServiceConfiguration;
 use Ecotone\Messaging\Handler\InterfaceToCallRegistry;
 use Ecotone\Messaging\Handler\Processor\MethodInvoker\AroundInterceptorBuilder;
 use Ecotone\Messaging\Precedence;
@@ -81,7 +82,7 @@ class DbalTransactionModule implements AnnotationModule
         return $extensionObject instanceof DbalConfiguration;
     }
 
-    public function getModuleExtensions(array $serviceExtensions): array
+    public function getModuleExtensions(ServiceConfiguration $serviceConfiguration, array $serviceExtensions): array
     {
         return [];
     }

--- a/packages/Dbal/src/Deduplication/DeduplicationModule.php
+++ b/packages/Dbal/src/Deduplication/DeduplicationModule.php
@@ -14,6 +14,7 @@ use Ecotone\Messaging\Config\Container\Definition;
 use Ecotone\Messaging\Config\Container\Reference;
 use Ecotone\Messaging\Config\ModulePackageList;
 use Ecotone\Messaging\Config\ModuleReferenceSearchService;
+use Ecotone\Messaging\Config\ServiceConfiguration;
 use Ecotone\Messaging\Handler\InterfaceToCallRegistry;
 use Ecotone\Messaging\Handler\Logger\LoggingGateway;
 use Ecotone\Messaging\Handler\Processor\MethodInvoker\AroundInterceptorBuilder;
@@ -88,7 +89,7 @@ class DeduplicationModule implements AnnotationModule
         return $extensionObject instanceof DbalConfiguration;
     }
 
-    public function getModuleExtensions(array $serviceExtensions): array
+    public function getModuleExtensions(ServiceConfiguration $serviceConfiguration, array $serviceExtensions): array
     {
         return [];
     }

--- a/packages/Dbal/src/DocumentStore/DbalDocumentStoreModule.php
+++ b/packages/Dbal/src/DocumentStore/DbalDocumentStoreModule.php
@@ -10,6 +10,7 @@ use Ecotone\Messaging\Config\Annotation\ModuleConfiguration\ExtensionObjectResol
 use Ecotone\Messaging\Config\Configuration;
 use Ecotone\Messaging\Config\ModulePackageList;
 use Ecotone\Messaging\Config\ModuleReferenceSearchService;
+use Ecotone\Messaging\Config\ServiceConfiguration;
 use Ecotone\Messaging\Handler\Gateway\GatewayProxyBuilder;
 use Ecotone\Messaging\Handler\Gateway\ParameterToMessageConverter\GatewayHeaderBuilder;
 use Ecotone\Messaging\Handler\Gateway\ParameterToMessageConverter\GatewayPayloadBuilder;
@@ -201,7 +202,7 @@ class DbalDocumentStoreModule implements AnnotationModule
             $extensionObject instanceof DbalConfiguration;
     }
 
-    public function getModuleExtensions(array $serviceExtensions): array
+    public function getModuleExtensions(ServiceConfiguration $serviceConfiguration, array $serviceExtensions): array
     {
         $dbalConfiguration = ExtensionObjectResolver::resolveUnique(DbalConfiguration::class, $serviceExtensions, DbalConfiguration::createWithDefaults());
 

--- a/packages/Dbal/src/ObjectManager/ObjectManagerModule.php
+++ b/packages/Dbal/src/ObjectManager/ObjectManagerModule.php
@@ -12,6 +12,7 @@ use Ecotone\Messaging\Config\Configuration;
 use Ecotone\Messaging\Config\Container\Reference;
 use Ecotone\Messaging\Config\ModulePackageList;
 use Ecotone\Messaging\Config\ModuleReferenceSearchService;
+use Ecotone\Messaging\Config\ServiceConfiguration;
 use Ecotone\Messaging\Handler\InterfaceToCallRegistry;
 use Ecotone\Messaging\Handler\Processor\MethodInvoker\AroundInterceptorBuilder;
 use Ecotone\Messaging\Precedence;
@@ -82,7 +83,7 @@ class ObjectManagerModule implements AnnotationModule
         return $extensionObject instanceof DbalConfiguration;
     }
 
-    public function getModuleExtensions(array $serviceExtensions): array
+    public function getModuleExtensions(ServiceConfiguration $serviceConfiguration, array $serviceExtensions): array
     {
         $dbalConfiguration = ExtensionObjectResolver::resolveUnique(DbalConfiguration::class, $serviceExtensions, DbalConfiguration::createWithDefaults());
         $repositories = [];

--- a/packages/Dbal/src/Recoverability/DbalDeadLetterModule.php
+++ b/packages/Dbal/src/Recoverability/DbalDeadLetterModule.php
@@ -15,6 +15,7 @@ use Ecotone\Messaging\Config\Container\InterfaceToCallReference;
 use Ecotone\Messaging\Config\Container\Reference;
 use Ecotone\Messaging\Config\ModulePackageList;
 use Ecotone\Messaging\Config\ModuleReferenceSearchService;
+use Ecotone\Messaging\Config\ServiceConfiguration;
 use Ecotone\Messaging\Handler\Gateway\GatewayProxyBuilder;
 use Ecotone\Messaging\Handler\Gateway\ParameterToMessageConverter\GatewayHeaderBuilder;
 use Ecotone\Messaging\Handler\InterfaceToCallRegistry;
@@ -76,7 +77,7 @@ class DbalDeadLetterModule implements AnnotationModule
         return $extensionObject instanceof DbalConfiguration || $extensionObject instanceof CustomDeadLetterGateway;
     }
 
-    public function getModuleExtensions(array $serviceExtensions): array
+    public function getModuleExtensions(ServiceConfiguration $serviceConfiguration, array $serviceExtensions): array
     {
         return [];
     }

--- a/packages/Ecotone/src/AnnotationFinder/AnnotationFinderFactory.php
+++ b/packages/Ecotone/src/AnnotationFinder/AnnotationFinderFactory.php
@@ -11,7 +11,7 @@ use Ecotone\AnnotationFinder\FileSystem\FileSystemAnnotationFinder;
  */
 class AnnotationFinderFactory
 {
-    public static function createForAttributes(string $rootProjectPath, array $namespaceToSearchIn, string $environmentName = 'prod', string $directoryToDiscoverNamespaces = '', array $systemClassesToRegister = [], array $userClassesToRegister = [], bool $isRunningForTesting = false): AnnotationFinder
+    public static function createForAttributes(string $rootProjectPath, array $namespaceToSearchIn, string $environmentName = 'prod', string $directoryToDiscoverNamespaces = '', array $systemClassesToRegister = [], array $userClassesToRegister = [], bool $isRunningForTesting = false): FileSystemAnnotationFinder
     {
         return new FileSystemAnnotationFinder(
             new AttributeResolver(),

--- a/packages/Ecotone/src/AnnotationFinder/FileSystem/FileSystemAnnotationFinder.php
+++ b/packages/Ecotone/src/AnnotationFinder/FileSystem/FileSystemAnnotationFinder.php
@@ -118,6 +118,11 @@ class FileSystemAnnotationFinder implements AnnotationFinder
         }
     }
 
+    public function registeredClasses(): array
+    {
+        return $this->registeredClasses;
+    }
+
     private function init(string $rootProjectDir, array $namespacesToUse, string $catalogToLoad, AutoloadNamespaceParser $autoloadNamespaceParser, array $systemClassesToRegister, array $userClassesToRegister, bool $isRunningForTesting)
     {
         if (! $catalogToLoad && $namespacesToUse == [] && $userClassesToRegister == [] && ! $isRunningForTesting) {
@@ -405,7 +410,7 @@ class FileSystemAnnotationFinder implements AnnotationFinder
         return $classes;
     }
 
-    public static function getRegisteredClassesForNamespaces(
+    private static function getRegisteredClassesForNamespaces(
         string $rootProjectDir,
         AutoloadNamespaceParser $autoloadNamespaceParser,
         array $namespacesToUse

--- a/packages/Ecotone/src/Messaging/Config/Annotation/ModuleConfiguration/NoExternalConfigurationModule.php
+++ b/packages/Ecotone/src/Messaging/Config/Annotation/ModuleConfiguration/NoExternalConfigurationModule.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Ecotone\Messaging\Config\Annotation\ModuleConfiguration;
 
 use Ecotone\Messaging\Config\Annotation\AnnotationModule;
+use Ecotone\Messaging\Config\ServiceConfiguration;
 
 /**
  * Class NoExternalConfigurationModule
@@ -16,7 +17,7 @@ use Ecotone\Messaging\Config\Annotation\AnnotationModule;
  */
 abstract class NoExternalConfigurationModule implements AnnotationModule
 {
-    public function getModuleExtensions(array $serviceExtensions): array
+    public function getModuleExtensions(ServiceConfiguration $serviceConfiguration, array $serviceExtensions): array
     {
         return [];
     }

--- a/packages/Ecotone/src/Messaging/Config/MessagingSystemConfiguration.php
+++ b/packages/Ecotone/src/Messaging/Config/MessagingSystemConfiguration.php
@@ -222,16 +222,16 @@ final class MessagingSystemConfiguration implements Configuration
     /**
      * @param string[] $skippedModulesPackages
      */
-    private function initialize(ModuleRetrievingService $moduleConfigurationRetrievingService, array $serviceExtensions, ServiceConfiguration $applicationConfiguration): void
+    private function initialize(ModuleRetrievingService $moduleConfigurationRetrievingService, array $serviceExtensions, ServiceConfiguration $serviceConfiguration): void
     {
         $moduleReferenceSearchService = ModuleReferenceSearchService::createEmpty();
 
-        $modules = $moduleConfigurationRetrievingService->findAllModuleConfigurations($applicationConfiguration->getSkippedModulesPackages());
+        $modules = $moduleConfigurationRetrievingService->findAllModuleConfigurations($serviceConfiguration->getSkippedModulesPackages());
         $moduleExtensions = [];
 
         $extensionObjects = $serviceExtensions;
         foreach ($modules as $module) {
-            $extensionObjects = array_merge($extensionObjects, $module->getModuleExtensions($serviceExtensions));
+            $extensionObjects = array_merge($extensionObjects, $module->getModuleExtensions($serviceConfiguration, $serviceExtensions));
         }
         foreach ($modules as $module) {
             $moduleExtensions[get_class($module)] = [];
@@ -252,6 +252,29 @@ final class MessagingSystemConfiguration implements Configuration
         }
 
         $this->moduleReferenceSearchService = $moduleReferenceSearchService;
+    }
+
+    public static function getModuleClassesFor(ServiceConfiguration $serviceConfiguration): array
+    {
+        $modulesClasses = [];
+        foreach (array_diff(array_merge(ModulePackageList::allPackages(), [ModulePackageList::TEST_PACKAGE]), $serviceConfiguration->getSkippedModulesPackages()) as $availablePackage) {
+            $modulesClasses = array_merge($modulesClasses, ModulePackageList::getModuleClassesForPackage($availablePackage));
+        }
+
+        return array_filter($modulesClasses, fn(string $moduleClassName): bool => class_exists($moduleClassName) || interface_exists($moduleClassName));
+    }
+
+    public static function addCorePackage(ServiceConfiguration $serviceConfiguration, bool $enableTestPackage): ServiceConfiguration
+    {
+        $requiredModules = [ModulePackageList::CORE_PACKAGE];
+        $skippedPackages = $serviceConfiguration->getSkippedModulesPackages();
+        if ($enableTestPackage) {
+            $requiredModules[] = ModulePackageList::TEST_PACKAGE;
+        }else {
+            $skippedPackages[] = ModulePackageList::TEST_PACKAGE;
+        }
+
+        return $serviceConfiguration->withSkippedModulePackageNames(array_diff($skippedPackages, $requiredModules));
     }
 
     private function prepareAndOptimizeConfiguration(InterfaceToCallRegistry $interfaceToCallRegistry): void
@@ -514,19 +537,9 @@ final class MessagingSystemConfiguration implements Configuration
         ConfigurationVariableService $configurationVariableService,
         ServiceConfiguration $serviceConfiguration,
         array $userLandClassesToRegister = [],
-        bool $enableTestPackage = false
+        bool $enableTestPackage = false,
     ): Configuration {
-        $requiredModules = [ModulePackageList::CORE_PACKAGE];
-        if ($enableTestPackage) {
-            $requiredModules[] = ModulePackageList::TEST_PACKAGE;
-        }
-
-        $serviceConfiguration = $serviceConfiguration->withSkippedModulePackageNames(array_diff($serviceConfiguration->getSkippedModulesPackages(), $requiredModules));
-
-        $modulesClasses = [];
-        foreach (array_diff(array_merge(ModulePackageList::allPackages(), [ModulePackageList::TEST_PACKAGE]), $serviceConfiguration->getSkippedModulesPackages()) as $availablePackage) {
-            $modulesClasses = array_merge($modulesClasses, ModulePackageList::getModuleClassesForPackage($availablePackage));
-        }
+        $serviceConfiguration = self::addCorePackage($serviceConfiguration, $enableTestPackage);
 
         return self::prepareWithAnnotationFinder(
             AnnotationFinderFactory::createForAttributes(
@@ -534,22 +547,25 @@ final class MessagingSystemConfiguration implements Configuration
                 $serviceConfiguration->getNamespaces(),
                 $serviceConfiguration->getEnvironment(),
                 $serviceConfiguration->getLoadedCatalog() ?? '',
-                array_filter($modulesClasses, fn (string $moduleClassName): bool => class_exists($moduleClassName) || interface_exists($moduleClassName)),
+                self::getModuleClassesFor($serviceConfiguration),
                 $userLandClassesToRegister,
                 $enableTestPackage
             ),
             $configurationVariableService,
             $serviceConfiguration,
+            $enableTestPackage,
         );
     }
 
-    private static function prepareWithAnnotationFinder(
+    public static function prepareWithAnnotationFinder(
         AnnotationFinder $annotationFinder,
         ConfigurationVariableService $configurationVariableService,
         ServiceConfiguration $serviceConfiguration,
+        bool $enableTestPackage = false,
     ): Configuration {
-        $preparationInterfaceRegistry = InterfaceToCallRegistry::createWith($annotationFinder);
+        $serviceConfiguration = self::addCorePackage($serviceConfiguration, $enableTestPackage);
 
+        $preparationInterfaceRegistry = InterfaceToCallRegistry::createWith($annotationFinder);
         return self::prepareWithModuleRetrievingService(
             new AnnotationModuleRetrievingService(
                 $annotationFinder,

--- a/packages/Ecotone/src/Messaging/Config/Module.php
+++ b/packages/Ecotone/src/Messaging/Config/Module.php
@@ -33,7 +33,7 @@ interface Module
      */
     public function canHandle($extensionObject): bool;
 
-    public function getModuleExtensions(array $serviceExtensions): array;
+    public function getModuleExtensions(ServiceConfiguration $serviceConfiguration, array $serviceExtensions): array;
 
     public function getModulePackageName(): string;
 }

--- a/packages/Ecotone/src/Modelling/Config/BusRoutingModule.php
+++ b/packages/Ecotone/src/Modelling/Config/BusRoutingModule.php
@@ -18,6 +18,7 @@ use Ecotone\Messaging\Config\Container\Definition;
 use Ecotone\Messaging\Config\Container\Reference;
 use Ecotone\Messaging\Config\ModulePackageList;
 use Ecotone\Messaging\Config\ModuleReferenceSearchService;
+use Ecotone\Messaging\Config\ServiceConfiguration;
 use Ecotone\Messaging\Gateway\MessagingEntrypointWithHeadersPropagation;
 use Ecotone\Messaging\Handler\InterfaceToCallRegistry;
 use Ecotone\Messaging\Handler\Logger\Config\MessageHandlerLogger;
@@ -430,7 +431,7 @@ class BusRoutingModule implements AnnotationModule
         return false;
     }
 
-    public function getModuleExtensions(array $serviceExtensions): array
+    public function getModuleExtensions(ServiceConfiguration $serviceConfiguration, array $serviceExtensions): array
     {
         return [];
     }

--- a/packages/Ecotone/src/Modelling/Config/InstantRetry/InstantRetryModule.php
+++ b/packages/Ecotone/src/Modelling/Config/InstantRetry/InstantRetryModule.php
@@ -10,6 +10,7 @@ use Ecotone\Messaging\Config\Annotation\ModuleConfiguration\ExtensionObjectResol
 use Ecotone\Messaging\Config\Configuration;
 use Ecotone\Messaging\Config\ModulePackageList;
 use Ecotone\Messaging\Config\ModuleReferenceSearchService;
+use Ecotone\Messaging\Config\ServiceConfiguration;
 use Ecotone\Messaging\Handler\InterfaceToCallRegistry;
 use Ecotone\Messaging\Handler\Processor\MethodInvoker\AroundInterceptorBuilder;
 use Ecotone\Messaging\Precedence;
@@ -56,7 +57,7 @@ final class InstantRetryModule implements AnnotationModule
         return $extensionObject instanceof InstantRetryConfiguration;
     }
 
-    public function getModuleExtensions(array $serviceExtensions): array
+    public function getModuleExtensions(ServiceConfiguration $serviceConfiguration, array $serviceExtensions): array
     {
         return [];
     }

--- a/packages/Ecotone/src/Modelling/Config/ModellingHandlerModule.php
+++ b/packages/Ecotone/src/Modelling/Config/ModellingHandlerModule.php
@@ -24,6 +24,7 @@ use Ecotone\Messaging\Config\Container\Definition;
 use Ecotone\Messaging\Config\ModulePackageList;
 use Ecotone\Messaging\Config\ModuleReferenceSearchService;
 use Ecotone\Messaging\Config\PriorityBasedOnType;
+use Ecotone\Messaging\Config\ServiceConfiguration;
 use Ecotone\Messaging\Handler\Bridge\BridgeBuilder;
 use Ecotone\Messaging\Handler\ClassDefinition;
 use Ecotone\Messaging\Handler\Gateway\GatewayProxyBuilder;
@@ -315,7 +316,7 @@ class ModellingHandlerModule implements AnnotationModule
             $extensionObject instanceof RegisterAggregateRepositoryChannels;
     }
 
-    public function getModuleExtensions(array $serviceExtensions): array
+    public function getModuleExtensions(ServiceConfiguration $serviceConfiguration, array $serviceExtensions): array
     {
         return [];
     }

--- a/packages/Ecotone/tests/Messaging/Fixture/Annotation/ModuleConfiguration/ExampleModuleConfiguration.php
+++ b/packages/Ecotone/tests/Messaging/Fixture/Annotation/ModuleConfiguration/ExampleModuleConfiguration.php
@@ -9,6 +9,7 @@ use Ecotone\Messaging\Attribute\ModuleAnnotation;
 use Ecotone\Messaging\Config\Annotation\AnnotationModule;
 use Ecotone\Messaging\Config\Configuration;
 use Ecotone\Messaging\Config\ModuleReferenceSearchService;
+use Ecotone\Messaging\Config\ServiceConfiguration;
 use Ecotone\Messaging\Handler\InterfaceToCallRegistry;
 use Ecotone\Messaging\Handler\MessageHandlerBuilder;
 use stdClass;
@@ -83,7 +84,7 @@ class ExampleModuleConfiguration implements AnnotationModule
         return $extensionObject instanceof stdClass;
     }
 
-    public function getModuleExtensions(array $serviceExtensions): array
+    public function getModuleExtensions(ServiceConfiguration $serviceConfiguration, array $serviceExtensions): array
     {
         return [];
     }

--- a/packages/Ecotone/tests/Messaging/Unit/Channel/DynamicChannel/DynamicMessageChannelBuilderTest.php
+++ b/packages/Ecotone/tests/Messaging/Unit/Channel/DynamicChannel/DynamicMessageChannelBuilderTest.php
@@ -8,6 +8,7 @@ use Ecotone\Lite\EcotoneLite;
 use Ecotone\Messaging\Channel\DynamicChannel\DynamicMessageChannelBuilder;
 use Ecotone\Messaging\Channel\SimpleMessageChannelBuilder;
 use Ecotone\Messaging\Config\ConfigurationException;
+use Ecotone\Messaging\Config\ModulePackageList;
 use Ecotone\Messaging\Config\ServiceConfiguration;
 use Ecotone\Messaging\Endpoint\PollingMetadata;
 use Ecotone\Messaging\Support\InvalidArgumentException;
@@ -525,20 +526,19 @@ final class DynamicMessageChannelBuilderTest extends TestCase
     {
         $this->expectException(ConfigurationException::class);
 
-        EcotoneLite::bootstrapFlowTesting(
+        EcotoneLite::bootstrap(
             [DynamicChannelResolver::class, SuccessServiceActivator::class],
             [new SuccessServiceActivator()],
             ServiceConfiguration::createWithDefaults()
                 ->withExtensionObjects([
                     PollingMetadata::create('async_channel')
                         ->setExecutionAmountLimit(1),
-                ]),
-            enableAsynchronousProcessing: [
-                DynamicMessageChannelBuilder::createRoundRobin('dynamic_channel', ['async_channel'])
-                    ->withInternalChannels([
-                        SimpleMessageChannelBuilder::createQueueChannel('async_channel'),
-                    ]),
-            ],
+                    DynamicMessageChannelBuilder::createRoundRobin('dynamic_channel', ['async_channel'])
+                        ->withInternalChannels([
+                            SimpleMessageChannelBuilder::createQueueChannel('async_channel'),
+                        ])
+                ])
+                ->withSkippedModulePackageNames(ModulePackageList::allPackagesExcept([ModulePackageList::ASYNCHRONOUS_PACKAGE])),
             licenceKey: LicenceTesting::VALID_LICENCE,
         );
     }

--- a/packages/Laravel/src/EcotoneProvider.php
+++ b/packages/Laravel/src/EcotoneProvider.php
@@ -52,10 +52,6 @@ class EcotoneProvider extends ServiceProvider
         $errorChannel = Config::get('ecotone.defaultErrorChannel');
 
         $skippedModules = Config::get('ecotone.skippedModulePackageNames');
-        if (! Config::get('ecotone.test')) {
-            $skippedModules[] = ModulePackageList::TEST_PACKAGE;
-        }
-
         /** @TODO Ecotone 2.0 use ServiceContext to configure Laravel */
         $applicationConfiguration = ServiceConfiguration::createWithDefaults()
             ->withEnvironment($environment)
@@ -113,6 +109,7 @@ class EcotoneProvider extends ServiceProvider
                 $rootCatalog,
                 new LaravelConfigurationVariableService(),
                 $applicationConfiguration,
+                enableTestPackage: Config::get('ecotone.test')
             );
             $definitionHolder = ContainerConfig::buildDefinitionHolder($configuration);
 

--- a/packages/PdoEventSourcing/src/Config/EventSourcingModule.php
+++ b/packages/PdoEventSourcing/src/Config/EventSourcingModule.php
@@ -297,7 +297,7 @@ class EventSourcingModule extends NoExternalConfigurationModule
             || $extensionObject instanceof ServiceConfiguration;
     }
 
-    public function getModuleExtensions(array $serviceExtensions): array
+    public function getModuleExtensions(ServiceConfiguration $serviceConfiguration, array $serviceExtensions): array
     {
         foreach ($serviceExtensions as $serviceExtension) {
             if ($serviceExtension instanceof EventSourcingRepositoryBuilder) {

--- a/packages/Symfony/DependencyInjection/EcotoneExtension.php
+++ b/packages/Symfony/DependencyInjection/EcotoneExtension.php
@@ -29,9 +29,6 @@ class EcotoneExtension extends Extension
         $config = $container->resolveEnvPlaceholders($config, true);
 
         $skippedModules = $config['skippedModulePackageNames'] ?? [];
-        if (! $config['test']) {
-            $skippedModules[] = ModulePackageList::TEST_PACKAGE;
-        }
 
         /** @TODO Ecotone 2.0 use ServiceContext to configure Symfony */
         $serviceConfiguration = ServiceConfiguration::createWithDefaults()
@@ -91,6 +88,7 @@ class EcotoneExtension extends Extension
             realpath(($container->hasParameter('kernel.project_dir') ? $container->getParameter('kernel.project_dir') : $container->getParameter('kernel.root_dir') . '/..')),
             $configurationVariableService,
             $serviceConfiguration,
+            enableTestPackage: $config['test']
         );
 
         $containerBuilder = new \Ecotone\Messaging\Config\Container\ContainerBuilder();


### PR DESCRIPTION
## Why is this change proposed?

## Description of Changes

This add automatic registration of in memory channels for testing purposes, if configuration not provided.
This way EcotoneLite tests can become simple to construct and understand. 

## Pull Request Contribution Terms

- [X] I have read and agree to the contribution terms outlined in [CONTRIBUTING](https://github.com/ecotoneframework/ecotone-dev/blob/main/CONTRIBUTING.md).