### PR TITLE
Fix: Ensure cache directory exists before writing proxy file

### DIFF
--- a/packages/Ecotone/src/Messaging/Handler/Gateway/ProxyFactory.php
+++ b/packages/Ecotone/src/Messaging/Handler/Gateway/ProxyFactory.php
@@ -105,7 +105,7 @@ class ProxyFactory
         // Code adapted from doctrine/orm/src/Proxy/ProxyFactory.php
         $parentDirectory = dirname($fileName);
 
-        if (! is_dir($parentDirectory) && ! @mkdir($parentDirectory, 0775, true)) {
+        if (! file_exists($parentDirectory) && ! is_dir($parentDirectory) && ! @mkdir($parentDirectory, 0775, true)) {
             throw ConfigurationException::create("Cannot create cache directory {$parentDirectory}");
         }
 


### PR DESCRIPTION
## Why is this change proposed?
During an HTTP request in a Symfony project using Ecotone, we sometimes encountered the following exception:
```
Ecotone\Messaging\Config\ConfigurationException: Cannot create cache directory /app/var/cache/dev/ecotone in /app/vendor/ecotone/ecotone/src/Messaging/MessagingException.php:52
Stack trace:
#0 /app/vendor/ecotone/ecotone/src/Messaging/Handler/Gateway/ProxyFactory.php(109): Ecotone\Messaging\MessagingException::create()
#1 /app/vendor/ecotone/ecotone/src/Messaging/Handler/Gateway/ProxyFactory.php(59): Ecotone\Messaging\Handler\Gateway\ProxyFactory->dumpFile()
#2 /app/vendor/ecotone/ecotone/src/Messaging/Handler/Gateway/ProxyFactory.php(67): Ecotone\Messaging\Handler\Gateway\ProxyFactory->generateCachedProxyFileFor()
```
Stack trace pointed to ProxyFactory::dumpFile(), which was attempting to write a generated proxy file without checking if the parent directory exists.

The condition missed a check for file_exists(), so in some edge cases (race condition), directory creation would fail and throw an exception even if the directory technically exists but is not ready.

## Description of Changes
This fix improves robustness and avoids runtime crashes during proxy generation in production environments.

## Pull Request Contribution Terms

- [X] I have read and agree to the contribution terms outlined in [CONTRIBUTING](https://github.com/ecotoneframework/ecotone-dev/blob/main/CONTRIBUTING.md).