### PR TITLE
metadata propagation issue

### DIFF
--- a/packages/Ecotone/src/Modelling/AggregateFlow/LoadAggregate/LoadAggregateMessageProcessor.php
+++ b/packages/Ecotone/src/Modelling/AggregateFlow/LoadAggregate/LoadAggregateMessageProcessor.php
@@ -38,7 +38,7 @@ final class LoadAggregateMessageProcessor implements MessageProcessor
         $messageType = TypeDescriptor::createFromVariable($message->getPayload());
 
         if (! $message->getHeaders()->containsKey(AggregateMessage::AGGREGATE_ID)) {
-            throw AggregateNotFoundException::create("Can't call Aggregate {$this->aggregateClassName}:{$this->aggregateMethod} as identifier header is missing. Please check your identifier mapping in {$messageType->toString()}. Have you forgot to add #[TargetIdentifier] in your Command or `aggregate.id` in metadata?");
+            throw AggregateNotFoundException::create(sprintf("Can't call Aggregate {$this->aggregateClassName}:{$this->aggregateMethod} as identifier header is missing. Please check your identifier mapping in {$messageType->toString()}. Have you forgot to add #[TargetIdentifier] in your Command or `%s` in metadata?", AggregateMessage::AGGREGATE_ID));
         }
 
         $aggregateIdentifiers = AggregateIdMetadata::createFrom(
@@ -47,7 +47,7 @@ final class LoadAggregateMessageProcessor implements MessageProcessor
 
         foreach ($aggregateIdentifiers as $identifierName => $aggregateIdentifier) {
             if (is_null($aggregateIdentifier)) {
-                throw AggregateNotFoundException::create("Can't call Aggregate {$this->aggregateClassName}:{$this->aggregateMethod} as value for identifier `{$identifierName}` is missing. Please check your identifier mapping in {$messageType->toString()}. Have you forgot to add #[TargetIdentifier] in your Command or `aggregate.id` in metadata?");
+                throw AggregateNotFoundException::create(sprintf("Can't call Aggregate {$this->aggregateClassName}:{$this->aggregateMethod} as value for identifier `{$identifierName}` is missing. Please check your identifier mapping in {$messageType->toString()}. Have you forgot to add #[TargetIdentifier] in your Command or `%s` in metadata?", AggregateMessage::AGGREGATE_ID));
             }
         }
 

--- a/packages/Ecotone/src/Modelling/MessageHandling/MetadataPropagator/MessageHeadersPropagatorInterceptor.php
+++ b/packages/Ecotone/src/Modelling/MessageHandling/MetadataPropagator/MessageHeadersPropagatorInterceptor.php
@@ -7,6 +7,7 @@ use Ecotone\Messaging\Attribute\ServiceActivator;
 use Ecotone\Messaging\Handler\Processor\MethodInvoker\MethodInvocation;
 use Ecotone\Messaging\Message;
 use Ecotone\Messaging\MessageHeaders;
+use Ecotone\Modelling\AggregateMessage;
 
 /**
  * licence Apache-2.0
@@ -26,6 +27,12 @@ class MessageHeadersPropagatorInterceptor
             $userlandHeaders = [];
         } else {
             $userlandHeaders = MessageHeaders::unsetAllFrameworkHeaders($message->getHeaders()->headers());
+            unset(
+                $userlandHeaders[AggregateMessage::AGGREGATE_ID],
+                $userlandHeaders[AggregateMessage::CALLED_AGGREGATE_CLASS],
+                $userlandHeaders[AggregateMessage::CALLED_AGGREGATE_INSTANCE],
+                $userlandHeaders[AggregateMessage::TARGET_VERSION],
+            );
             $userlandHeaders[MessageHeaders::MESSAGE_ID] = $message->getHeaders()->getMessageId();
             $userlandHeaders[MessageHeaders::MESSAGE_CORRELATION_ID] = $message->getHeaders()->getCorrelationId();
         }

--- a/packages/Ecotone/tests/Modelling/Fixture/BasketWithReservations/AddItemToBasket.php
+++ b/packages/Ecotone/tests/Modelling/Fixture/BasketWithReservations/AddItemToBasket.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Ecotone\Modelling\Fixture\BasketWithReservations;
+
+final class AddItemToBasket
+{
+    public function __construct(public string $basketId, public string $itemId) {}
+}

--- a/packages/Ecotone/tests/Modelling/Fixture/BasketWithReservations/Basket.php
+++ b/packages/Ecotone/tests/Modelling/Fixture/BasketWithReservations/Basket.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Ecotone\Modelling\Fixture\BasketWithReservations;
+
+use Ecotone\Messaging\Attribute\Asynchronous;
+use Ecotone\Modelling\Attribute\CommandHandler;
+use Ecotone\Modelling\Attribute\EventHandler;
+use Ecotone\Modelling\Attribute\EventSourcingAggregate;
+use Ecotone\Modelling\Attribute\EventSourcingHandler;
+use Ecotone\Modelling\Attribute\Identifier;
+use Ecotone\Modelling\WithAggregateVersioning;
+
+#[EventSourcingAggregate]
+final class Basket
+{
+    use WithAggregateVersioning;
+
+    #[Identifier]
+    private string $basketId;
+
+    #[CommandHandler]
+    public function addItem(AddItemToBasket $command): array
+    {
+        return [new ItemWasAddedToBasket($this->basketId, $command->itemId)];
+    }
+
+    #[EventHandler(endpointId: 'basket.itemWasAddedToBasket')]
+    #[Asynchronous(channelName: 'basket')]
+    public function whenItemWasAddedToBasket(ItemWasAddedToBasket $event): array
+    {
+        return [new ItemReservationCreated($event->itemId)];
+    }
+
+    #[EventSourcingHandler]
+    public function applyBasketCreated(BasketCreated $event): void
+    {
+        $this->basketId = $event->basketId;
+    }
+}

--- a/packages/Ecotone/tests/Modelling/Fixture/BasketWithReservations/BasketCreated.php
+++ b/packages/Ecotone/tests/Modelling/Fixture/BasketWithReservations/BasketCreated.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Ecotone\Modelling\Fixture\BasketWithReservations;
+
+final class BasketCreated
+{
+    public function __construct(public string $basketId)
+    {
+    }
+}

--- a/packages/Ecotone/tests/Modelling/Fixture/BasketWithReservations/ItemInventory.php
+++ b/packages/Ecotone/tests/Modelling/Fixture/BasketWithReservations/ItemInventory.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Ecotone\Modelling\Fixture\BasketWithReservations;
+
+use Ecotone\Messaging\Attribute\Asynchronous;
+use Ecotone\Modelling\Attribute\EventHandler;
+use Ecotone\Modelling\Attribute\EventSourcingAggregate;
+use Ecotone\Modelling\Attribute\EventSourcingHandler;
+use Ecotone\Modelling\Attribute\Identifier;
+use Ecotone\Modelling\WithAggregateVersioning;
+
+#[EventSourcingAggregate]
+final class ItemInventory
+{
+    use WithAggregateVersioning;
+
+    #[Identifier]
+    private string $itemId;
+
+    #[EventHandler(endpointId: 'item.itemReservationCreated')]
+    #[Asynchronous(channelName: 'itemInventory')]
+    public function whenItemReservationCreated(ItemReservationCreated $event): array
+    {
+        return [new ItemReserved($event->itemId)];
+    }
+
+    #[EventSourcingHandler]
+    public function applyItemInventoryCreated(ItemInventoryCreated $event): void
+    {
+        $this->itemId = $event->itemId;
+    }
+}

--- a/packages/Ecotone/tests/Modelling/Fixture/BasketWithReservations/ItemInventoryCreated.php
+++ b/packages/Ecotone/tests/Modelling/Fixture/BasketWithReservations/ItemInventoryCreated.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Ecotone\Modelling\Fixture\BasketWithReservations;
+
+final class ItemInventoryCreated
+{
+    public function __construct(public string $itemId)
+    {
+    }
+}

--- a/packages/Ecotone/tests/Modelling/Fixture/BasketWithReservations/ItemReservationCreated.php
+++ b/packages/Ecotone/tests/Modelling/Fixture/BasketWithReservations/ItemReservationCreated.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Ecotone\Modelling\Fixture\BasketWithReservations;
+
+final class ItemReservationCreated
+{
+    public function __construct(public string $itemId)
+    {
+    }
+}

--- a/packages/Ecotone/tests/Modelling/Fixture/BasketWithReservations/ItemReserved.php
+++ b/packages/Ecotone/tests/Modelling/Fixture/BasketWithReservations/ItemReserved.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Ecotone\Modelling\Fixture\BasketWithReservations;
+
+final class ItemReserved
+{
+    public function __construct(public string $itemId)
+    {
+    }
+}

--- a/packages/Ecotone/tests/Modelling/Fixture/BasketWithReservations/ItemWasAddedToBasket.php
+++ b/packages/Ecotone/tests/Modelling/Fixture/BasketWithReservations/ItemWasAddedToBasket.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Ecotone\Modelling\Fixture\BasketWithReservations;
+
+final class ItemWasAddedToBasket
+{
+    public function __construct(public string $basketId, public string $itemId)
+    {
+    }
+}


### PR DESCRIPTION
## Why is this change proposed?

when message flow goes outside of aggregate which was called as first, its identifier is always propagated

## Test scenario

1. `Item` gets added to `Basket`
2. `Basket` (separated EH) records reservation
3. `ItemInventory` (different aggregate) also records reservation

Problem occurs when loading `ItemInventory` due `Basket` identifier is in use.

## Pull Request Contribution Terms

- [X] I have read and agree to the contribution terms outlined in [CONTRIBUTING](https://github.com/ecotoneframework/ecotone-dev/blob/main/CONTRIBUTING.md).