### PR TITLE
Deduplication clearing

### DIFF
--- a/packages/Dbal/src/Deduplication/DeduplicationInterceptor.php
+++ b/packages/Dbal/src/Deduplication/DeduplicationInterceptor.php
@@ -177,7 +177,7 @@ class DeduplicationInterceptor
             ->andWhere('handled_at <= :threshold')
             ->setParameter('threshold', ($this->clock->unixTimeInMilliseconds() - $this->minimumTimeToRemoveMessageInMilliseconds), Types::BIGINT)
             ->setMaxResults($this->deduplicationRemovalBatchSize)
-            ->executeQuery()
+            ->execute()
             ->fetchAllAssociative();
         return $messageIds;
     }

--- a/packages/Dbal/src/Deduplication/DeduplicationInterceptor.php
+++ b/packages/Dbal/src/Deduplication/DeduplicationInterceptor.php
@@ -108,7 +108,7 @@ class DeduplicationInterceptor
                 ->delete($this->getTableName())
                 ->andWhere('message_id IN (:messageIds)')
                 ->setParameter('messageIds', array_column($messageIds, 'message_id'), Connection::PARAM_STR_ARRAY)
-                ->executeStatement();
+                ->execute();
         }
     }
 

--- a/packages/Dbal/src/Deduplication/DeduplicationInterceptor.php
+++ b/packages/Dbal/src/Deduplication/DeduplicationInterceptor.php
@@ -107,7 +107,7 @@ class DeduplicationInterceptor
             $this->getConnection($connectionFactory)->createQueryBuilder()
                 ->delete($this->getTableName())
                 ->andWhere('message_id IN (:messageIds)')
-                ->setParameter('messageIds', array_column($messageIds, 'message_id'), ArrayParameterType::STRING)
+                ->setParameter('messageIds', array_column($messageIds, 'message_id'), Connection::PARAM_STR_ARRAY)
                 ->executeStatement();
         }
     }

--- a/packages/Dbal/tests/Integration/Deduplication/DbalDeduplicationInterceptorTest.php
+++ b/packages/Dbal/tests/Integration/Deduplication/DbalDeduplicationInterceptorTest.php
@@ -27,6 +27,7 @@ class DbalDeduplicationInterceptorTest extends DbalMessagingTestCase
             $this->getConnectionFactory(),
             new EpochBasedClock(),
             1000,
+            1000,
             new StubLoggingGateway()
         );
 
@@ -59,38 +60,6 @@ class DbalDeduplicationInterceptorTest extends DbalMessagingTestCase
             $this->getConnectionFactory(),
             new EpochBasedClock(),
             1000,
-            new StubLoggingGateway()
-        );
-
-        $methodInvocation = StubMethodInvocation::create();
-
-        $dbalTransactionInterceptor->deduplicate(
-            $methodInvocation,
-            MessageBuilder::withPayload([])->setMultipleHeaders([MessageHeaders::MESSAGE_ID => 1])->build(),
-            null,
-            null,
-            new AsynchronousRunningEndpoint('endpoint1')
-        );
-
-        $this->assertEquals(1, $methodInvocation->getCalledTimes());
-
-        $dbalTransactionInterceptor->deduplicate(
-            $methodInvocation,
-            MessageBuilder::withPayload([])->setMultipleHeaders([MessageHeaders::MESSAGE_ID => 1])->build(),
-            null,
-            null,
-            new AsynchronousRunningEndpoint('endpoint1')
-        );
-
-        $this->assertEquals(1, $methodInvocation->getCalledTimes());
-    }
-
-    public function test_handling_message_with_same_id_when_it_was_removed_by_time_limit()
-    {
-        $clock = StubUTCClock::createWithCurrentTime('2017-01-01 00:00:00');
-        $dbalTransactionInterceptor = new DeduplicationInterceptor(
-            $this->getConnectionFactory(),
-            $clock,
             1000,
             new StubLoggingGateway()
         );
@@ -107,8 +76,6 @@ class DbalDeduplicationInterceptorTest extends DbalMessagingTestCase
 
         $this->assertEquals(1, $methodInvocation->getCalledTimes());
 
-        $clock->sleep(1);
-
         $dbalTransactionInterceptor->deduplicate(
             $methodInvocation,
             MessageBuilder::withPayload([])->setMultipleHeaders([MessageHeaders::MESSAGE_ID => 1])->build(),
@@ -117,6 +84,6 @@ class DbalDeduplicationInterceptorTest extends DbalMessagingTestCase
             new AsynchronousRunningEndpoint('endpoint1')
         );
 
-        $this->assertEquals(2, $methodInvocation->getCalledTimes());
+        $this->assertEquals(1, $methodInvocation->getCalledTimes());
     }
 }

--- a/packages/Ecotone/src/Lite/Test/FlowTestSupport.php
+++ b/packages/Ecotone/src/Lite/Test/FlowTestSupport.php
@@ -423,7 +423,7 @@ final class FlowTestSupport
     /**
      * @param array<string, mixed> $parameters
      */
-    public function runConsoleCommand(string $name, array $parameters)
+    public function runConsoleCommand(string $name, array $parameters = [])
     {
         $this->configuredMessagingSystem->runConsoleCommand($name, $parameters);
 


### PR DESCRIPTION
## Why is this change proposed?

Deduplication have run automatically inside the Message Consumer, however deleting record may result in index rebuild which will cause database locks. So when this happened performance of the application was affected, as other places in the system which used deduplication had to wait for lock to finish.

## Description of Changes

Ecotone now moves the cleaning of deduplication to separate console command, which can be triggered periodically in background. It also introduces batch removal to avoid big volume of data being deleted at once, which could lock table for longer period of time.

![image](https://github.com/user-attachments/assets/17f65b26-39fa-4a34-8148-56d5d86f8a4b)


## Pull Request Contribution Terms

- [X] I have read and agree to the contribution terms outlined in [CONTRIBUTING](https://github.com/ecotoneframework/ecotone-dev/blob/main/CONTRIBUTING.md).