### PR TITLE
single projection manager service in container

### DIFF
--- a/packages/PdoEventSourcing/src/Config/InboundChannelAdapter/ProjectionExecutorBuilder.php
+++ b/packages/PdoEventSourcing/src/Config/InboundChannelAdapter/ProjectionExecutorBuilder.php
@@ -26,7 +26,6 @@ class ProjectionExecutorBuilder extends InputOutputMessageHandlerBuilder impleme
 {
     public function __construct(
         private ProjectionSetupConfiguration $projectionSetupConfiguration,
-        private array $projectSetupConfigurations,
         private string $methodName
     ) {
     }
@@ -41,12 +40,7 @@ class ProjectionExecutorBuilder extends InputOutputMessageHandlerBuilder impleme
         $projectionEventHandler =  new Definition(
             ProjectionEventHandler::class,
             [
-                new Definition(LazyProophProjectionManager::class, [
-                    Reference::to(EventSourcingConfiguration::class),
-                    $this->projectSetupConfigurations,
-                    Reference::to(ReferenceSearchService::class),
-                    Reference::to(LazyProophEventStore::class),
-                ]),
+                new Reference(LazyProophProjectionManager::class),
                 $this->projectionSetupConfiguration,
                 Reference::to(ConversionService::REFERENCE_NAME),
             ]

--- a/packages/PdoEventSourcing/src/Config/ProjectionManagerBuilder.php
+++ b/packages/PdoEventSourcing/src/Config/ProjectionManagerBuilder.php
@@ -7,6 +7,7 @@ use Ecotone\EventSourcing\ProjectionSetupConfiguration;
 use Ecotone\EventSourcing\Prooph\LazyProophEventStore;
 use Ecotone\EventSourcing\Prooph\LazyProophProjectionManager;
 use Ecotone\Messaging\Config\Container\Definition;
+use Ecotone\Messaging\Config\Container\InterfaceToCallReference;
 use Ecotone\Messaging\Config\Container\MessagingContainerBuilder;
 use Ecotone\Messaging\Config\Container\Reference;
 use Ecotone\Messaging\Handler\InputOutputMessageHandlerBuilder;
@@ -23,13 +24,11 @@ class ProjectionManagerBuilder extends InputOutputMessageHandlerBuilder
 {
     /**
      * @param ParameterConverterBuilder[] $parameterConverters
-     * @param ProjectionSetupConfiguration[] $projectionSetupConfigurations
      */
     private function __construct(
         private string $methodName,
         private array $parameterConverters,
         private EventSourcingConfiguration $eventSourcingConfiguration,
-        private array $projectionSetupConfigurations
     ) {
     }
 
@@ -41,9 +40,8 @@ class ProjectionManagerBuilder extends InputOutputMessageHandlerBuilder
         string $methodName,
         array $parameterConverters,
         EventSourcingConfiguration $eventSourcingConfiguration,
-        array $projectionSetupConfigurations
     ): static {
-        return new self($methodName, $parameterConverters, $eventSourcingConfiguration, $projectionSetupConfigurations);
+        return new self($methodName, $parameterConverters, $eventSourcingConfiguration);
     }
 
     public function getInputMessageChannelName(): string
@@ -58,17 +56,7 @@ class ProjectionManagerBuilder extends InputOutputMessageHandlerBuilder
 
     public function compile(MessagingContainerBuilder $builder): Definition
     {
-        $lazyProophProjectionManager = new Definition(
-            LazyProophProjectionManager::class,
-            [
-                new Reference(EventSourcingConfiguration::class),
-                $this->projectionSetupConfigurations,
-                new Reference(ReferenceSearchService::class),
-                new Reference(LazyProophEventStore::class),
-            ]
-        );
-
-        return ServiceActivatorBuilder::createWithDefinition($lazyProophProjectionManager, $this->methodName)
+        return ServiceActivatorBuilder::create(LazyProophProjectionManager::class, new InterfaceToCallReference(LazyProophProjectionManager::class, $this->methodName))
             ->withMethodParameterConverters($this->parameterConverters)
             ->withInputChannelName($this->getInputMessageChannelName())
             ->compile($builder);


### PR DESCRIPTION
## Why is this change proposed?
Possible performance improvement

## Description of Changes
LazyProophProjectionManager class was registered multiple times in the container (each action on each projection + each event handler on each projection) while it should be a singleton. This 

## Pull Request Contribution Terms

- [X] I have read and agree to the contribution terms outlined in [CONTRIBUTING](https://github.com/ecotoneframework/ecotone-dev/blob/main/CONTRIBUTING.md).