### PR TITLE
backward compatibility for aggregate id fetching

### DIFF
--- a/packages/Ecotone/src/Modelling/AggregateIdentifierRetrevingService.php
+++ b/packages/Ecotone/src/Modelling/AggregateIdentifierRetrevingService.php
@@ -38,6 +38,11 @@ class AggregateIdentifierRetrevingService implements MessageProcessor
 
     public function process(Message $message): Message
     {
+        /** @TODO Ecotone 2.0 (remove) this. For backward compatibility because it's ran again when message is consumed from Queue e*/
+        if ($message->getHeaders()->containsKey(AggregateMessage::AGGREGATE_ID)) {
+            return $message;
+        }
+
         if ($message->getHeaders()->containsKey(AggregateMessage::OVERRIDE_AGGREGATE_IDENTIFIER)) {
             $aggregateIds = $message->getHeaders()->get(AggregateMessage::OVERRIDE_AGGREGATE_IDENTIFIER);
             $aggregateIds = is_array($aggregateIds) ? $aggregateIds : [array_key_first($this->messageIdentifierMapping) => $aggregateIds];

--- a/packages/Ecotone/src/Modelling/Config/AggregrateModule.php
+++ b/packages/Ecotone/src/Modelling/Config/AggregrateModule.php
@@ -316,7 +316,8 @@ class AggregrateModule implements AnnotationModule
                 $handledPayloadType = MessageHandlerRoutingModule::getFirstParameterClassIfAny($registration, $interfaceToCallRegistry);
                 $handledPayloadType = $handledPayloadType ? $interfaceToCallRegistry->getClassDefinitionFor(TypeDescriptor::create($handledPayloadType)) : null;
                 $serviceActivatorHandler
-//                    ->chain(AggregateIdentifierRetrevingServiceBuilder::createWith($aggregateClassDefinition, $annotation->getIdentifierMetadataMapping(), $annotation->getIdentifierMapping(), $handledPayloadType, $interfaceToCallRegistry))
+                    /** @TODO Ecotone 2.0 (remove) this. For backward compatibility when messages without AggregateMessage::AGGREGATE_ID is not available*/
+                    ->chain(AggregateIdentifierRetrevingServiceBuilder::createWith($aggregateClassDefinition, $annotation->getIdentifierMetadataMapping(), $annotation->getIdentifierMapping(), $handledPayloadType, $interfaceToCallRegistry))
                     ->chain(
                         LoadAggregateServiceBuilder::create($aggregateClassDefinition, $registration->getMethodName(), $handledPayloadType, $dropMessageOnNotFound ? LoadAggregateMode::createDropMessageOnNotFound() : LoadAggregateMode::createThrowOnNotFound())
                     );


### PR DESCRIPTION
## Why is this change proposed?

This is for backward compatibility, when there are Messages in the queue, which do not contain AggregateMessage::AGGREGATE_ID header. In relation to https://github.com/ecotoneframework/ecotone-dev/pull/454

## Description of Changes

## Pull Request Contribution Terms

- [X] I have read and agree to the contribution terms outlined in [CONTRIBUTING](https://github.com/ecotoneframework/ecotone-dev/blob/main/CONTRIBUTING.md).