### PR TITLE
Skip calling event sourcing handler setting initial state for aggregates

### DIFF
--- a/packages/Ecotone/src/Lite/Test/FlowTestSupport.php
+++ b/packages/Ecotone/src/Lite/Test/FlowTestSupport.php
@@ -190,10 +190,10 @@ final class FlowTestSupport
             [],
             [
                 AggregateMessage::OVERRIDE_AGGREGATE_IDENTIFIER => is_object($identifiers) ? (string)$identifiers : $identifiers,
-                AggregateMessage::TARGET_VERSION => $aggregateVersion,
-                AggregateMessage::CALLED_AGGREGATE_CLASS => $aggregateClass,
-                AggregateMessage::CALLED_AGGREGATE_INSTANCE => new $aggregateClass(),
-                AggregateMessage::RECORDED_AGGREGATE_EVENTS => $events,
+                AggregateMessage::TEST_SETUP_AGGREGATE_VERSION => $aggregateVersion,
+                AggregateMessage::TEST_SETUP_AGGREGATE_CLASS => $aggregateClass,
+                AggregateMessage::TEST_SETUP_AGGREGATE_INSTANCE => new $aggregateClass(),
+                AggregateMessage::TEST_SETUP_AGGREGATE_EVENTS => $events,
             ],
             AggregrateModule::getRegisterAggregateSaveRepositoryInputChannel($aggregateClass, forTesting: true)
         );
@@ -206,8 +206,8 @@ final class FlowTestSupport
         $this->messagingEntrypoint->sendWithHeaders(
             $aggregate,
             [
-                AggregateMessage::CALLED_AGGREGATE_INSTANCE => $aggregate,
-                AggregateMessage::CALLED_AGGREGATE_CLASS => $aggregate::class,
+                AggregateMessage::TEST_SETUP_AGGREGATE_INSTANCE => $aggregate,
+                AggregateMessage::TEST_SETUP_AGGREGATE_CLASS => $aggregate::class,
             ],
             AggregrateModule::getRegisterAggregateSaveRepositoryInputChannel($aggregate::class, forTesting: true)
         );

--- a/packages/Ecotone/src/Modelling/AggregateFlow/SaveAggregate/AggregateResolver/AggregateResolver.php
+++ b/packages/Ecotone/src/Modelling/AggregateFlow/SaveAggregate/AggregateResolver/AggregateResolver.php
@@ -12,7 +12,6 @@ use Ecotone\Messaging\Handler\Enricher\PropertyReaderAccessor;
 use Ecotone\Messaging\Handler\TypeDescriptor;
 use Ecotone\Messaging\Message;
 use Ecotone\Messaging\MessageConverter\HeaderMapper;
-use Ecotone\Messaging\MessageHeaders;
 use Ecotone\Messaging\Support\Assert;
 use Ecotone\Messaging\Support\MessageBuilder;
 use Ecotone\Modelling\AggregateFlow\SaveAggregate\SaveAggregateServiceTemplate;
@@ -169,17 +168,12 @@ final class AggregateResolver
             $aggregateDefinition->isEventSourced(),
         );
 
-        $enrichedEvents = [];
-        $incrementedVersion = $versionBeforeHandling;
-        foreach ($events as $event) {
-            $incrementedVersion += 1;
-
-            $enrichedEvents[] = $event->withAddedMetadata([
-                MessageHeaders::EVENT_AGGREGATE_ID => count($identifiers) == 1 ? $identifiers[array_key_first($identifiers)] : $identifiers,
-                MessageHeaders::EVENT_AGGREGATE_TYPE => $aggregateDefinition->getAggregateClassType(),
-                MessageHeaders::EVENT_AGGREGATE_VERSION => $incrementedVersion,
-            ]);
-        }
+        $enrichedEvents = SaveAggregateServiceTemplate::enrichAggregateEvents(
+            events: $events,
+            versionBeforeHandling: (int) $versionBeforeHandling,
+            identifiers: $identifiers,
+            aggregateDefinition: $aggregateDefinition
+        );
 
         return new ResolvedAggregate(
             $aggregateDefinition,

--- a/packages/Ecotone/src/Modelling/AggregateFlow/SaveAggregate/SaveAggregateService.php
+++ b/packages/Ecotone/src/Modelling/AggregateFlow/SaveAggregate/SaveAggregateService.php
@@ -29,8 +29,7 @@ final class SaveAggregateService implements MessageProcessor
     public function __construct(
         private AggregateRepository $aggregateRepository,
         private PropertyReaderAccessor $propertyReaderAccessor,
-        private AggregateResolver      $aggregateResolver,
-        private bool $publishEvents,
+        private AggregateResolver $aggregateResolver,
         private EventBus $eventBus,
     ) {
 
@@ -66,10 +65,8 @@ final class SaveAggregateService implements MessageProcessor
             );
         }
 
-        if ($this->publishEvents) {
-            foreach ($resolvedAggregates as $resolvedAggregate) {
-                $this->publishEvents($resolvedAggregate->getEvents());
-            }
+        foreach ($resolvedAggregates as $resolvedAggregate) {
+            $this->publishEvents($resolvedAggregate->getEvents());
         }
 
         return SaveAggregateServiceTemplate::buildReplyMessage(

--- a/packages/Ecotone/src/Modelling/AggregateFlow/SaveAggregate/SaveAggregateServiceBuilder.php
+++ b/packages/Ecotone/src/Modelling/AggregateFlow/SaveAggregate/SaveAggregateServiceBuilder.php
@@ -23,21 +23,9 @@ class SaveAggregateServiceBuilder implements CompilableBuilder
 {
     private ?string $calledAggregateClassName = null;
 
-    private function __construct(
-        private bool $publishEvents = true,
-    ) {
-    }
-
     public static function create(): self
     {
         return new self();
-    }
-
-    public function withPublishEvents(bool $publishEvents): self
-    {
-        $this->publishEvents = $publishEvents;
-
-        return $this;
     }
 
     public function compile(MessagingContainerBuilder $builder): Definition
@@ -46,7 +34,6 @@ class SaveAggregateServiceBuilder implements CompilableBuilder
             new Reference(AllAggregateRepository::class),
             Definition::createFor(PropertyReaderAccessor::class, []),
             new Reference(AggregateResolver::class),
-            $this->publishEvents,
             Reference::to(EventBus::class),
         ]);
     }

--- a/packages/Ecotone/src/Modelling/AggregateFlow/SaveAggregate/SaveAggregateServiceTemplate.php
+++ b/packages/Ecotone/src/Modelling/AggregateFlow/SaveAggregate/SaveAggregateServiceTemplate.php
@@ -168,4 +168,16 @@ class SaveAggregateServiceTemplate
     {
         return array_unique(array_values($aggregateIds)) !== [null];
     }
+
+    public static function enrichAggregateEvents(array $events, int $versionBeforeHandling, array $identifiers, AggregateClassDefinition $aggregateDefinition): array
+    {
+        $incrementedVersion = $versionBeforeHandling;
+        return array_map(static function (object $event) use (&$incrementedVersion, $identifiers, $aggregateDefinition): object {
+            return $event->withAddedMetadata([
+                MessageHeaders::EVENT_AGGREGATE_ID => count($identifiers) === 1 ? $identifiers[array_key_first($identifiers)] : $identifiers,
+                MessageHeaders::EVENT_AGGREGATE_TYPE => $aggregateDefinition->getAggregateClassType(),
+                MessageHeaders::EVENT_AGGREGATE_VERSION => ++$incrementedVersion,
+            ]);
+        }, $events);
+    }
 }

--- a/packages/Ecotone/src/Modelling/AggregateFlow/SaveAggregate/SaveAggregateTestSetupService.php
+++ b/packages/Ecotone/src/Modelling/AggregateFlow/SaveAggregate/SaveAggregateTestSetupService.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ecotone\Modelling\AggregateFlow\SaveAggregate;
+
+use Ecotone\EventSourcing\Mapping\EventMapper;
+use Ecotone\Messaging\Conversion\ConversionService;
+use Ecotone\Messaging\Handler\Enricher\PropertyReaderAccessor;
+use Ecotone\Messaging\Handler\MessageProcessor;
+use Ecotone\Messaging\Handler\TypeDescriptor;
+use Ecotone\Messaging\Message;
+use Ecotone\Messaging\MessageConverter\HeaderMapper;
+use Ecotone\Messaging\MessageHeaders;
+use Ecotone\Messaging\Support\MessageBuilder;
+use Ecotone\Modelling\AggregateFlow\SaveAggregate\AggregateResolver\AggregateDefinitionRegistry;
+use Ecotone\Modelling\AggregateFlow\SaveAggregate\AggregateResolver\ResolvedAggregate;
+use Ecotone\Modelling\AggregateMessage;
+use Ecotone\Modelling\Repository\AggregateRepository;
+
+/**
+ * licence Apache-2.0
+ */
+final class SaveAggregateTestSetupService implements MessageProcessor
+{
+    public function __construct(
+        private AggregateDefinitionRegistry $aggregateDefinitionRegistry,
+        private PropertyReaderAccessor $propertyReaderAccessor,
+        private ConversionService $conversionService,
+        private HeaderMapper $headerMapper,
+        private EventMapper $eventMapper,
+        private AggregateRepository $aggregateRepository,
+    ) { }
+
+    public function process(Message $message): Message|null
+    {
+        $resolvedAggregate = $this->resolveAggregate($message);
+        $metadata = MessageHeaders::unsetNonUserKeys($message->getHeaders()->headers());
+
+        if (! $resolvedAggregate) {
+            return null;
+        }
+
+        $version = $resolvedAggregate->getVersionBeforeHandling();
+
+        $this->aggregateRepository->save(
+            $resolvedAggregate,
+            $metadata,
+            $version
+        );
+
+        /** Clear internally recorded events */
+        if ($resolvedAggregate->getAggregateClassDefinition()->hasEventRecordingMethod()) {
+            call_user_func([$resolvedAggregate->getAggregateInstance(), $resolvedAggregate->getAggregateClassDefinition()->getEventRecorderMethod()]);
+        }
+
+        return null;
+    }
+
+    private function resolveAggregate(Message $message): ResolvedAggregate
+    {
+        $aggregateDefinition = $this->aggregateDefinitionRegistry->getFor(TypeDescriptor::create($message->getHeaders()->get(AggregateMessage::TEST_SETUP_AGGREGATE_CLASS)));
+        $calledAggregateInstance = $message->getHeaders()->containsKey(AggregateMessage::TEST_SETUP_AGGREGATE_INSTANCE) ? $message->getHeaders()->get(AggregateMessage::TEST_SETUP_AGGREGATE_INSTANCE) : null;
+        $versionBeforeHandling = $message->getHeaders()->containsKey(AggregateMessage::TEST_SETUP_AGGREGATE_VERSION) ? $message->getHeaders()->get(AggregateMessage::TEST_SETUP_AGGREGATE_VERSION) : 0;
+
+        $identifiers = SaveAggregateServiceTemplate::getAggregateIds(
+            $this->propertyReaderAccessor,
+            $message->getHeaders()->headers(),
+            $calledAggregateInstance,
+            $aggregateDefinition,
+            $aggregateDefinition->isEventSourced(),
+        );
+
+        $events = SaveAggregateServiceTemplate::buildEcotoneEvents(
+            $this->resolveEvents($message),
+            $aggregateDefinition->getDefinition()->getClassName(),
+            MessageBuilder::fromMessage($message)
+                ->removeHeaders([
+                    AggregateMessage::TEST_SETUP_AGGREGATE_CLASS,
+                    AggregateMessage::TEST_SETUP_AGGREGATE_INSTANCE,
+                    AggregateMessage::TEST_SETUP_AGGREGATE_VERSION,
+                ])
+                ->build(),
+            $this->headerMapper,
+            $this->conversionService,
+            $this->eventMapper,
+        );
+
+        $enrichedEvents = SaveAggregateServiceTemplate::enrichAggregateEvents(
+            events: $events,
+            versionBeforeHandling: (int) $versionBeforeHandling,
+            identifiers: $identifiers,
+            aggregateDefinition: $aggregateDefinition
+        );
+
+        return new ResolvedAggregate(
+            aggregateClassDefinition: $aggregateDefinition,
+            isNewInstance: true,
+            aggregateInstance: $calledAggregateInstance,
+            versionBeforeHandling: $versionBeforeHandling,
+            identifiers: $identifiers,
+            events: $enrichedEvents,
+        );
+    }
+
+    private function resolveEvents(Message $message): array
+    {
+        if ($message->getHeaders()->containsKey(AggregateMessage::TEST_SETUP_AGGREGATE_EVENTS)) {
+            return $message->getHeaders()->get(AggregateMessage::TEST_SETUP_AGGREGATE_EVENTS);
+        }
+
+        return [];
+    }
+}

--- a/packages/Ecotone/src/Modelling/AggregateFlow/SaveAggregate/SaveAggregateTestSetupServiceBuilder.php
+++ b/packages/Ecotone/src/Modelling/AggregateFlow/SaveAggregate/SaveAggregateTestSetupServiceBuilder.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ecotone\Modelling\AggregateFlow\SaveAggregate;
+
+use Ecotone\EventSourcing\Mapping\EventMapper;
+use Ecotone\Messaging\Config\Container\CompilableBuilder;
+use Ecotone\Messaging\Config\Container\Definition;
+use Ecotone\Messaging\Config\Container\MessagingContainerBuilder;
+use Ecotone\Messaging\Config\Container\Reference;
+use Ecotone\Messaging\Conversion\ConversionService;
+use Ecotone\Messaging\Handler\Enricher\PropertyReaderAccessor;
+use Ecotone\Messaging\MessageConverter\DefaultHeaderMapper;
+use Ecotone\Modelling\AggregateFlow\SaveAggregate\AggregateResolver\AggregateDefinitionRegistry;
+use Ecotone\Modelling\Repository\AllAggregateRepository;
+
+/**
+ * licence Apache-2.0
+ */
+final class SaveAggregateTestSetupServiceBuilder implements CompilableBuilder
+{
+    public static function create(): self
+    {
+        return new self();
+    }
+
+    public function compile(MessagingContainerBuilder $builder): Definition
+    {
+        return new Definition(SaveAggregateTestSetupService::class, [
+            new Reference(AggregateDefinitionRegistry::class),
+            new Reference(PropertyReaderAccessor::class),
+            new Reference(ConversionService::class),
+            DefaultHeaderMapper::createAllHeadersMapping()->getDefinition(),
+            Reference::to(EventMapper::class),
+            new Reference(AllAggregateRepository::class),
+        ]);
+    }
+
+    public function __toString(): string
+    {
+        return sprintf('Save Aggregate Test Setup State Processor');
+    }
+}

--- a/packages/Ecotone/src/Modelling/AggregateMessage.php
+++ b/packages/Ecotone/src/Modelling/AggregateMessage.php
@@ -21,4 +21,10 @@ interface AggregateMessage
     public const TARGET_VERSION = 'ecotone.modelling.aggregate.target_version';
     public const RECORDED_AGGREGATE_EVENTS = 'ecotone.modelling.called_aggregate_events';
     public const NULL_EXECUTION_RESULT = 'ecotone.modelling.is_nullable_execution_result';
+
+    // test setup state headers
+    public const TEST_SETUP_AGGREGATE_VERSION = 'ecotone.modeling.test_setup.aggregate_version';
+    public const TEST_SETUP_AGGREGATE_CLASS = 'ecotone.modeling.test_setup.aggregate_class';
+    public const TEST_SETUP_AGGREGATE_INSTANCE = 'ecotone.modeling.test_setup.aggregate_instance';
+    public const TEST_SETUP_AGGREGATE_EVENTS = 'ecotone.modeling.test_setup.aggregate_events';
 }

--- a/packages/Ecotone/src/Modelling/Config/AggregrateModule.php
+++ b/packages/Ecotone/src/Modelling/Config/AggregrateModule.php
@@ -45,6 +45,7 @@ use Ecotone\Modelling\AggregateFlow\SaveAggregate\AggregateResolver\AggregateDef
 use Ecotone\Modelling\AggregateFlow\SaveAggregate\AggregateResolver\AggregateDefinitionResolver;
 use Ecotone\Modelling\AggregateFlow\SaveAggregate\AggregateResolver\AggregateResolver;
 use Ecotone\Modelling\AggregateFlow\SaveAggregate\SaveAggregateServiceBuilder;
+use Ecotone\Modelling\AggregateFlow\SaveAggregate\SaveAggregateTestSetupServiceBuilder;
 use Ecotone\Modelling\AggregateIdentifierRetrevingServiceBuilder;
 use Ecotone\Modelling\AggregateMessage;
 use Ecotone\Modelling\Attribute\Aggregate;
@@ -523,7 +524,7 @@ class AggregrateModule implements AnnotationModule
                     MessageProcessorActivatorBuilder::create()
                         ->withInputChannelName(self::getRegisterAggregateSaveRepositoryInputChannel($aggregateClass, forTesting: true))
                         ->chain(AggregateIdentifierRetrevingServiceBuilder::createWith($aggregateClassDefinition, [], [], null, $interfaceToCallRegistry))
-                        ->chain(SaveAggregateServiceBuilder::create()->withPublishEvents(false))
+                        ->chain(SaveAggregateTestSetupServiceBuilder::create())
                 );
             }
         }

--- a/packages/Ecotone/tests/Messaging/Unit/Handler/Processor/InterceptorsOrderingTest.php
+++ b/packages/Ecotone/tests/Messaging/Unit/Handler/Processor/InterceptorsOrderingTest.php
@@ -195,8 +195,6 @@ class InterceptorsOrderingTest extends TestCase
             [new InterceptorOrderingInterceptors(), $callStack],
         )
             ->withStateFor(new InterceptorOrderingAggregate('existingAggregateId'));
-        // Remove event handler event from stack
-        $callStack->reset();
 
         $ecotone
             ->sendCommandWithRoutingKey('actionVoid', metadata: ['aggregate.id' => 'existingAggregateId']);
@@ -307,7 +305,6 @@ class InterceptorsOrderingTest extends TestCase
                 'around end',
                 'afterChangeHeaders',
                 'after',
-
                 'command-output-channel',
             ],
             $callStack->getCalls()

--- a/packages/Ecotone/tests/Modelling/Fixture/SimplifiedAggregate/SimplifiedAggregate.php
+++ b/packages/Ecotone/tests/Modelling/Fixture/SimplifiedAggregate/SimplifiedAggregate.php
@@ -25,7 +25,7 @@ class SimplifiedAggregate
     }
 
     #[CommandHandler('aggregate.enable')]
-    public function enable(#[Reference] IdGenerator $idGenerator): void
+    public function enable(): void
     {
         $this->isEnabled = true;
     }
@@ -36,7 +36,7 @@ class SimplifiedAggregate
     }
 
     #[QueryHandler('aggregate.isEnabled')]
-    public function isEnabled(#[Reference] IdGenerator $idGenerator): bool
+    public function isEnabled(): bool
     {
         return $this->isEnabled;
     }

--- a/packages/Ecotone/tests/Modelling/Unit/SaveAggregateServiceBuilderTest.php
+++ b/packages/Ecotone/tests/Modelling/Unit/SaveAggregateServiceBuilderTest.php
@@ -42,6 +42,7 @@ use Test\Ecotone\Modelling\Fixture\EventSourcingRepositoryShortcut\TwitterWithRe
 use Test\Ecotone\Modelling\Fixture\EventSourcingRepositoryShortcut\TwitWasCreated;
 use Test\Ecotone\Modelling\Fixture\IncorrectEventSourcedAggregate\NoIdDefinedAfterCallingFactory\NoIdDefinedAfterRecordingEvents;
 use Test\Ecotone\Modelling\Fixture\IncorrectEventSourcedAggregate\PublicIdentifierGetMethodWithParameters;
+use Test\Ecotone\Modelling\Fixture\SimplifiedAggregate\SimplifiedAggregate;
 use Test\Ecotone\Modelling\Fixture\Ticket\AssignWorkerCommand;
 use Test\Ecotone\Modelling\Fixture\Ticket\StartTicketCommand;
 use Test\Ecotone\Modelling\Fixture\Ticket\Ticket;
@@ -404,26 +405,6 @@ class SaveAggregateServiceBuilderTest extends TestCase
         $eventStream = $repository->findBy(EventSourcingAggregateWithInternalRecorder::class, ['id' => $id]);
         $this->assertCount(2, $eventStream->getEvents());
         $this->assertSame('something_was_created', $eventStream->getEvents()[1]->getEventName());
-    }
-
-    public function test_using_initial_state_for_event_sourced_aggregates(): void
-    {
-        $ecotoneTestSupport = EcotoneLite::bootstrapFlowTesting([Ticket::class]);
-
-        $ticketId = Uuid::uuid4()->toString();
-
-        $this->assertEquals(
-            'Elvis',
-            $ecotoneTestSupport
-                ->withEventsFor($ticketId, Ticket::class, [
-                    new TicketWasStartedEvent($ticketId),
-                ])
-                ->withEventsFor($ticketId, Ticket::class, [
-                    new WorkerWasAssignedEvent($ticketId, 'Elvis'),
-                ], 1)
-                ->getAggregate(Ticket::class, ['ticketId' => $ticketId])
-                ->getWorkerId()
-        );
     }
 
     public function test_storing_pure_event_sourced_aggregate_via_business_repository_for_first_time(): void

--- a/packages/Ecotone/tests/Modelling/Unit/SaveAggregateTestSetupServiceBuilderTest.php
+++ b/packages/Ecotone/tests/Modelling/Unit/SaveAggregateTestSetupServiceBuilderTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modelling\Unit;
+
+use Ecotone\Lite\EcotoneLite;
+use PHPUnit\Framework\TestCase;
+use Ramsey\Uuid\Uuid;
+use Test\Ecotone\Modelling\Fixture\SimplifiedAggregate\SimplifiedAggregate;
+use Test\Ecotone\Modelling\Fixture\Ticket\Ticket;
+use Test\Ecotone\Modelling\Fixture\Ticket\TicketWasStartedEvent;
+use Test\Ecotone\Modelling\Fixture\Ticket\WorkerWasAssignedEvent;
+
+/**
+ * licence Apache-2.0
+ * @internal
+ */
+final class SaveAggregateTestSetupServiceBuilderTest extends TestCase
+{
+    public function test_using_initial_state_for_event_sourced_aggregates(): void
+    {
+        $ecotoneTestSupport = EcotoneLite::bootstrapFlowTesting([Ticket::class]);
+
+        $ticketId = Uuid::uuid4()->toString();
+
+        $this->assertEquals(
+            'Elvis',
+            $ecotoneTestSupport
+                ->withEventsFor($ticketId, Ticket::class, [
+                    new TicketWasStartedEvent($ticketId),
+                ])
+                ->withEventsFor($ticketId, Ticket::class, [
+                    new WorkerWasAssignedEvent($ticketId, 'Elvis'),
+                ], 1)
+                ->getAggregate(Ticket::class, ['ticketId' => $ticketId])
+                ->getWorkerId()
+        );
+    }
+
+    public function test_using_initial_state_for_state_aggregates(): void
+    {
+        $ecotoneTestSupport = EcotoneLite::bootstrapFlowTesting([SimplifiedAggregate::class]);
+
+        $this->assertTrue(
+            $ecotoneTestSupport
+                ->withStateFor(new SimplifiedAggregate(id: $id = '123', isEnabled: true))
+                ->getAggregate(SimplifiedAggregate::class, $id)
+                ->isEnabled()
+        );
+    }
+}


### PR DESCRIPTION
## Why is this change proposed?

In case of testing smaller parts or integration with parts of complex ES aggregates it may be redundant to fully setup an aggregate. Calling #[EventSourcingHandler] methods forces that.

Framework should not try to validate correct setup for ES Aggregate because this is never a technical issue.

## Pull Request Contribution Terms

- [X] I have read and agree to the contribution terms outlined in [CONTRIBUTING](https://github.com/ecotoneframework/ecotone-dev/blob/main/CONTRIBUTING.md).