### PR TITLE
keep projections running

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -124,7 +124,7 @@
         "laminas/laminas-code": "^4",
         "jms/serializer": "^3.32",
         "laravel/framework": "^9.5.2|^10.0|^11.0|^12.0|^13.0",
-        "prooph/pdo-event-store": "^1.16.2",
+        "prooph/pdo-event-store": "^1.16.3",
         "psr/log": "^2.0|^3.0",
         "queue-interop/queue-interop": "^0.8",
         "ramsey/uuid": "^4.0",

--- a/packages/PdoEventSourcing/composer.json
+++ b/packages/PdoEventSourcing/composer.json
@@ -34,7 +34,7 @@
     },
     "require": {
         "ecotone/dbal": "~1.254.0",
-        "prooph/pdo-event-store": "^1.16.2"
+        "prooph/pdo-event-store": "^1.16.3"
     },
     "require-dev": {
         "phpunit/phpunit": "^10.5|^11.0",

--- a/packages/PdoEventSourcing/tests/Integration/GapDetectionInPollingProjectionTest.php
+++ b/packages/PdoEventSourcing/tests/Integration/GapDetectionInPollingProjectionTest.php
@@ -55,24 +55,24 @@ final class GapDetectionInPollingProjectionTest extends EventSourcingMessagingTe
         $this->missingEvent = $connection->fetchAssociative(sprintf('select * from %s where no = ?', $streamName), [2]);
         $connection->delete($streamName, ['no' => 2]);
 
-        $initialTimestamp = 1712501960;
+        $initialTimestamp = (new \DateTimeImmutable('now', new \DateTimeZone('UTC')))->getTimestamp();
 
         $metadata = json_decode($connection->fetchOne(sprintf('select metadata from %s where no = ?', $streamName), [1]), true);
         $metadata['timestamp'] = $initialTimestamp;
         $connection->update($streamName, ['metadata' => json_encode($metadata), 'created_at' => date(DATE_ATOM, $initialTimestamp)], ['no' => 1]);
 
         $metadata = json_decode($connection->fetchOne(sprintf('select metadata from %s where no = ?', $streamName), [3]), true);
-        $metadata['timestamp'] = $initialTimestamp + 100;
-        $connection->update($streamName, ['metadata' => json_encode($metadata), 'created_at' => date(DATE_ATOM, $initialTimestamp + 100)], ['no' => 3]);
+        $metadata['timestamp'] = $initialTimestamp + 10;
+        $connection->update($streamName, ['metadata' => json_encode($metadata), 'created_at' => date(DATE_ATOM, $initialTimestamp + 10)], ['no' => 3]);
 
         $metadata = json_decode($connection->fetchOne(sprintf('select metadata from %s where no = ?', $streamName), [4]), true);
-        $metadata['timestamp'] = $initialTimestamp + 200;
-        $connection->update($streamName, ['metadata' => json_encode($metadata), 'created_at' => date(DATE_ATOM, $initialTimestamp + 200)], ['no' => 4]);
+        $metadata['timestamp'] = $initialTimestamp + 20;
+        $connection->update($streamName, ['metadata' => json_encode($metadata), 'created_at' => date(DATE_ATOM, $initialTimestamp + 20)], ['no' => 4]);
     }
 
     public function test_detecting_gaps_without_detection_window(): void
     {
-        $gapDetection = new GapDetection([10, 20, 50]);
+        $gapDetection = new GapDetection([0]);
 
         $ecotone = $this->bootstrapEcotoneWithGapDetection($gapDetection);
         $ecotone->initializeProjection(InProgressTicketList::IN_PROGRESS_TICKET_PROJECTION);
@@ -80,10 +80,13 @@ final class GapDetectionInPollingProjectionTest extends EventSourcingMessagingTe
 
         self::assertEquals([
             ['ticket_id' => '123', 'ticket_type' => 'alert'],
+            ['ticket_id' => '124', 'ticket_type' => 'alert'],
+            ['ticket_id' => '125', 'ticket_type' => 'warning'],
         ], $ecotone->sendQueryWithRouting('getInProgressTickets'));
 
         $this->addMissingEvent();
 
+        $ecotone->resetProjection(InProgressTicketList::IN_PROGRESS_TICKET_PROJECTION);
         $ecotone->run(InProgressTicketList::IN_PROGRESS_TICKET_PROJECTION);
 
         self::assertEquals([


### PR DESCRIPTION
## Why is this change proposed?

due Prooph may change database projections status to `idle` after first cycle when triggered with `keepRunning: false`, non-polling asynchronous database projections should be triggered with `keepRunning: true`

## Description of Changes

Issue occurs when resetting asynchronous projection. With `keepRunning: false` Prooph will run it once for amount of events defined with `load_count` option and change its status to `idle`. Ecotone checks projection status after first run and runs it again while status remains either as `rebuilding` or `running`.

I made following assumptions:
- InMemory projections are not managed by locks like database projections
- running polling projection makes application responsible for triggering projection
- resetting polling projection acts like it was triggered
- asynchronous, ES projection should "listen" for incoming events

## Pull Request Contribution Terms

- [X] I have read and agree to the contribution terms outlined in [CONTRIBUTING](https://github.com/ecotoneframework/ecotone-dev/blob/main/CONTRIBUTING.md).