### PR TITLE
Default enum support for jms and handle snapshot failures with grace

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -122,7 +122,7 @@
         "enqueue/enqueue": "^0.10.0",
         "ext-amqp": "*",
         "laminas/laminas-code": "^4",
-        "jms/serializer": "^3.17",
+        "jms/serializer": "^3.32",
         "laravel/framework": "^9.5.2|^10.0|^11.0",
         "prooph/pdo-event-store": "^1.15.1",
         "psr/log": "^2.0|^3.0",

--- a/packages/Ecotone/src/Messaging/Store/Document/InMemoryDocumentStore.php
+++ b/packages/Ecotone/src/Messaging/Store/Document/InMemoryDocumentStore.php
@@ -81,7 +81,13 @@ final class InMemoryDocumentStore implements DocumentStore
             return null;
         }
 
-        return $this->collection[$collectionName][$documentId];
+        $document = $this->collection[$collectionName][$documentId];
+
+        if ($document instanceof \Throwable) {
+            throw $document;
+        }
+
+        return $document;
     }
 
     public function getAllDocuments(string $collectionName): array

--- a/packages/Ecotone/src/Modelling/AggregateFlow/LoadAggregate/LoadAggregateServiceBuilder.php
+++ b/packages/Ecotone/src/Modelling/AggregateFlow/LoadAggregate/LoadAggregateServiceBuilder.php
@@ -11,6 +11,8 @@ use Ecotone\Messaging\Handler\Enricher\PropertyEditorAccessor;
 use Ecotone\Messaging\Handler\Enricher\PropertyReaderAccessor;
 use Ecotone\Messaging\Handler\ExpressionEvaluationService;
 use Ecotone\Messaging\Handler\InterfaceToCallRegistry;
+use Ecotone\Messaging\Handler\Logger\LoggingGateway;
+use Ecotone\Messaging\Handler\Logger\LoggingService;
 use Ecotone\Messaging\Handler\Processor\InterceptedMessageProcessorBuilder;
 use Ecotone\Messaging\Handler\TypeDescriptor;
 use Ecotone\Modelling\Attribute\AggregateVersion;
@@ -122,6 +124,7 @@ class LoadAggregateServiceBuilder implements InterceptedMessageProcessorBuilder
             new Definition(LoadAggregateMode::class, [$this->loadAggregateMode->getType()]),
             new Reference(ContainerInterface::class),
             $this->eventSourcingConfiguration,
+            Reference::to(LoggingGateway::class)
         ]);
     }
 

--- a/packages/Ecotone/src/Modelling/AggregateFlow/LoadAggregate/LoadEventSourcingAggregateService.php
+++ b/packages/Ecotone/src/Modelling/AggregateFlow/LoadAggregate/LoadEventSourcingAggregateService.php
@@ -8,11 +8,14 @@ use Ecotone\Messaging\Handler\ClassDefinition;
 use Ecotone\Messaging\Handler\Enricher\PropertyEditorAccessor;
 use Ecotone\Messaging\Handler\Enricher\PropertyPath;
 use Ecotone\Messaging\Handler\Enricher\PropertyReaderAccessor;
+use Ecotone\Messaging\Handler\Logger\LoggingGateway;
+use Ecotone\Messaging\Handler\Logger\LoggingService;
 use Ecotone\Messaging\Handler\MessageProcessor;
 use Ecotone\Messaging\Handler\TypeDescriptor;
 use Ecotone\Messaging\Message;
 use Ecotone\Messaging\MessageHeaders;
 use Ecotone\Messaging\NullableMessageChannel;
+use Ecotone\Messaging\Store\Document\DocumentException;
 use Ecotone\Messaging\Store\Document\DocumentStore;
 use Ecotone\Messaging\Support\Assert;
 use Ecotone\Messaging\Support\MessageBuilder;
@@ -43,6 +46,7 @@ final class LoadEventSourcingAggregateService implements MessageProcessor
         private LoadAggregateMode $loadAggregateMode,
         private ContainerInterface $container,
         private BaseEventSourcingConfiguration $eventSourcingConfiguration,
+        private LoggingGateway $loggingGateway,
     ) {
     }
 
@@ -75,11 +79,20 @@ final class LoadEventSourcingAggregateService implements MessageProcessor
                 /** @var DocumentStore $documentStore */
                 $documentStore = $this->container->get($config['documentStore']);
 
-                $aggregate = $documentStore->findDocument(SaveAggregateService::getSnapshotCollectionName($this->aggregateClassName), SaveAggregateService::getSnapshotDocumentId($aggregateIdentifiers));
+                try {
+                    $aggregate = $documentStore->findDocument(SaveAggregateService::getSnapshotCollectionName($this->aggregateClassName), SaveAggregateService::getSnapshotDocumentId($aggregateIdentifiers));
+                }catch (DocumentException $documentException) {
+                    $this->loggingGateway->error("Failure during loading snapshot for aggregate {$this->aggregateClassName} with identifiers " . json_encode($aggregateIdentifiers) . ". Error: " . $documentException->getMessage(), [
+                        'exception' => $documentException
+                    ]);
+                }
 
-                if (! is_null($aggregate)) {
+                if ($aggregate !== null && $aggregate::class === $this->aggregateClassName) {
                     $aggregateVersion = $this->getAggregateVersion($aggregate);
                     Assert::isTrue($aggregateVersion > 0, sprintf('Serialization for snapshot of %s is set incorrectly, it does not serialize aggregate version', $aggregate::class));
+                }elseif ($aggregate !== null) {
+                    $this->loggingGateway->error("Snapshot for aggregate {$this->aggregateClassName} was found, but it is not instance of {$this->aggregateClassName}. It is type of " . gettype($aggregate) . ". Snapshot ignored to self-heal system.");
+                    $aggregate = null;
                 }
             }
         }

--- a/packages/Ecotone/src/Modelling/AggregateFlow/LoadAggregate/LoadEventSourcingAggregateService.php
+++ b/packages/Ecotone/src/Modelling/AggregateFlow/LoadAggregate/LoadEventSourcingAggregateService.php
@@ -82,7 +82,7 @@ final class LoadEventSourcingAggregateService implements MessageProcessor
                 try {
                     $aggregate = $documentStore->findDocument(SaveAggregateService::getSnapshotCollectionName($this->aggregateClassName), SaveAggregateService::getSnapshotDocumentId($aggregateIdentifiers));
                 }catch (DocumentException $documentException) {
-                    $this->loggingGateway->error("Failure during loading snapshot for aggregate {$this->aggregateClassName} with identifiers " . json_encode($aggregateIdentifiers) . ". Error: " . $documentException->getMessage(), [
+                    $this->loggingGateway->error("Failure during loading snapshot for aggregate {$this->aggregateClassName} with identifiers " . json_encode($aggregateIdentifiers) . ". Snapshot ignored to self system system. Error: " . $documentException->getMessage(), [
                         'exception' => $documentException
                     ]);
                 }

--- a/packages/JmsConverter/composer.json
+++ b/packages/JmsConverter/composer.json
@@ -39,7 +39,7 @@
     },
     "require": {
         "ecotone/ecotone": "~1.246.0",
-        "jms/serializer": "^3.17",
+        "jms/serializer": "^3.32",
         "symfony/cache": "^5.4|^6.1|^7.0"
     },
     "require-dev": {

--- a/packages/JmsConverter/src/JMSConverterBuilder.php
+++ b/packages/JmsConverter/src/JMSConverterBuilder.php
@@ -36,6 +36,9 @@ class JMSConverterBuilder implements CompilableBuilder
                     ? new IdenticalPropertyNamingStrategy()
                     : new CamelCaseNamingStrategy()
             )
+            ->setDocBlockTypeResolver(true)
+            ->enableEnumSupport($jmsConverterConfiguration->isEnumSupportEnabled())
+            ->addDefaultHandlers()
             ->configureHandlers(function (HandlerRegistry $registry) use ($convertersHandlers) {
                 foreach ($convertersHandlers as $converterHandler) {
                     $registry->registerHandler(
@@ -57,7 +60,6 @@ class JMSConverterBuilder implements CompilableBuilder
             $builder->setCacheDir($serviceCacheConfiguration->getPath() . DIRECTORY_SEPARATOR . 'jms');
         }
 
-        $builder->setDocBlockTypeResolver(true);
 
         return new JMSConverter($builder->build(), $jmsConverterConfiguration);
     }
@@ -67,6 +69,7 @@ class JMSConverterBuilder implements CompilableBuilder
         $configuration = new Definition(JMSConverterConfiguration::class, [
             $this->jmsConverterConfiguration->getNamingStrategy(),
             $this->jmsConverterConfiguration->getDefaultNullSerialization(),
+            $this->jmsConverterConfiguration->isEnumSupportEnabled(),
         ]);
         $converterHandlers = [];
         foreach ($this->converterHandlerBuilders as $converterHandlerBuilder) {

--- a/packages/JmsConverter/src/JMSConverterConfiguration.php
+++ b/packages/JmsConverter/src/JMSConverterConfiguration.php
@@ -17,7 +17,10 @@ class JMSConverterConfiguration
 
     public function __construct(
         private string $namingStrategy = self::IDENTICAL_PROPERTY_NAMING_STRATEGY,
-        private bool $defaultNullSerialization = false
+        /** @TODO Ecotone 2.0 - make default yes */
+        private bool $defaultNullSerialization = false,
+        /** @TODO Ecotone 2.0 - make default yes */
+        private bool $enableEnumSupport = false,
     ) {
     }
 
@@ -40,6 +43,13 @@ class JMSConverterConfiguration
         return $this;
     }
 
+    public function withDefaultEnumSupport(bool $enabled): static
+    {
+        $this->enableEnumSupport = $enabled;
+
+        return $this;
+    }
+
     public function getNamingStrategy(): string
     {
         return $this->namingStrategy;
@@ -48,5 +58,10 @@ class JMSConverterConfiguration
     public function getDefaultNullSerialization(): bool
     {
         return $this->defaultNullSerialization;
+    }
+
+    public function isEnumSupportEnabled(): bool
+    {
+        return $this->enableEnumSupport;
     }
 }

--- a/packages/JmsConverter/tests/Fixture/ExamplesToConvert/Date/ObjectWithDate.php
+++ b/packages/JmsConverter/tests/Fixture/ExamplesToConvert/Date/ObjectWithDate.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Ecotone\JMSConverter\Fixture\ExamplesToConvert\Date;
+
+final class ObjectWithDate
+{
+    public function __construct(public \DateTimeInterface $date)
+    {
+
+    }
+}

--- a/packages/JmsConverter/tests/Fixture/ExamplesToConvert/Date/YearMonthDayDateConverter.php
+++ b/packages/JmsConverter/tests/Fixture/ExamplesToConvert/Date/YearMonthDayDateConverter.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Ecotone\JMSConverter\Fixture\ExamplesToConvert\Date;
+
+use Ecotone\Messaging\Attribute\Converter;
+
+final class YearMonthDayDateConverter
+{
+    #[Converter]
+    public function convert(\DateTimeInterface $date): string
+    {
+        return $date->format("Y-m-d");
+    }
+
+    #[Converter]
+    public function reverse(string $date): \DateTimeInterface
+    {
+        return new \DateTimeImmutable($date);
+    }
+}

--- a/packages/JmsConverter/tests/Fixture/ExamplesToConvert/Enum/Account.php
+++ b/packages/JmsConverter/tests/Fixture/ExamplesToConvert/Enum/Account.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Test\Ecotone\JMSConverter\Fixture\ExamplesToConvert\Enum;
+
+class Account
+{
+    public function __construct(public AccountStatus $status)
+    {
+
+    }
+}

--- a/packages/JmsConverter/tests/Fixture/ExamplesToConvert/Enum/AccountStatus.php
+++ b/packages/JmsConverter/tests/Fixture/ExamplesToConvert/Enum/AccountStatus.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Ecotone\JMSConverter\Fixture\ExamplesToConvert\Enum;
+
+enum AccountStatus: string
+{
+    case ACTIVE = "active";
+    case INACTIVE = "inactive";
+    case BLOCKED = "blocked";
+}

--- a/packages/JmsConverter/tests/Fixture/ExamplesToConvert/Enum/AccountStatusConverter.php
+++ b/packages/JmsConverter/tests/Fixture/ExamplesToConvert/Enum/AccountStatusConverter.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Ecotone\JMSConverter\Fixture\ExamplesToConvert\Enum;
+
+use Ecotone\Messaging\Attribute\Converter;
+
+final class AccountStatusConverter
+{
+    #[Converter]
+    public function from(AccountStatus $status): array
+    {
+        return [
+            'value' => $status->value
+        ];
+    }
+
+    #[Converter]
+    public function to(array $status): AccountStatus
+    {
+        return AccountStatus::from($status['value']);
+    }
+}


### PR DESCRIPTION
## Why is this change proposed?

This is to allow more inbuilt functionalities for serialization, and to make event sourcing snapshoting more robust

## Description of Changes

- Add default JMS handlers, that can be overridden by custom ones
- Add optional default Enum support
- Self heal on unrestorable snapshots and log error

![image](https://github.com/user-attachments/assets/1e3cf7a9-c831-494a-8e9d-7064baf9b93b)


## Pull Request Contribution Terms

- [X] I have read and agree to the contribution terms outlined in [CONTRIBUTING](https://github.com/ecotoneframework/ecotone-dev/blob/main/CONTRIBUTING.md).