### PR TITLE
Fix repository handling

### DIFF
--- a/packages/Dbal/src/ObjectManager/ManagerRegistryRepository.php
+++ b/packages/Dbal/src/ObjectManager/ManagerRegistryRepository.php
@@ -26,7 +26,7 @@ class ManagerRegistryRepository implements StandardRepository
     public function canHandle(string $aggregateClassName): bool
     {
         if (is_null($this->relatedClasses)) {
-            return true;
+            return $this->getManagerRegistry($aggregateClassName) !== null;
         }
 
         return in_array($aggregateClassName, $this->relatedClasses);
@@ -47,7 +47,7 @@ class ManagerRegistryRepository implements StandardRepository
         }
     }
 
-    private function getManagerRegistry(string $aggregateClass): ObjectManager
+    private function getManagerRegistry(string $aggregateClass): ?ObjectManager
     {
         $connectionFactory = $this->connectionFactory;
         if ($connectionFactory instanceof MultiTenantConnectionFactory) {


### PR DESCRIPTION
## Why is this change proposed?

Probable fix for #467 

## Description of Changes

I did not find a simple way to add a failing test, it should be done with Symfony (for a non emulated ManagerRegistry), Dbal and Event sourcing packages.

#449, by trying to decouple event sourcing from core, removes the majority of "`isEventSourced`" checks. For this reason, a `StandardRepository` implementation should be more precise in its `canHandle` as it can be asked if it can handle event sourced aggregates classes.

## Pull Request Contribution Terms

- [X] I have read and agree to the contribution terms outlined in [CONTRIBUTING](https://github.com/ecotoneframework/ecotone-dev/blob/main/CONTRIBUTING.md).