### PR TITLE
Allow for side effects only calls for pure es

### DIFF
--- a/packages/Ecotone/src/Modelling/AggregateFlow/CallAggregate/CallAggregateServiceBuilder.php
+++ b/packages/Ecotone/src/Modelling/AggregateFlow/CallAggregate/CallAggregateServiceBuilder.php
@@ -16,6 +16,7 @@ use Ecotone\Messaging\Handler\Processor\MethodInvoker\MethodInvokerAggregateObje
 use Ecotone\Messaging\Handler\Processor\MethodInvoker\MethodInvokerBuilder;
 use Ecotone\Messaging\Handler\TypeDescriptor;
 use Ecotone\Messaging\Support\Assert;
+use Ecotone\Modelling\AggregateFlow\SaveAggregate\AggregateResolver\AggregateDefinitionRegistry;
 use Ecotone\Modelling\Attribute\AggregateVersion;
 use Ecotone\Modelling\Attribute\EventSourcingAggregate;
 use Ecotone\Modelling\Attribute\EventSourcingSaga;
@@ -119,6 +120,8 @@ class CallAggregateServiceBuilder implements InterceptedMessageProcessorBuilder
         )
             ->withResultToMessageConverter(
                 new Definition(CallAggregateResultToMessageConverter::class, [
+                    Reference::to(AggregateDefinitionRegistry::class),
+                    $this->interfaceToCall->getInterfaceName(),
                     $this->interfaceToCall->getReturnType(),
                     new Reference(PropertyReaderAccessor::class),
                     $this->isCommandHandler,

--- a/packages/Ecotone/tests/Modelling/Fixture/AggregateServiceBuilder/EventSourcingAggregateExample.php
+++ b/packages/Ecotone/tests/Modelling/Fixture/AggregateServiceBuilder/EventSourcingAggregateExample.php
@@ -34,6 +34,12 @@ final class EventSourcingAggregateExample
         return [new SomethingWasDone($this->id)];
     }
 
+    #[CommandHandler('aggregate.onlySideEffects')]
+    public function handle(\stdClass $class): void
+    {
+        $class->name = "test";
+    }
+
     #[EventSourcingHandler]
     public function applyAggregateCreated(AggregateCreated $event): void
     {

--- a/packages/Ecotone/tests/Modelling/Unit/EventSourcingAggregateTest.php
+++ b/packages/Ecotone/tests/Modelling/Unit/EventSourcingAggregateTest.php
@@ -8,6 +8,8 @@ use Ecotone\Lite\EcotoneLite;
 use Ecotone\Messaging\Support\InvalidArgumentException;
 use Ecotone\Test\LicenceTesting;
 use PHPUnit\Framework\TestCase;
+use Test\Ecotone\Modelling\Fixture\AggregateServiceBuilder\CreateAggregate;
+use Test\Ecotone\Modelling\Fixture\AggregateServiceBuilder\EventSourcingAggregateExample;
 use Test\Ecotone\Modelling\Fixture\EventRevision\Person;
 use Test\Ecotone\Modelling\Fixture\EventRevision\RegisterPerson;
 
@@ -43,5 +45,20 @@ final class EventSourcingAggregateTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
 
         $ecotoneLite->sendCommand(new RegisterPerson('123', 'premium'));
+    }
+
+    public function test_calling_pure_event_sourced_aggregate_only_for_side_effects(): void
+    {
+        $ecotoneLite = EcotoneLite::bootstrapFlowTesting([
+            EventSourcingAggregateExample::class,
+        ]);
+
+
+        $stdClass = new \stdClass();
+        $ecotoneLite
+            ->sendCommand(new CreateAggregate(123))
+            ->sendCommandWithRoutingKey('aggregate.onlySideEffects', $stdClass, metadata: ['aggregate.id' => 123]);
+
+        $this->assertSame('test', $stdClass->name);
     }
 }


### PR DESCRIPTION
## Why is this change proposed?

This allows to use `void` command handlers for Pure Event Sourcing Aggregates.

## Description of Changes

## Pull Request Contribution Terms

- [X] I have read and agree to the contribution terms outlined in [CONTRIBUTING](https://github.com/ecotoneframework/ecotone-dev/blob/main/CONTRIBUTING.md).