### PR TITLE
feat: avoid nested retries

### DIFF
--- a/packages/Ecotone/src/Modelling/Config/InstantRetry/InstantRetryInterceptor.php
+++ b/packages/Ecotone/src/Modelling/Config/InstantRetry/InstantRetryInterceptor.php
@@ -14,44 +14,57 @@ use Exception;
 /**
  * licence Apache-2.0
  */
-class InstantRetryInterceptor implements DefinedObject
+class InstantRetryInterceptor
 {
-    public function __construct(private int $maxRetryAttempts, private array $exceptions = [])
+    public function __construct(
+        private int $maxRetryAttempts,
+        private array $exceptions,
+        private RetryStatusTracker $retryStatusTracker,
+    )
     {
     }
 
     public function retry(MethodInvocation $methodInvocation, Message $message, #[Reference] LoggingGateway $logger)
     {
-        $isSuccessful = false;
-        $retries = 0;
+        if ($this->retryStatusTracker->isCurrentlyWrappedByRetry()) {
+            return $methodInvocation->proceed();
+        }
 
-        $result = null;
-        while (! $isSuccessful) {
-            try {
-                $result = $methodInvocation->proceed();
-                $isSuccessful = true;
-            } catch (Exception $exception) {
-                if (! $this->canRetryThrownException($exception) || $retries >= $this->maxRetryAttempts) {
+        try {
+            $isSuccessful = false;
+            $retries = 0;
+            $this->retryStatusTracker->markAsWrapped();
+
+            $result = null;
+            while (! $isSuccessful) {
+                try {
+                    $result = $methodInvocation->proceed();
+                    $isSuccessful = true;
+                } catch (Exception $exception) {
+                    if (! $this->canRetryThrownException($exception) || $retries >= $this->maxRetryAttempts) {
+                        $logger->info(
+                            sprintf('Instant retry have exceed %d/%d retry limit. No more retries will be done', $retries, $this->maxRetryAttempts),
+                            $message,
+                            ['exception' => $exception],
+                        );
+                        throw $exception;
+                    }
+
+                    $retries++;
                     $logger->info(
-                        sprintf('Instant retry have exceed %d/%d retry limit. No more retries will be done', $retries, $this->maxRetryAttempts),
+                        sprintf(
+                            'Exception happened. Trying to self-heal by doing instant try %d out of %d. Due to %s',
+                            $retries,
+                            $this->maxRetryAttempts,
+                            $exception->getMessage()
+                        ),
                         $message,
-                        ['exception' => $exception],
+                        ['exception' => $exception]
                     );
-                    throw $exception;
                 }
-
-                $retries++;
-                $logger->info(
-                    sprintf(
-                        'Exception happened. Trying to self-heal by doing instant try %d out of %d. Due to %s',
-                        $retries,
-                        $this->maxRetryAttempts,
-                        $exception->getMessage()
-                    ),
-                    $message,
-                    ['exception' => $exception]
-                );
             }
+        } finally {
+            $this->retryStatusTracker->markAsUnwrapped();
         }
 
         return $result;
@@ -70,10 +83,5 @@ class InstantRetryInterceptor implements DefinedObject
         }
 
         return false;
-    }
-
-    public function getDefinition(): Definition
-    {
-        return new Definition(self::class, [$this->maxRetryAttempts, $this->exceptions]);
     }
 }

--- a/packages/Ecotone/src/Modelling/Config/InstantRetry/InstantRetryModule.php
+++ b/packages/Ecotone/src/Modelling/Config/InstantRetry/InstantRetryModule.php
@@ -8,6 +8,8 @@ use Ecotone\Messaging\Attribute\ModuleAnnotation;
 use Ecotone\Messaging\Config\Annotation\AnnotationModule;
 use Ecotone\Messaging\Config\Annotation\ModuleConfiguration\ExtensionObjectResolver;
 use Ecotone\Messaging\Config\Configuration;
+use Ecotone\Messaging\Config\Container\Definition;
+use Ecotone\Messaging\Config\Container\Reference;
 use Ecotone\Messaging\Config\ModulePackageList;
 use Ecotone\Messaging\Config\ModuleReferenceSearchService;
 use Ecotone\Messaging\Config\ServiceConfiguration;
@@ -15,6 +17,7 @@ use Ecotone\Messaging\Handler\InterfaceToCallRegistry;
 use Ecotone\Messaging\Handler\Processor\MethodInvoker\AroundInterceptorBuilder;
 use Ecotone\Messaging\Precedence;
 use Ecotone\Modelling\CommandBus;
+use Ramsey\Uuid\Uuid;
 
 #[ModuleAnnotation]
 /**
@@ -40,6 +43,7 @@ final class InstantRetryModule implements AnnotationModule
     public function prepare(Configuration $messagingConfiguration, array $extensionObjects, ModuleReferenceSearchService $moduleReferenceSearchService, InterfaceToCallRegistry $interfaceToCallRegistry): void
     {
         $configuration = ExtensionObjectResolver::resolveUnique(InstantRetryConfiguration::class, $extensionObjects, InstantRetryConfiguration::createWithDefaults());
+        $messagingConfiguration->registerServiceDefinition(RetryStatusTracker::class, Definition::createFor(RetryStatusTracker::class, [false]));
 
         if ($configuration->isEnabledForCommandBus()) {
             $this->registerInterceptor($messagingConfiguration, $interfaceToCallRegistry, $configuration->getCommandBusRetryTimes(), $configuration->getCommandBuExceptions(), CommandBus::class);
@@ -69,12 +73,14 @@ final class InstantRetryModule implements AnnotationModule
 
     private function registerInterceptor(Configuration $messagingConfiguration, InterfaceToCallRegistry $interfaceToCallRegistry, int $retryAttempt, array $exceptions, string $pointcut): void
     {
+        $instantRetryId = Uuid::uuid7()->toString();
+        $messagingConfiguration->registerServiceDefinition($instantRetryId, Definition::createFor(InstantRetryInterceptor::class, [$retryAttempt, $exceptions, Reference::to(RetryStatusTracker::class)]));
+
         $messagingConfiguration
             ->registerAroundMethodInterceptor(
-                AroundInterceptorBuilder::createWithDirectObjectAndResolveConverters(
-                    $interfaceToCallRegistry,
-                    new InstantRetryInterceptor($retryAttempt, $exceptions),
-                    'retry',
+                AroundInterceptorBuilder::create(
+                    $instantRetryId,
+                    $interfaceToCallRegistry->getFor(InstantRetryInterceptor::class, 'retry'),
                     Precedence::AROUND_INSTANT_RETRY_PRECEDENCE,
                     $pointcut
                 )

--- a/packages/Ecotone/src/Modelling/Config/InstantRetry/InstantRetryModule.php
+++ b/packages/Ecotone/src/Modelling/Config/InstantRetry/InstantRetryModule.php
@@ -73,7 +73,7 @@ final class InstantRetryModule implements AnnotationModule
 
     private function registerInterceptor(Configuration $messagingConfiguration, InterfaceToCallRegistry $interfaceToCallRegistry, int $retryAttempt, array $exceptions, string $pointcut): void
     {
-        $instantRetryId = Uuid::uuid7()->toString();
+        $instantRetryId = Uuid::uuid4()->toString();
         $messagingConfiguration->registerServiceDefinition($instantRetryId, Definition::createFor(InstantRetryInterceptor::class, [$retryAttempt, $exceptions, Reference::to(RetryStatusTracker::class)]));
 
         $messagingConfiguration

--- a/packages/Ecotone/src/Modelling/Config/InstantRetry/RetryStatusTracker.php
+++ b/packages/Ecotone/src/Modelling/Config/InstantRetry/RetryStatusTracker.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Ecotone\Modelling\Config\InstantRetry;
 
+/**
+ * licence Apache-2.0
+ */
 final class RetryStatusTracker
 {
     public function __construct(

--- a/packages/Ecotone/src/Modelling/Config/InstantRetry/RetryStatusTracker.php
+++ b/packages/Ecotone/src/Modelling/Config/InstantRetry/RetryStatusTracker.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ecotone\Modelling\Config\InstantRetry;
+
+final class RetryStatusTracker
+{
+    public function __construct(
+        private bool $isWrappedByRetryInterceptor
+    )
+    {
+
+    }
+
+    public function markAsWrapped(): void
+    {
+        $this->isWrappedByRetryInterceptor = true;
+    }
+
+    public function markAsUnwrapped(): void
+    {
+        $this->isWrappedByRetryInterceptor = false;
+    }
+
+    public function isCurrentlyWrappedByRetry(): bool
+    {
+        return $this->isWrappedByRetryInterceptor;
+    }
+}


### PR DESCRIPTION
## Why is this change proposed?

In case Command Bus with enabled retries is executed within context that is already retried, it leads to situation where retries are multipled. 
Besides in case nested retried was executed due to SQL exception then it will not resolve itself as it requires transaction rollback which is done by outer retries.

## Pull Request Contribution Terms

- [X] I have read and agree to the contribution terms outlined in [CONTRIBUTING](https://github.com/ecotoneframework/ecotone-dev/blob/main/CONTRIBUTING.md).