### PR TITLE
Kafka partitioning

### DIFF
--- a/packages/Ecotone/src/Lite/Test/FlowTestSupport.php
+++ b/packages/Ecotone/src/Lite/Test/FlowTestSupport.php
@@ -189,13 +189,13 @@ final class FlowTestSupport
         $this->messagingEntrypoint->sendWithHeaders(
             [],
             [
-                AggregateMessage::AGGREGATE_ID => is_object($identifiers) ? (string)$identifiers : $identifiers,
+                AggregateMessage::OVERRIDE_AGGREGATE_IDENTIFIER => is_object($identifiers) ? (string)$identifiers : $identifiers,
                 AggregateMessage::TARGET_VERSION => $aggregateVersion,
                 AggregateMessage::CALLED_AGGREGATE_CLASS => $aggregateClass,
                 AggregateMessage::CALLED_AGGREGATE_INSTANCE => new $aggregateClass(),
                 AggregateMessage::RECORDED_AGGREGATE_EVENTS => $events,
             ],
-            AggregrateModule::getRegisterAggregateSaveRepositoryInputChannel($aggregateClass). '.test_setup_state'
+            AggregrateModule::getRegisterAggregateSaveRepositoryInputChannel($aggregateClass, forTesting: true)
         );
 
         return $this;
@@ -209,7 +209,7 @@ final class FlowTestSupport
                 AggregateMessage::CALLED_AGGREGATE_INSTANCE => $aggregate,
                 AggregateMessage::CALLED_AGGREGATE_CLASS => $aggregate::class,
             ],
-            AggregrateModule::getRegisterAggregateSaveRepositoryInputChannel($aggregate::class). '.test_setup_state'
+            AggregrateModule::getRegisterAggregateSaveRepositoryInputChannel($aggregate::class, forTesting: true)
         );
 
         return $this;

--- a/packages/Ecotone/src/Messaging/Handler/Enricher/PropertyReaderAccessor.php
+++ b/packages/Ecotone/src/Messaging/Handler/Enricher/PropertyReaderAccessor.php
@@ -93,9 +93,11 @@ class PropertyReaderAccessor
             } else {
                 $objectReflection = new ReflectionClass($fromData);
                 $classProperty = $objectReflection->getProperty($currentAccessProperty);
-                $classProperty->setAccessible(true);
 
-                return $classProperty->getValue($fromData);
+                if ($classProperty->isInitialized($fromData)) {
+                    $classProperty->setAccessible(true);
+                    return $classProperty->getValue($fromData);
+                }
             }
         }
 

--- a/packages/Ecotone/src/Messaging/MessageHeaders.php
+++ b/packages/Ecotone/src/Messaging/MessageHeaders.php
@@ -5,6 +5,7 @@ namespace Ecotone\Messaging;
 use Ecotone\Messaging\Conversion\MediaType;
 use Ecotone\Messaging\Gateway\MessagingEntrypoint;
 use Ecotone\Messaging\Handler\TypeDescriptor;
+use Ecotone\Modelling\AggregateFlow\AggregateIdMetadata;
 use Ecotone\Modelling\AggregateMessage;
 use Ecotone\Modelling\Api\Distribution\DistributedBusHeader;
 use Ecotone\Modelling\Config\MessageBusChannel;
@@ -286,7 +287,7 @@ final class MessageHeaders
     public static function unsetAggregateKeys(array $metadata): array
     {
         unset(
-            $metadata[AggregateMessage::AGGREGATE_ID],
+            $metadata[AggregateMessage::OVERRIDE_AGGREGATE_IDENTIFIER],
             $metadata[AggregateMessage::CALLED_AGGREGATE_INSTANCE],
             $metadata[AggregateMessage::CALLED_AGGREGATE_CLASS],
             $metadata[AggregateMessage::RECORDED_AGGREGATE_EVENTS],

--- a/packages/Ecotone/src/Messaging/MessageHeaders.php
+++ b/packages/Ecotone/src/Messaging/MessageHeaders.php
@@ -217,7 +217,6 @@ final class MessageHeaders
         $metadata = self::unsetEnqueueMetadata($metadata);
         $metadata = self::unsetDistributionKeys($metadata);
         $metadata = self::unsetBusKeys($metadata);
-        unset($metadata[AggregateMessage::OVERRIDE_AGGREGATE_IDENTIFIER]);
 
         return self::unsetAggregateKeys($metadata);
     }

--- a/packages/Ecotone/src/Modelling/AggregateFlow/AggregateIdMetadata.php
+++ b/packages/Ecotone/src/Modelling/AggregateFlow/AggregateIdMetadata.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ecotone\Modelling\AggregateFlow;
+
+final class AggregateIdMetadata
+{
+    /**
+     * @param array<string, string> $identifiers
+     */
+    public function __construct(private array $identifiers)
+    {
+
+    }
+
+    public static function createFrom(array|string|self $identifiers): self
+    {
+        if (! is_array($identifiers) && ! $identifiers instanceof self) {
+            return new self(
+                \json_decode($identifiers, true, 512, JSON_THROW_ON_ERROR)
+            );
+        }
+
+        if ($identifiers instanceof self) {
+            return $identifiers;
+        }
+
+        return new self($identifiers);
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function getIdentifiers(): array
+    {
+        return $this->identifiers;
+    }
+}

--- a/packages/Ecotone/src/Modelling/AggregateFlow/AggregateIdMetadataConverter.php
+++ b/packages/Ecotone/src/Modelling/AggregateFlow/AggregateIdMetadataConverter.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ecotone\Modelling\AggregateFlow;
+
+use Ecotone\Messaging\Config\Container\CompilableBuilder;
+use Ecotone\Messaging\Config\Container\ContainerBuilder;
+use Ecotone\Messaging\Config\Container\Definition;
+use Ecotone\Messaging\Config\Container\MessagingContainerBuilder;
+use Ecotone\Messaging\Config\Container\Reference;
+use Ecotone\Messaging\Conversion\Converter;
+use Ecotone\Messaging\Conversion\MediaType;
+use Ecotone\Messaging\Handler\TypeDescriptor;
+
+final class AggregateIdMetadataConverter implements CompilableBuilder, Converter
+{
+    public function from(AggregateIdMetadata $aggregateIdMetadata): string
+    {
+        return json_encode($aggregateIdMetadata->getIdentifiers(), JSON_THROW_ON_ERROR);
+    }
+
+    public function to(string $aggregateIdMetadata): AggregateIdMetadata
+    {
+        return new AggregateIdMetadata(json_decode($aggregateIdMetadata, true, 512, JSON_THROW_ON_ERROR));
+    }
+
+    public function convert($source, TypeDescriptor $sourceType, MediaType $sourceMediaType, TypeDescriptor $targetType, MediaType $targetMediaType)
+    {
+        if ($targetType->isCompatibleWith(TypeDescriptor::create(AggregateIdMetadata::class))) {
+            return $this->to($source);
+        }
+
+        return $this->from($source);
+    }
+
+    public function matches(TypeDescriptor $sourceType, MediaType $sourceMediaType, TypeDescriptor $targetType, MediaType $targetMediaType): bool
+    {
+        return $sourceMediaType->isCompatibleWithParsed(MediaType::APPLICATION_X_PHP) && $sourceType->isCompatibleWith(TypeDescriptor::create(AggregateIdMetadata::class))
+            && $targetMediaType->isCompatibleWithParsed(MediaType::APPLICATION_X_PHP) && $targetType->isCompatibleWith(TypeDescriptor::createStringType());
+    }
+
+    public function compile(MessagingContainerBuilder $builder): Definition|Reference
+    {
+        return new Definition(self::class);
+    }
+}

--- a/packages/Ecotone/src/Modelling/AggregateFlow/LoadAggregate/LoadAggregateMessageProcessor.php
+++ b/packages/Ecotone/src/Modelling/AggregateFlow/LoadAggregate/LoadAggregateMessageProcessor.php
@@ -12,9 +12,11 @@ use Ecotone\Messaging\Message;
 use Ecotone\Messaging\MessageHeaders;
 use Ecotone\Messaging\NullableMessageChannel;
 use Ecotone\Messaging\Support\MessageBuilder;
+use Ecotone\Modelling\AggregateFlow\SaveAggregate\AggregateResolver\AggregateDefinitionRegistry;
 use Ecotone\Modelling\AggregateMessage;
 use Ecotone\Modelling\AggregateNotFoundException;
 use Ecotone\Modelling\Repository\AggregateRepository;
+use Ecotone\Modelling\AggregateFlow\AggregateIdMetadata;
 
 /**
  * licence Apache-2.0
@@ -35,7 +37,9 @@ final class LoadAggregateMessageProcessor implements MessageProcessor
     {
         $resultMessage = MessageBuilder::fromMessage($message);
 
-        $aggregateIdentifiers = $message->getHeaders()->get(AggregateMessage::AGGREGATE_ID);
+        $aggregateIdentifiers = AggregateIdMetadata::createFrom(
+            $message->getHeaders()->get(AggregateMessage::AGGREGATE_ID)
+        )->getIdentifiers();
 
         foreach ($aggregateIdentifiers as $identifierName => $aggregateIdentifier) {
             if (is_null($aggregateIdentifier)) {

--- a/packages/Ecotone/src/Modelling/AggregateFlow/LoadAggregate/LoadAggregateServiceBuilder.php
+++ b/packages/Ecotone/src/Modelling/AggregateFlow/LoadAggregate/LoadAggregateServiceBuilder.php
@@ -12,6 +12,7 @@ use Ecotone\Messaging\Handler\Enricher\PropertyReaderAccessor;
 use Ecotone\Messaging\Handler\ExpressionEvaluationService;
 use Ecotone\Messaging\Handler\Processor\InterceptedMessageProcessorBuilder;
 use Ecotone\Messaging\Handler\TypeDescriptor;
+use Ecotone\Modelling\AggregateFlow\SaveAggregate\AggregateResolver\AggregateDefinitionRegistry;
 use Ecotone\Modelling\Attribute\TargetAggregateVersion;
 use Ecotone\Modelling\Repository\AllAggregateRepository;
 

--- a/packages/Ecotone/src/Modelling/AggregateFlow/SaveAggregate/SaveAggregateServiceTemplate.php
+++ b/packages/Ecotone/src/Modelling/AggregateFlow/SaveAggregate/SaveAggregateServiceTemplate.php
@@ -17,6 +17,7 @@ use Ecotone\Messaging\Metadata\RevisionMetadataEnricher;
 use Ecotone\Messaging\Support\Assert;
 use Ecotone\Messaging\Support\InvalidArgumentException;
 use Ecotone\Messaging\Support\MessageBuilder;
+use Ecotone\Modelling\AggregateFlow\AggregateIdMetadata;
 use Ecotone\Modelling\AggregateFlow\SaveAggregate\AggregateResolver\AggregateClassDefinition;
 use Ecotone\Modelling\AggregateIdResolver;
 use Ecotone\Modelling\AggregateMessage;
@@ -65,14 +66,8 @@ class SaveAggregateServiceTemplate
         AggregateClassDefinition $aggregateDefinition,
         bool $throwOnNoIdentifier
     ): array {
-        $aggregateIds = $metadata[AggregateMessage::AGGREGATE_ID] ?? [];
-        if ($aggregateIds) {
-            if (! is_array($aggregateIds)) {
-                return [
-                    array_key_first($aggregateDefinition->getAggregateIdentifierMapping()) => (string)$aggregateIds,
-                ];
-            }
-
+        $aggregateIds = isset($metadata[AggregateMessage::AGGREGATE_ID]) ? AggregateIdMetadata::createFrom($metadata[AggregateMessage::AGGREGATE_ID])->getIdentifiers() : [];
+        if ($aggregateIds && self::hasAnyIdentifiersDefined($aggregateIds)) {
             return $aggregateIds;
         }
 
@@ -102,7 +97,7 @@ class SaveAggregateServiceTemplate
             $aggregateIds[$aggregateIdName] = $id;
         }
 
-        return AggregateIdResolver::resolveArrayOfIdentifiers(get_class($aggregate), $aggregateIds);
+        return AggregateIdResolver::resolveArrayOfIdentifiers(get_class($aggregate), $aggregateIds)->getIdentifiers();
     }
 
     /**
@@ -165,5 +160,10 @@ class SaveAggregateServiceTemplate
                 $eventMetadata
             );
         }, $events);
+    }
+
+    public static function hasAnyIdentifiersDefined(array $aggregateIds): bool
+    {
+        return array_unique(array_values($aggregateIds)) !== [null];
     }
 }

--- a/packages/Ecotone/src/Modelling/AggregateFlow/SaveAggregate/SaveAggregateServiceTemplate.php
+++ b/packages/Ecotone/src/Modelling/AggregateFlow/SaveAggregate/SaveAggregateServiceTemplate.php
@@ -144,6 +144,8 @@ class SaveAggregateServiceTemplate
                 $event = $event->getPayload();
             }
             $eventMetadata = MessageHeaders::unsetAllFrameworkHeaders($eventMetadata);
+            /** This need to be removed explicitly after saving, to be passed correctly across asynchronous message channels */
+            unset($eventMetadata[AggregateMessage::AGGREGATE_ID]);
             $eventMetadata = $headerMapper->mapFromMessageHeaders($eventMetadata, $conversionService);
 
             $eventMetadata = RevisionMetadataEnricher::enrich($eventMetadata, $event);

--- a/packages/Ecotone/src/Modelling/AggregateIdResolver.php
+++ b/packages/Ecotone/src/Modelling/AggregateIdResolver.php
@@ -2,6 +2,8 @@
 
 namespace Ecotone\Modelling;
 
+use Ecotone\Modelling\AggregateFlow\AggregateIdMetadata;
+
 /**
  * licence Apache-2.0
  */
@@ -23,13 +25,13 @@ class AggregateIdResolver
         return $id;
     }
 
-    public static function resolveArrayOfIdentifiers(string $aggregateClass, array $ids): array
+    public static function resolveArrayOfIdentifiers(string $aggregateClass, array $ids): AggregateIdMetadata
     {
         $resolvedIdentifiers = [];
         foreach ($ids as $name => $id) {
             $resolvedIdentifiers[$name] = self::resolve($aggregateClass, $id);
         }
 
-        return $resolvedIdentifiers;
+        return new AggregateIdMetadata($resolvedIdentifiers);
     }
 }

--- a/packages/Ecotone/src/Modelling/AggregateMessage.php
+++ b/packages/Ecotone/src/Modelling/AggregateMessage.php
@@ -14,9 +14,8 @@ interface AggregateMessage
 {
     /** User facing header, may contain scalar and array format  */
     public const OVERRIDE_AGGREGATE_IDENTIFIER = 'aggregate.id';
-    /** Internal header, format is always array (identityName: value) */
+    /** Internal header, format is always array (identityName: value). Should be used via AggregateIdMetadata */
     public const AGGREGATE_ID = 'ecotone.modelling.aggregate.id';
-    public const AGGREGATE_OBJECT_EXISTS = 'ecotone.modelling.aggregate_exists';
     public const CALLED_AGGREGATE_INSTANCE = 'ecotone.modelling.called_aggregate';
     public const CALLED_AGGREGATE_CLASS = 'ecotone.modelling.called_aggregate_class';
     public const TARGET_VERSION = 'ecotone.modelling.aggregate.target_version';

--- a/packages/Ecotone/src/Modelling/AggregateMessage.php
+++ b/packages/Ecotone/src/Modelling/AggregateMessage.php
@@ -12,11 +12,13 @@ namespace Ecotone\Modelling;
  */
 interface AggregateMessage
 {
+    /** User facing header, may contain scalar and array format  */
     public const OVERRIDE_AGGREGATE_IDENTIFIER = 'aggregate.id';
+    /** Internal header, format is always array (identityName: value) */
+    public const AGGREGATE_ID = 'ecotone.modelling.aggregate.id';
     public const AGGREGATE_OBJECT_EXISTS = 'ecotone.modelling.aggregate_exists';
     public const CALLED_AGGREGATE_INSTANCE = 'ecotone.modelling.called_aggregate';
     public const CALLED_AGGREGATE_CLASS = 'ecotone.modelling.called_aggregate_class';
-    public const AGGREGATE_ID = 'ecotone.modelling.aggregate.id';
     public const TARGET_VERSION = 'ecotone.modelling.aggregate.target_version';
     public const RECORDED_AGGREGATE_EVENTS = 'ecotone.modelling.called_aggregate_events';
     public const NULL_EXECUTION_RESULT = 'ecotone.modelling.is_nullable_execution_result';

--- a/packages/Ecotone/src/Modelling/Config/AggregrateModule.php
+++ b/packages/Ecotone/src/Modelling/Config/AggregrateModule.php
@@ -383,9 +383,9 @@ class AggregrateModule implements AnnotationModule
         return self::getAggregateRepositoryInputChannel($className, '.will_load', false, $allowNulls);
     }
 
-    public static function getRegisterAggregateSaveRepositoryInputChannel(string $className): string
+    public static function getRegisterAggregateSaveRepositoryInputChannel(string $className, bool $forTesting = false): string
     {
-        return self::getAggregateRepositoryInputChannel($className, '.will_save', true, false);
+        return self::getAggregateRepositoryInputChannel($className, '.will_save', true, false) . ($forTesting ? '.test_setup_state' : '');
     }
 
     public static function getAggregateRepositoryInputChannel(string $className, string $methodName1, bool $isSave, bool $canReturnNull): string
@@ -506,10 +506,10 @@ class AggregrateModule implements AnnotationModule
             if ($messagingConfiguration->isRunningForTest()) {
                 $messagingConfiguration->registerMessageHandler(
                     MessageProcessorActivatorBuilder::create()
-                        ->withInputChannelName(self::getRegisterAggregateSaveRepositoryInputChannel($aggregateClass) . '.test_setup_state')
+                        ->withInputChannelName(self::getRegisterAggregateSaveRepositoryInputChannel($aggregateClass, forTesting: true))
+                        ->chain(AggregateIdentifierRetrevingServiceBuilder::createWith($aggregateClassDefinition, [], [], null, $interfaceToCallRegistry))
                         ->chain(
-                            SaveAggregateServiceBuilder::create()
-                                ->withPublishEvents(false)
+                            SaveAggregateServiceBuilder::create()->withPublishEvents(false)
                         )
                 );
             }

--- a/packages/Ecotone/tests/Modelling/Fixture/Ticket/Ticket.php
+++ b/packages/Ecotone/tests/Modelling/Fixture/Ticket/Ticket.php
@@ -64,6 +64,11 @@ class Ticket
         return $this->version;
     }
 
+    public function getWorkerId(): ?string
+    {
+        return $this->workerId;
+    }
+
     public function setVersion(int $version): void
     {
         $this->version = $version;

--- a/packages/Ecotone/tests/Modelling/Unit/IdentifierMappingTest.php
+++ b/packages/Ecotone/tests/Modelling/Unit/IdentifierMappingTest.php
@@ -6,6 +6,7 @@ namespace Test\Ecotone\Modelling\Unit;
 
 use Ecotone\Lite\EcotoneLite;
 use Ecotone\Messaging\Channel\SimpleMessageChannelBuilder;
+use Ecotone\Modelling\AggregateMessage;
 use PHPUnit\Framework\TestCase;
 use Test\Ecotone\Modelling\Fixture\IdentifierMapping\AttributeMapping\OrderProcessWithAttributeHeadersMapping;
 use Test\Ecotone\Modelling\Fixture\IdentifierMapping\AttributeMapping\OrderProcessWithAttributePayloadMapping;
@@ -150,6 +151,9 @@ final class IdentifierMappingTest extends TestCase
                 ->getSaga(OrderProcessWithAttributePayloadMapping::class, '123')
                 ->getStatus()
         );
+
+        $recordedEvents = $ecotoneLite->getRecordedEventHeaders();
+        $this->assertArrayNotHasKey(AggregateMessage::AGGREGATE_ID, $recordedEvents[0]->headers());
     }
 
     public function test_mapping_using_attribute_mapper_from_header(): void

--- a/packages/Ecotone/tests/Modelling/Unit/SaveAggregateServiceBuilderTest.php
+++ b/packages/Ecotone/tests/Modelling/Unit/SaveAggregateServiceBuilderTest.php
@@ -45,6 +45,9 @@ use Test\Ecotone\Modelling\Fixture\IncorrectEventSourcedAggregate\PublicIdentifi
 use Test\Ecotone\Modelling\Fixture\Ticket\AssignWorkerCommand;
 use Test\Ecotone\Modelling\Fixture\Ticket\StartTicketCommand;
 use Test\Ecotone\Modelling\Fixture\Ticket\Ticket;
+use Test\Ecotone\Modelling\Fixture\Ticket\TicketWasStartedEvent;
+use Test\Ecotone\Modelling\Fixture\Ticket\WorkerAssignationFailedEvent;
+use Test\Ecotone\Modelling\Fixture\Ticket\WorkerWasAssignedEvent;
 
 /**
  * Class ServiceCallToAggregateAdapterTest
@@ -402,6 +405,26 @@ class SaveAggregateServiceBuilderTest extends TestCase
         $eventStream = $repository->findBy(EventSourcingAggregateWithInternalRecorder::class, ['id' => $id]);
         $this->assertCount(2, $eventStream->getEvents());
         $this->assertSame('something_was_created', $eventStream->getEvents()[1]->getEventName());
+    }
+
+    public function test_using_initial_state_for_event_sourced_aggregates(): void
+    {
+        $ecotoneTestSupport = EcotoneLite::bootstrapFlowTesting([Ticket::class]);
+
+        $ticketId = Uuid::uuid4()->toString();
+
+        $this->assertEquals(
+            'Elvis',
+            $ecotoneTestSupport
+                ->withEventsFor($ticketId, Ticket::class, [
+                    new TicketWasStartedEvent($ticketId),
+                ])
+                ->withEventsFor($ticketId, Ticket::class, [
+                    new WorkerWasAssignedEvent($ticketId, 'Elvis'),
+                ], 1)
+                ->getAggregate(Ticket::class, ['ticketId' => $ticketId])
+                ->getWorkerId()
+        );
     }
 
     public function test_storing_pure_event_sourced_aggregate_via_business_repository_for_first_time(): void

--- a/packages/Kafka/src/Api/KafkaHeader.php
+++ b/packages/Kafka/src/Api/KafkaHeader.php
@@ -14,4 +14,6 @@ interface KafkaHeader
     public const PARTITION_HEADER_NAME = 'kafka_partition';
     public const OFFSET_HEADER_NAME = 'kafka_offset';
     public const KAFKA_TIMESTAMP_HEADER_NAME = 'kafka_timestamp';
+    public const KAFKA_TARGET_PARTITION_KEY_HEADER_NAME = 'kafka_partition_target_key';
+    public const KAFKA_SOURCE_PARTITION_KEY_HEADER_NAME = 'kafka_partition_source_key';
 }

--- a/packages/Kafka/src/Api/KafkaHeader.php
+++ b/packages/Kafka/src/Api/KafkaHeader.php
@@ -14,6 +14,6 @@ interface KafkaHeader
     public const PARTITION_HEADER_NAME = 'kafka_partition';
     public const OFFSET_HEADER_NAME = 'kafka_offset';
     public const KAFKA_TIMESTAMP_HEADER_NAME = 'kafka_timestamp';
-    public const KAFKA_TARGET_PARTITION_KEY_HEADER_NAME = 'kafka_partition_target_key';
-    public const KAFKA_SOURCE_PARTITION_KEY_HEADER_NAME = 'kafka_partition_source_key';
+    public const KAFKA_TARGET_PARTITION_KEY_HEADER_NAME = 'ecotone.kafka.partition_target_key';
+    public const KAFKA_SOURCE_PARTITION_KEY_HEADER_NAME = 'ecotone.kafka.partition_source_key';
 }

--- a/packages/Kafka/src/Outbound/KafkaOutboundChannelAdapter.php
+++ b/packages/Kafka/src/Outbound/KafkaOutboundChannelAdapter.php
@@ -51,13 +51,16 @@ final class KafkaOutboundChannelAdapter implements MessageHandler
             $partitionKey = $message->getHeaders()->getMessageId();
         }
 
+        $headers = $outboundMessage->getHeaders();
+        unset($headers[KafkaHeader::KAFKA_TARGET_PARTITION_KEY_HEADER_NAME]);
+
         $topic->producev(
             RD_KAFKA_PARTITION_UA,
             0,
             $outboundMessage->getPayload(),
             $partitionKey,
             array_merge(
-                $outboundMessage->getHeaders(),
+                $headers,
                 [
                     KafkaHeader::KAFKA_SOURCE_PARTITION_KEY_HEADER_NAME => $partitionKey
                 ]

--- a/packages/Kafka/src/Outbound/KafkaOutboundChannelAdapter.php
+++ b/packages/Kafka/src/Outbound/KafkaOutboundChannelAdapter.php
@@ -4,12 +4,15 @@ declare(strict_types=1);
 
 namespace Ecotone\Kafka\Outbound;
 
+use Ecotone\Kafka\Api\KafkaHeader;
 use Ecotone\Kafka\Configuration\KafkaAdmin;
 use Ecotone\Kafka\Configuration\KafkaPublisherConfiguration;
 use Ecotone\Messaging\Channel\PollableChannel\Serialization\OutboundMessageConverter;
 use Ecotone\Messaging\Conversion\ConversionService;
 use Ecotone\Messaging\Message;
 use Ecotone\Messaging\MessageHandler;
+use Ecotone\Messaging\MessageHeaders;
+use Ecotone\Modelling\AggregateMessage;
 
 /**
  * licence Enterprise
@@ -37,17 +40,28 @@ final class KafkaOutboundChannelAdapter implements MessageHandler
         $topic = $this->kafkaAdmin->getTopicForProducer($this->referenceName);
         $outboundMessage = $this->outboundMessageConverter->prepare($message, $this->conversionService);
 
+        if ($message->getHeaders()->containsKey(KafkaHeader::KAFKA_TARGET_PARTITION_KEY_HEADER_NAME)) {
+            $partitionKey = $message->getHeaders()->get(KafkaHeader::KAFKA_TARGET_PARTITION_KEY_HEADER_NAME);
+        } elseif ($message->getHeaders()->containsKey(AggregateMessage::AGGREGATE_ID)) {
+            $partitionKey = $message->getHeaders()->get(AggregateMessage::AGGREGATE_ID);
+        } elseif ($message->getHeaders()->containsKey(MessageHeaders::EVENT_AGGREGATE_ID)) {
+            $partitionKey = $message->getHeaders()->get(MessageHeaders::EVENT_AGGREGATE_ID);
+        } else {
+            $partitionKey = $message->getHeaders()->getMessageId();
+        }
+
         $topic->producev(
             RD_KAFKA_PARTITION_UA,
             0,
             $outboundMessage->getPayload(),
-            $message->getHeaders()->getMessageId(),
-            $outboundMessage->getHeaders(),
+            $partitionKey,
+            array_merge(
+                $outboundMessage->getHeaders(),
+                [
+                    KafkaHeader::KAFKA_SOURCE_PARTITION_KEY_HEADER_NAME => $partitionKey
+                ]
+            )
         );
-
-
-        // calculate time to wait for ack
-        //        $start = microtime(true);
 
         /**
          * Producer won't produce the message to the broker immediately it will wait until the producer queue (queue.buffering.max.messages)gets full or size of the queue(queue.buffering.max.kbytes).
@@ -57,9 +71,5 @@ final class KafkaOutboundChannelAdapter implements MessageHandler
         if ($result !== 0) {
             throw MessagePublishingException::create('Failed to send message to Kafka');
         }
-
-        //        $end = microtime(true);
-        //        $timeToWait = ($end - $start) * 1000;
-        //        dd($timeToWait);
     }
 }

--- a/packages/Kafka/src/Outbound/KafkaOutboundChannelAdapter.php
+++ b/packages/Kafka/src/Outbound/KafkaOutboundChannelAdapter.php
@@ -12,6 +12,7 @@ use Ecotone\Messaging\Conversion\ConversionService;
 use Ecotone\Messaging\Message;
 use Ecotone\Messaging\MessageHandler;
 use Ecotone\Messaging\MessageHeaders;
+use Ecotone\Modelling\AggregateFlow\AggregateIdMetadata;
 use Ecotone\Modelling\AggregateMessage;
 
 /**
@@ -43,7 +44,7 @@ final class KafkaOutboundChannelAdapter implements MessageHandler
         if ($message->getHeaders()->containsKey(KafkaHeader::KAFKA_TARGET_PARTITION_KEY_HEADER_NAME)) {
             $partitionKey = $message->getHeaders()->get(KafkaHeader::KAFKA_TARGET_PARTITION_KEY_HEADER_NAME);
         } elseif ($message->getHeaders()->containsKey(AggregateMessage::AGGREGATE_ID)) {
-            $partitionKey = $message->getHeaders()->get(AggregateMessage::AGGREGATE_ID);
+            $partitionKey = implode(",", array_values(AggregateIdMetadata::createFrom($message->getHeaders()->get(AggregateMessage::AGGREGATE_ID))->getIdentifiers()));
         } elseif ($message->getHeaders()->containsKey(MessageHeaders::EVENT_AGGREGATE_ID)) {
             $partitionKey = $message->getHeaders()->get(MessageHeaders::EVENT_AGGREGATE_ID);
         } else {

--- a/packages/Kafka/tests/Fixture/Calendar/Calendar.php
+++ b/packages/Kafka/tests/Fixture/Calendar/Calendar.php
@@ -9,6 +9,7 @@ use Ecotone\Modelling\Attribute\Aggregate;
 use Ecotone\Modelling\Attribute\CommandHandler;
 use Ecotone\Modelling\Attribute\Identifier;
 use Ecotone\Modelling\Attribute\QueryHandler;
+use Ecotone\Modelling\WithEvents;
 
 #[Aggregate]
 /**
@@ -16,6 +17,8 @@ use Ecotone\Modelling\Attribute\QueryHandler;
  */
 final class Calendar
 {
+    use WithEvents;
+
     private array $meetings = [];
 
     public function __construct(#[Identifier] private string $calendarId)
@@ -28,11 +31,12 @@ final class Calendar
         return new self($command->calendarId);
     }
 
-    #[CommandHandler(endpointId: 'calendar.schedule-meeting')]
     #[Asynchronous(channelName: 'async')]
+    #[CommandHandler(endpointId: 'calendar.schedule-meeting')]
     public function scheduleMeeting(ScheduleMeeting $command, array $metadata): void
     {
         $this->meetings[] = ['id' => $command->meetingId, 'metadata' => $metadata];
+        $this->recordThat(new MeetingCreated($this->calendarId));
     }
 
     /**

--- a/packages/Kafka/tests/Fixture/Calendar/Calendar.php
+++ b/packages/Kafka/tests/Fixture/Calendar/Calendar.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Ecotone\Kafka\Fixture\Calendar;
+
+use Ecotone\Messaging\Attribute\Asynchronous;
+use Ecotone\Modelling\Attribute\Aggregate;
+use Ecotone\Modelling\Attribute\CommandHandler;
+use Ecotone\Modelling\Attribute\Identifier;
+use Ecotone\Modelling\Attribute\QueryHandler;
+
+#[Aggregate]
+/**
+ * licence Apache-2.0
+ */
+final class Calendar
+{
+    private array $meetings = [];
+
+    public function __construct(#[Identifier] private string $calendarId)
+    {
+    }
+
+    #[CommandHandler]
+    public static function create(CreateCalendar $command): self
+    {
+        return new self($command->calendarId);
+    }
+
+    #[CommandHandler(endpointId: 'calendar.schedule-meeting')]
+    #[Asynchronous(channelName: 'async')]
+    public function scheduleMeeting(ScheduleMeeting $command, array $metadata): void
+    {
+        $this->meetings[] = ['id' => $command->meetingId, 'metadata' => $metadata];
+    }
+
+    /**
+     * @return array
+     */
+    #[QueryHandler('calendar.getMeetings')]
+    public function getMeetings(): array
+    {
+        return $this->meetings;
+    }
+}

--- a/packages/Kafka/tests/Fixture/Calendar/CloseTicket.php
+++ b/packages/Kafka/tests/Fixture/Calendar/CloseTicket.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Ecotone\Kafka\Fixture\Calendar;
+
+final readonly class CloseTicket
+{
+    public function __construct(public string $ticketId)
+    {
+    }
+}

--- a/packages/Kafka/tests/Fixture/Calendar/CreateCalendar.php
+++ b/packages/Kafka/tests/Fixture/Calendar/CreateCalendar.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Ecotone\Kafka\Fixture\Calendar;
+
+/**
+ * licence Apache-2.0
+ */
+final class CreateCalendar
+{
+    public function __construct(public string $calendarId)
+    {
+    }
+}

--- a/packages/Kafka/tests/Fixture/Calendar/MeetingCreated.php
+++ b/packages/Kafka/tests/Fixture/Calendar/MeetingCreated.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Ecotone\Kafka\Fixture\Calendar;
+
+final class MeetingCreated
+{
+    public function __construct(public string $calendarId)
+    {
+    }
+}

--- a/packages/Kafka/tests/Fixture/Calendar/MeetingHistory.php
+++ b/packages/Kafka/tests/Fixture/Calendar/MeetingHistory.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Ecotone\Kafka\Fixture\Calendar;
+
+use Ecotone\Messaging\Attribute\Asynchronous;
+use Ecotone\Modelling\Attribute\EventHandler;
+use Ecotone\Modelling\Attribute\QueryHandler;
+
+final class MeetingHistory
+{
+    private array $history = [];
+
+    #[Asynchronous(channelName: 'async')]
+    #[EventHandler(endpointId: 'meeting.history.endpoint')]
+    public function when(MeetingCreated $event, array $metadata): void
+    {
+        $this->history[] = ['payload' => $event->calendarId, 'metadata' => $metadata];
+    }
+
+    #[QueryHandler('meeting.getHistory')]
+    public function getHistory(): array
+    {
+        return $this->history;
+    }
+}

--- a/packages/Kafka/tests/Fixture/Calendar/ScheduleMeeting.php
+++ b/packages/Kafka/tests/Fixture/Calendar/ScheduleMeeting.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Ecotone\Kafka\Fixture\Calendar;
+
+/**
+ * licence Apache-2.0
+ */
+final class ScheduleMeeting
+{
+    public function __construct(
+        public string $calendarId,
+        public string $meetingId,
+    ) {
+    }
+}

--- a/packages/Kafka/tests/Integration/KafkaChannelAdapterTest.php
+++ b/packages/Kafka/tests/Integration/KafkaChannelAdapterTest.php
@@ -4,16 +4,20 @@ declare(strict_types=1);
 
 namespace Test\Ecotone\Kafka\Integration;
 
+use Ecotone\Kafka\Api\KafkaHeader;
 use Ecotone\Kafka\Configuration\KafkaBrokerConfiguration;
 use Ecotone\Kafka\Configuration\KafkaPublisherConfiguration;
 use Ecotone\Kafka\Configuration\TopicConfiguration;
 use Ecotone\Kafka\Outbound\MessagePublishingException;
 use Ecotone\Lite\EcotoneLite;
+use Ecotone\Lite\Test\FlowTestSupport;
 use Ecotone\Messaging\Config\ModulePackageList;
 use Ecotone\Messaging\Config\ServiceConfiguration;
 use Ecotone\Messaging\Endpoint\ExecutionPollingMetadata;
 use Ecotone\Messaging\Handler\Logger\EchoLogger;
+use Ecotone\Messaging\MessageHeaders;
 use Ecotone\Messaging\MessagePublisher;
+use Ecotone\Modelling\AggregateMessage;
 use Ecotone\Test\LicenceTesting;
 use PHPUnit\Framework\TestCase;
 use Ramsey\Uuid\Uuid;
@@ -28,17 +32,7 @@ final class KafkaChannelAdapterTest extends TestCase
 {
     public function test_sending_and_receiving_from_kafka_topic(): void
     {
-        $ecotoneLite = EcotoneLite::bootstrapFlowTesting(
-            [ExampleKafkaConsumer::class],
-            [KafkaBrokerConfiguration::class => ConnectionTestCase::getConnection(), new ExampleKafkaConsumer(), 'logger' => new EchoLogger()],
-            ServiceConfiguration::createWithDefaults()
-                ->withSkippedModulePackageNames(ModulePackageList::allPackagesExcept([ModulePackageList::ASYNCHRONOUS_PACKAGE, ModulePackageList::KAFKA_PACKAGE]))
-                ->withExtensionObjects([
-                    KafkaPublisherConfiguration::createWithDefaults($topicName = Uuid::uuid4()->toString()),
-                    TopicConfiguration::createWithReferenceName('exampleTopic', $topicName),
-                ]),
-            licenceKey: LicenceTesting::VALID_LICENCE,
-        );
+        $ecotoneLite = $this->bootstrapFlowTesting();
 
         /** @var MessagePublisher $kafkaPublisher */
         $kafkaPublisher = $ecotoneLite->getGateway(MessagePublisher::class);
@@ -59,6 +53,53 @@ final class KafkaChannelAdapterTest extends TestCase
 
         $messages = $ecotoneLite->sendQueryWithRouting('getMessages');
         self::assertCount(1, $messages);
+    }
+
+    /**
+     * @dataProvider providePartitionKeySet
+     */
+    public function test_sending_with_partition_keys(array $metadata, string $expectedKey)
+    {
+        $ecotoneLite = $this->bootstrapFlowTesting();
+
+        /** @var MessagePublisher $kafkaPublisher */
+        $kafkaPublisher = $ecotoneLite->getGateway(MessagePublisher::class);
+
+        $kafkaPublisher->sendWithMetadata('exampleData', 'application/text', $metadata);
+
+        $ecotoneLite->run('exampleConsumer', ExecutionPollingMetadata::createWithTestingSetup(
+            maxExecutionTimeInMilliseconds: 30000
+        ));
+
+        $messages = $ecotoneLite->sendQueryWithRouting('getMessages');
+
+        self::assertCount(1, $messages);
+        self::assertEquals($expectedKey, $messages[0]['metadata'][KafkaHeader::KAFKA_SOURCE_PARTITION_KEY_HEADER_NAME]);
+    }
+
+    public function providePartitionKeySet(): iterable
+    {
+        $messageId = Uuid::uuid4()->toString();
+        $aggregateId = Uuid::uuid4()->toString();
+        $eventAggregateId = Uuid::uuid4()->toString();
+        $customKey = Uuid::uuid4()->toString();
+
+        yield 'with no partition key, message id is used' => [
+            'metadata' => [MessageHeaders::MESSAGE_ID => $messageId],
+            'expectedKey' => $messageId,
+        ];
+        yield "with event aggregate id as partition key" => [
+            'metadata' => [MessageHeaders::MESSAGE_ID => $messageId, MessageHeaders::EVENT_AGGREGATE_ID => $eventAggregateId],
+            'expectedKey' => $eventAggregateId,
+        ];
+        yield 'with only partition key header' => [
+            'metadata' => [MessageHeaders::MESSAGE_ID => $messageId, MessageHeaders::EVENT_AGGREGATE_ID => $eventAggregateId, AggregateMessage::AGGREGATE_ID => $aggregateId],
+            'expectedKey' => $aggregateId,
+        ];
+        yield 'with custom partition key' => [
+            'metadata' => [MessageHeaders::MESSAGE_ID => $messageId, MessageHeaders::EVENT_AGGREGATE_ID => $eventAggregateId, AggregateMessage::AGGREGATE_ID => $aggregateId, KafkaHeader::KAFKA_TARGET_PARTITION_KEY_HEADER_NAME => $customKey],
+            'expectedKey' => $customKey,
+        ];
     }
 
     public function test_throwing_exception_on_failure_during_sending(): void
@@ -82,5 +123,20 @@ final class KafkaChannelAdapterTest extends TestCase
         $kafkaPublisher = $ecotoneLite->getGateway(MessagePublisher::class);
 
         $kafkaPublisher->sendWithMetadata('exampleData', 'application/text', ['key' => 'value']);
+    }
+
+    public function bootstrapFlowTesting(): FlowTestSupport
+    {
+        return EcotoneLite::bootstrapFlowTesting(
+            [ExampleKafkaConsumer::class],
+            [KafkaBrokerConfiguration::class => ConnectionTestCase::getConnection(), new ExampleKafkaConsumer(), 'logger' => new EchoLogger()],
+            ServiceConfiguration::createWithDefaults()
+                ->withSkippedModulePackageNames(ModulePackageList::allPackagesExcept([ModulePackageList::ASYNCHRONOUS_PACKAGE, ModulePackageList::KAFKA_PACKAGE]))
+                ->withExtensionObjects([
+                    KafkaPublisherConfiguration::createWithDefaults($topicName = Uuid::uuid4()->toString()),
+                    TopicConfiguration::createWithReferenceName('exampleTopic', $topicName),
+                ]),
+            licenceKey: LicenceTesting::VALID_LICENCE,
+        );
     }
 }

--- a/packages/Kafka/tests/Integration/KafkaChannelAdapterTest.php
+++ b/packages/Kafka/tests/Integration/KafkaChannelAdapterTest.php
@@ -92,12 +92,12 @@ final class KafkaChannelAdapterTest extends TestCase
             'metadata' => [MessageHeaders::MESSAGE_ID => $messageId, MessageHeaders::EVENT_AGGREGATE_ID => $eventAggregateId],
             'expectedKey' => $eventAggregateId,
         ];
-        yield 'with only partition key header' => [
-            'metadata' => [MessageHeaders::MESSAGE_ID => $messageId, MessageHeaders::EVENT_AGGREGATE_ID => $eventAggregateId, AggregateMessage::AGGREGATE_ID => $aggregateId],
+        yield 'with target aggregate id header' => [
+            'metadata' => [MessageHeaders::MESSAGE_ID => $messageId, MessageHeaders::EVENT_AGGREGATE_ID => $eventAggregateId, AggregateMessage::AGGREGATE_ID => ['orderId' => $aggregateId]],
             'expectedKey' => $aggregateId,
         ];
         yield 'with custom partition key' => [
-            'metadata' => [MessageHeaders::MESSAGE_ID => $messageId, MessageHeaders::EVENT_AGGREGATE_ID => $eventAggregateId, AggregateMessage::AGGREGATE_ID => $aggregateId, KafkaHeader::KAFKA_TARGET_PARTITION_KEY_HEADER_NAME => $customKey],
+            'metadata' => [MessageHeaders::MESSAGE_ID => $messageId, MessageHeaders::EVENT_AGGREGATE_ID => $eventAggregateId, AggregateMessage::AGGREGATE_ID => ['orderId' => $aggregateId], KafkaHeader::KAFKA_TARGET_PARTITION_KEY_HEADER_NAME => $customKey],
             'expectedKey' => $customKey,
         ];
     }
@@ -129,7 +129,9 @@ final class KafkaChannelAdapterTest extends TestCase
     {
         return EcotoneLite::bootstrapFlowTesting(
             [ExampleKafkaConsumer::class],
-            [KafkaBrokerConfiguration::class => ConnectionTestCase::getConnection(), new ExampleKafkaConsumer(), 'logger' => new EchoLogger()],
+            [KafkaBrokerConfiguration::class => ConnectionTestCase::getConnection(), new ExampleKafkaConsumer(),
+//                'logger' => new EchoLogger()
+            ],
             ServiceConfiguration::createWithDefaults()
                 ->withSkippedModulePackageNames(ModulePackageList::allPackagesExcept([ModulePackageList::ASYNCHRONOUS_PACKAGE, ModulePackageList::KAFKA_PACKAGE]))
                 ->withExtensionObjects([


### PR DESCRIPTION
## Why is this change proposed?

This add ability to partition messages within Kafka module. This way order of messages can be preserved when scaling up Message Consumers.

## Description of Changes

![image](https://github.com/user-attachments/assets/a54541c1-28c1-497d-bca2-a0043fa5acb7)
![image](https://github.com/user-attachments/assets/e2410eda-4770-40b4-aecb-af96f2b77d1d)
![image](https://github.com/user-attachments/assets/721477fb-57b2-4f5b-8672-a770bec6d2d3)
![image](https://github.com/user-attachments/assets/b751b5fe-8f11-4724-987a-f0ea84012b40)


## Pull Request Contribution Terms

- [X] I have read and agree to the contribution terms outlined in [CONTRIBUTING](https://github.com/ecotoneframework/ecotone-dev/blob/main/CONTRIBUTING.md).