### PR TITLE
amqp - message is delivered on lost hearbeat

### DIFF
--- a/packages/Amqp/src/AmqpBackedMessageChannelBuilder.php
+++ b/packages/Amqp/src/AmqpBackedMessageChannelBuilder.php
@@ -53,9 +53,9 @@ class AmqpBackedMessageChannelBuilder extends EnqueueMessageChannelBuilder
         return $this->outboundChannelAdapter;
     }
 
-    public function withDeliveryGuarantee(bool $deliveryGuarantee): self
+    public function withPublisherAcknowledgments(bool $enabled): self
     {
-        $this->getAmqpOutboundChannelAdapter()->withDeliveryGuarantee($deliveryGuarantee);
+        $this->getAmqpOutboundChannelAdapter()->withPublisherAcknowledgments($enabled);
 
         return $this;
     }

--- a/packages/Amqp/src/AmqpBackedMessageChannelBuilder.php
+++ b/packages/Amqp/src/AmqpBackedMessageChannelBuilder.php
@@ -48,6 +48,18 @@ class AmqpBackedMessageChannelBuilder extends EnqueueMessageChannelBuilder
         );
     }
 
+    private function getAmqpOutboundChannelAdapter(): AmqpOutboundChannelAdapterBuilder
+    {
+        return $this->outboundChannelAdapter;
+    }
+
+    public function withDeliveryGuarantee(bool $deliveryGuarantee): self
+    {
+        $this->getAmqpOutboundChannelAdapter()->withDeliveryGuarantee($deliveryGuarantee);
+
+        return $this;
+    }
+
     public function getMessageChannelName(): string
     {
         return $this->channelName;

--- a/packages/Amqp/src/AmqpOutboundChannelAdapter.php
+++ b/packages/Amqp/src/AmqpOutboundChannelAdapter.php
@@ -76,17 +76,11 @@ class AmqpOutboundChannelAdapter implements MessageHandler
         $messageToSend
             ->setDeliveryMode($this->defaultPersistentDelivery ? AmqpMessage::DELIVERY_MODE_PERSISTENT : AmqpMessage::DELIVERY_MODE_NON_PERSISTENT);
 
-        try {
-            $this->connectionFactory->getProducer()
-                ->setTimeToLive($outboundMessage->getTimeToLive())
-                ->setDelayStrategy(new HeadersExchangeDelayStrategy())
-                ->setDeliveryDelay($outboundMessage->getDeliveryDelay())
+        $this->connectionFactory->getProducer()
+            ->setTimeToLive($outboundMessage->getTimeToLive())
+            ->setDelayStrategy(new HeadersExchangeDelayStrategy())
+            ->setDeliveryDelay($outboundMessage->getDeliveryDelay())
 //            this allow for having queue per delay instead of queue per delay + exchangeName
-                ->send(new AmqpTopic($exchangeName), $messageToSend);
-        } catch (AMQPConnectionException|AMQPChannelException $exception) {
-            $this->connectionFactory->reconnect();
-
-            throw $exception;
-        }
+            ->send(new AmqpTopic($exchangeName), $messageToSend);
     }
 }

--- a/packages/Amqp/src/AmqpOutboundChannelAdapterBuilder.php
+++ b/packages/Amqp/src/AmqpOutboundChannelAdapterBuilder.php
@@ -27,6 +27,7 @@ class AmqpOutboundChannelAdapterBuilder extends EnqueueOutboundChannelAdapterBui
     private string $exchangeName;
     private bool $defaultPersistentDelivery = self::DEFAULT_PERSISTENT_MODE;
     private array $staticHeadersToAdd = [];
+    private bool $deliveryGuarantee = true;
 
     private function __construct(string $exchangeName, string $amqpConnectionFactoryReferenceName)
     {
@@ -53,6 +54,13 @@ class AmqpOutboundChannelAdapterBuilder extends EnqueueOutboundChannelAdapterBui
     public function withDefaultRoutingKey(string $routingKey): self
     {
         $this->defaultRoutingKey = $routingKey;
+
+        return $this;
+    }
+
+    public function withDeliveryGuarantee(bool $deliveryGuarantee): self
+    {
+        $this->deliveryGuarantee = $deliveryGuarantee;
 
         return $this;
     }
@@ -126,6 +134,7 @@ class AmqpOutboundChannelAdapterBuilder extends EnqueueOutboundChannelAdapterBui
             $this->exchangeFromHeader,
             $this->defaultPersistentDelivery,
             $this->autoDeclare,
+            $this->deliveryGuarantee,
             $outboundMessageConverter,
             new Reference(ConversionService::REFERENCE_NAME),
             Reference::to(AmqpTransactionInterceptor::class),

--- a/packages/Amqp/src/AmqpOutboundChannelAdapterBuilder.php
+++ b/packages/Amqp/src/AmqpOutboundChannelAdapterBuilder.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Ecotone\Amqp;
 
+use Ecotone\Amqp\Transaction\AmqpTransactionInterceptor;
 use Ecotone\Enqueue\CachedConnectionFactory;
 use Ecotone\Enqueue\EnqueueOutboundChannelAdapterBuilder;
 use Ecotone\Messaging\Channel\PollableChannel\Serialization\OutboundMessageConverter;
@@ -127,6 +128,7 @@ class AmqpOutboundChannelAdapterBuilder extends EnqueueOutboundChannelAdapterBui
             $this->autoDeclare,
             $outboundMessageConverter,
             new Reference(ConversionService::REFERENCE_NAME),
+            Reference::to(AmqpTransactionInterceptor::class),
         ]);
     }
 }

--- a/packages/Amqp/src/AmqpOutboundChannelAdapterBuilder.php
+++ b/packages/Amqp/src/AmqpOutboundChannelAdapterBuilder.php
@@ -27,7 +27,7 @@ class AmqpOutboundChannelAdapterBuilder extends EnqueueOutboundChannelAdapterBui
     private string $exchangeName;
     private bool $defaultPersistentDelivery = self::DEFAULT_PERSISTENT_MODE;
     private array $staticHeadersToAdd = [];
-    private bool $deliveryGuarantee = true;
+    private bool $publisherAcknowledgments = true;
 
     private function __construct(string $exchangeName, string $amqpConnectionFactoryReferenceName)
     {
@@ -58,9 +58,9 @@ class AmqpOutboundChannelAdapterBuilder extends EnqueueOutboundChannelAdapterBui
         return $this;
     }
 
-    public function withDeliveryGuarantee(bool $deliveryGuarantee): self
+    public function withPublisherAcknowledgments(bool $publisherAcknowledgments): self
     {
-        $this->deliveryGuarantee = $deliveryGuarantee;
+        $this->publisherAcknowledgments = $publisherAcknowledgments;
 
         return $this;
     }
@@ -134,7 +134,7 @@ class AmqpOutboundChannelAdapterBuilder extends EnqueueOutboundChannelAdapterBui
             $this->exchangeFromHeader,
             $this->defaultPersistentDelivery,
             $this->autoDeclare,
-            $this->deliveryGuarantee,
+            $this->publisherAcknowledgments,
             $outboundMessageConverter,
             new Reference(ConversionService::REFERENCE_NAME),
             Reference::to(AmqpTransactionInterceptor::class),

--- a/packages/Amqp/src/AmqpReconnectableConnectionFactory.php
+++ b/packages/Amqp/src/AmqpReconnectableConnectionFactory.php
@@ -63,6 +63,10 @@ class AmqpReconnectableConnectionFactory implements ReconnectableConnectionFacto
 
         Assert::isSubclassOf($context, AmqpContext::class, 'Context must be ' . AmqpContext::class);
 
+        if (!$context->getExtChannel()->getConnection()->isConnected()) {
+            return true;
+        }
+
         return ! $context->getExtChannel()->isConnected();
     }
 

--- a/packages/Amqp/src/AmqpReconnectableConnectionFactory.php
+++ b/packages/Amqp/src/AmqpReconnectableConnectionFactory.php
@@ -37,7 +37,10 @@ class AmqpReconnectableConnectionFactory implements ReconnectableConnectionFacto
             $this->reconnect();
         }
 
-        return $this->connectionFactory->createContext();
+        $context = $this->connectionFactory->createContext();
+        $context->getExtChannel()->setConfirmCallback(fn() => false, fn() => throw new \RuntimeException("Message was failed to be persisted in RabbitMQ instance. Check RabbitMQ server logs."));
+
+        return $context;
     }
 
     public function getConnectionInstanceId(): string

--- a/packages/Amqp/src/Transaction/AmqpTransactionInterceptor.php
+++ b/packages/Amqp/src/Transaction/AmqpTransactionInterceptor.php
@@ -90,7 +90,9 @@ class AmqpTransactionInterceptor
                 $this->logger->info(
                     'AMQP transaction was roll backed',
                     $message,
-                    $exception
+                    [
+                        'exception' => $exception
+                    ]
                 );
 
                 throw $exception;
@@ -103,5 +105,10 @@ class AmqpTransactionInterceptor
 
         $this->isRunningTransaction = false;
         return $result;
+    }
+
+    public function isRunningInTransaction(): bool
+    {
+        return $this->isRunningTransaction;
     }
 }

--- a/packages/Amqp/src/Transaction/AmqpTransactionModule.php
+++ b/packages/Amqp/src/Transaction/AmqpTransactionModule.php
@@ -51,18 +51,14 @@ class AmqpTransactionModule implements AnnotationModule
         $amqpConfiguration = ExtensionObjectResolver::resolveUnique(AmqpConfiguration::class, $extensionObjects, AmqpConfiguration::createWithDefaults());
         ;
 
-        $isTransactionWrapperEnabled = false;
         if ($amqpConfiguration->isTransactionOnAsynchronousEndpoints()) {
             $pointcut .= '||' . AsynchronousRunningEndpoint::class;
-            $isTransactionWrapperEnabled = true;
         }
         if ($amqpConfiguration->isTransactionOnCommandBus()) {
-            $pointcut .= '||' . CommandBus::class . '';
-            $isTransactionWrapperEnabled = true;
+            $pointcut .= '||' . CommandBus::class;
         }
         if ($amqpConfiguration->isTransactionOnConsoleCommands()) {
-            $pointcut .= '||' . ConsoleCommand::class . '';
-            $isTransactionWrapperEnabled = true;
+            $pointcut .= '||' . ConsoleCommand::class;
         }
         if ($amqpConfiguration->getDefaultConnectionReferenceNames()) {
             $connectionFactories = $amqpConfiguration->getDefaultConnectionReferenceNames();

--- a/packages/Amqp/tests/Configuration/AmqpModuleTest.php
+++ b/packages/Amqp/tests/Configuration/AmqpModuleTest.php
@@ -48,39 +48,6 @@ final class AmqpModuleTest extends AmqpMessagingTestCase
         );
     }
 
-    public function test_registering_amqp_backed_message_channel_with_application_media_type()
-    {
-        $amqpChannelBuilder = AmqpBackedMessageChannelBuilder::create('amqpChannel');
-        $messagingSystem    = MessagingSystemConfiguration::prepareWithDefaults(
-            InMemoryModuleMessaging::createWith(
-                [AmqpModule::create(InMemoryAnnotationFinder::createEmpty(), InterfaceToCallRegistry::createEmpty())],
-                [
-                    ServiceConfiguration::createWithDefaults()
-                        ->withDefaultSerializationMediaType(MediaType::APPLICATION_JSON),
-                    $amqpChannelBuilder,
-                ]
-            )
-        )
-            ->registerMessageChannel($amqpChannelBuilder)
-            ->registerConverter(new ArrayToJsonConverterBuilder())
-            ->buildMessagingSystemFromConfiguration(
-                InMemoryReferenceSearchService::createWith(
-                    [
-                        AmqpConnectionFactory::class => $this->getCachedConnectionFactory(),
-                    ]
-                )
-            );
-
-        /** @var PollableChannel $channel */
-        $channel = $messagingSystem->getMessageChannelByName('amqpChannel');
-        $channel->send(MessageBuilder::withPayload([1, 2, 3])->setContentType(MediaType::createApplicationXPHPArray())->build());
-
-        $this->assertEquals(
-            '[1,2,3]',
-            $channel->receive()->getPayload()
-        );
-    }
-
     public function test_registering_amqp_configuration()
     {
         $amqpExchange = AmqpExchange::createDirectExchange('exchange');

--- a/packages/Amqp/tests/Integration/AmqpMessageChannelTest.php
+++ b/packages/Amqp/tests/Integration/AmqpMessageChannelTest.php
@@ -74,7 +74,7 @@ final class AmqpMessageChannelTest extends AmqpMessagingTestCase
                 ->withSkippedModulePackageNames(ModulePackageList::allPackagesExcept([ModulePackageList::AMQP_PACKAGE]))
                 ->withExtensionObjects([
                     AmqpBackedMessageChannelBuilder::create($queueName)
-                        ->withDeliveryGuarantee(false),
+                        ->withPublisherAcknowledgments(false),
                 ])
         );
 

--- a/packages/Amqp/tests/Integration/GeneralAmqpTest.php
+++ b/packages/Amqp/tests/Integration/GeneralAmqpTest.php
@@ -52,14 +52,12 @@ final class GeneralAmqpTest extends AmqpMessagingTestCase
         );
 
         $ecotone->sendCommandWithRoutingKey('order.register', 'milk');
-        $ecotone->run('orders');
-        self::assertEquals(['milk'], $ecotone->sendQueryWithRouting('order.getOrders'));
         sleep(2);
         $ecotone->sendCommandWithRoutingKey('order.register', 'salt');
-        $ecotone->run('orders');
-        self::assertEquals(['milk', 'salt'], $ecotone->sendQueryWithRouting('order.getOrders'));
         sleep(10);
         $ecotone->sendCommandWithRoutingKey('order.register', 'sunflower');
+        $ecotone->run('orders');
+        $ecotone->run('orders');
         $ecotone->run('orders');
         self::assertEquals(['milk', 'salt', 'sunflower'], $ecotone->sendQueryWithRouting('order.getOrders'));
     }

--- a/packages/Amqp/tests/Integration/GeneralAmqpTest.php
+++ b/packages/Amqp/tests/Integration/GeneralAmqpTest.php
@@ -47,7 +47,9 @@ final class GeneralAmqpTest extends AmqpMessagingTestCase
     {
         $ecotone = $this->bootstrapEcotone(
             namespaces: ['Test\Ecotone\Amqp\Fixture\Order'],
-            services: [new OrderService(), new OrderErrorHandler(), 'logger' => new EchoLogger()],
+            services: [new OrderService(), new OrderErrorHandler(),
+//                'logger' => new EchoLogger()
+            ],
             amqpConfig: ['heartbeat' => 2]
         );
 

--- a/packages/Amqp/tests/Integration/GeneralAmqpTest.php
+++ b/packages/Amqp/tests/Integration/GeneralAmqpTest.php
@@ -56,10 +56,10 @@ final class GeneralAmqpTest extends AmqpMessagingTestCase
         $ecotone->sendCommandWithRoutingKey('order.register', 'salt');
         sleep(5);
         $ecotone->sendCommandWithRoutingKey('order.register', 'sunflower');
-//        $ecotone->run('orders');
-//        $ecotone->run('orders');
-//        $ecotone->run('orders');
-//        self::assertEquals(['milk', 'salt', 'sunflower'], $ecotone->sendQueryWithRouting('order.getOrders'));
+        $ecotone->run('orders');
+        $ecotone->run('orders');
+        $ecotone->run('orders');
+        self::assertEquals(['milk', 'salt', 'sunflower'], $ecotone->sendQueryWithRouting('order.getOrders'));
     }
 
     public function test_adding_product_to_shopping_cart_with_publisher_and_consumer(): void

--- a/packages/Amqp/tests/Integration/GeneralAmqpTest.php
+++ b/packages/Amqp/tests/Integration/GeneralAmqpTest.php
@@ -48,18 +48,18 @@ final class GeneralAmqpTest extends AmqpMessagingTestCase
         $ecotone = $this->bootstrapEcotone(
             namespaces: ['Test\Ecotone\Amqp\Fixture\Order'],
             services: [new OrderService(), new OrderErrorHandler(), 'logger' => new EchoLogger()],
-            amqpConfig: ['heartbeat' => 1]
+            amqpConfig: ['heartbeat' => 2]
         );
 
         $ecotone->sendCommandWithRoutingKey('order.register', 'milk');
-        sleep(2);
+        sleep(5);
         $ecotone->sendCommandWithRoutingKey('order.register', 'salt');
-        sleep(10);
+        sleep(5);
         $ecotone->sendCommandWithRoutingKey('order.register', 'sunflower');
-        $ecotone->run('orders');
-        $ecotone->run('orders');
-        $ecotone->run('orders');
-        self::assertEquals(['milk', 'salt', 'sunflower'], $ecotone->sendQueryWithRouting('order.getOrders'));
+//        $ecotone->run('orders');
+//        $ecotone->run('orders');
+//        $ecotone->run('orders');
+//        self::assertEquals(['milk', 'salt', 'sunflower'], $ecotone->sendQueryWithRouting('order.getOrders'));
     }
 
     public function test_adding_product_to_shopping_cart_with_publisher_and_consumer(): void

--- a/packages/Ecotone/src/Messaging/Channel/PollableChannel/SendRetries/SendRetryChannelInterceptor.php
+++ b/packages/Ecotone/src/Messaging/Channel/PollableChannel/SendRetries/SendRetryChannelInterceptor.php
@@ -41,7 +41,7 @@ final class SendRetryChannelInterceptor extends AbstractChannelInterceptor imple
         if ($exception !== null) {
             $attempt = 1;
             while ($this->retryTemplate->canBeCalledNextTime($attempt)) {
-                $this->logger->info("Message was not sent to {$this->relatedChannel} due to exception. Trying to self-heal by doing retry attempt: {$attempt}/{$this->retryTemplate->getMaxAttempts()}", [
+                $this->logger->info("Message was not sent to {$this->relatedChannel} due to exception. Trying to self-heal by doing retry attempt: {$attempt}/{$this->retryTemplate->getMaxAttempts()}. Exception message: `{$exception->getMessage()}`", [
                     'exception' => $exception->getMessage(),
                     'relatedChannel' => $this->relatedChannel,
                 ]);
@@ -60,7 +60,7 @@ final class SendRetryChannelInterceptor extends AbstractChannelInterceptor imple
             }
         }
 
-        $this->logger->error("Message was not sent to {$this->relatedChannel} due to exception. No more retries will be done", [
+        $this->logger->error("Message was not sent to {$this->relatedChannel} due to exception. No more retries will be done. Exception message: `{$exception->getMessage()}`", [
             'exception' => $exception->getMessage(),
             'relatedChannel' => $this->relatedChannel,
         ]);

--- a/packages/Enqueue/src/CachedConnectionFactory.php
+++ b/packages/Enqueue/src/CachedConnectionFactory.php
@@ -48,6 +48,7 @@ class CachedConnectionFactory implements ConnectionFactory
     public function reconnect(): void
     {
         $this->connectionFactory->reconnect();
+        $this->cachedContext = [];
     }
 
     public function getConsumer(Destination $destination): Consumer


### PR DESCRIPTION
## Why is this change proposed?

- Message is delivered on lost hearbeat, in relation to #428 
- Ensure message is considered sent, when it's stored on RabbitMQ Server side (publisher acks)

![image](https://github.com/user-attachments/assets/2ed782ae-5c86-4c66-a466-1878f30cecdf)



## Description of Changes

## Pull Request Contribution Terms

- [X] I have read and agree to the contribution terms outlined in [CONTRIBUTING](https://github.com/ecotoneframework/ecotone-dev/blob/main/CONTRIBUTING.md).