### PR TITLE
WIP: Event routing behavior

### DIFF
--- a/packages/Ecotone/tests/Modelling/Fixture/PriorityEventHandler/SynchronousPriorityHandlerWithInheritance.php
+++ b/packages/Ecotone/tests/Modelling/Fixture/PriorityEventHandler/SynchronousPriorityHandlerWithInheritance.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Ecotone\Modelling\Fixture\PriorityEventHandler;
+
+use Ecotone\Messaging\Attribute\Endpoint\Priority;
+use Ecotone\Modelling\Attribute\EventHandler;
+use Ecotone\Modelling\Attribute\QueryHandler;
+
+/**
+ * licence Apache-2.0
+ */
+final class SynchronousPriorityHandlerWithInheritance
+{
+    public array $triggers = [];
+
+    #[Priority(3)]
+    #[EventHandler(endpointId: 'middlePriorityHandler')]
+    public function middlePriorityHandler(OrderWasPlaced $event): void
+    {
+        $this->triggers[] = 'middlePriorityHandler';
+    }
+
+    #[Priority(1)]
+    #[EventHandler(endpointId: 'lowerPriorityHandlerWithObjectRouting')]
+    public function lowerPriorityHandler(object $event): void
+    {
+        $this->triggers[] = 'lowerPriorityHandlerWithObjectRouting';
+    }
+
+    #[Priority(5)]
+    #[EventHandler(endpointId: 'higherPriorityHandler')]
+    public function higherPriorityHandler(OrderWasPlaced $event): void
+    {
+        $this->triggers[] = 'higherPriorityHandler';
+    }
+
+    #[QueryHandler('getTriggers')]
+    public function getTriggers(): array
+    {
+        return $this->triggers;
+    }
+}

--- a/packages/Ecotone/tests/Modelling/Unit/ModellingEcotoneLiteTest.php
+++ b/packages/Ecotone/tests/Modelling/Unit/ModellingEcotoneLiteTest.php
@@ -24,6 +24,7 @@ use Test\Ecotone\Modelling\Fixture\PriorityEventHandler\AggregateSynchronousPrio
 use Test\Ecotone\Modelling\Fixture\PriorityEventHandler\AggregateSynchronousPriorityWithLowerPriorityHandler;
 use Test\Ecotone\Modelling\Fixture\PriorityEventHandler\OrderWasPlaced;
 use Test\Ecotone\Modelling\Fixture\PriorityEventHandler\SynchronousPriorityHandler;
+use Test\Ecotone\Modelling\Fixture\PriorityEventHandler\SynchronousPriorityHandlerWithInheritance;
 
 /**
  * @internal
@@ -65,6 +66,23 @@ final class ModellingEcotoneLiteTest extends TestCase
 
         $this->assertSame(
             ['higherPriorityHandler', 'middlePriorityHandler', 'lowerPriorityHandler'],
+            $ecotoneTestSupport
+                ->publishEvent(new OrderWasPlaced(1))
+                ->sendQueryWithRouting('getTriggers')
+        );
+    }
+
+    public function test_synchronous_event_handlers_should_be_handled_in_priority_with_inheritance()
+    {
+        $ecotoneTestSupport = EcotoneLite::bootstrapFlowTesting(
+            [SynchronousPriorityHandlerWithInheritance::class],
+            [
+                new SynchronousPriorityHandlerWithInheritance(),
+            ]
+        );
+
+        $this->assertSame(
+            ['lowerPriorityHandlerWithObjectRouting', 'higherPriorityHandler', 'middlePriorityHandler'],
             $ecotoneTestSupport
                 ->publishEvent(new OrderWasPlaced(1))
                 ->sendQueryWithRouting('getTriggers')


### PR DESCRIPTION
## Why is this change proposed?

Synchronous and asynchronous event handler priorities have the same behavior.
Respect ordering of `NamedEvent`.

## Description of Changes

## Pull Request Contribution Terms

- [X] I have read and agree to the contribution terms outlined in [CONTRIBUTING](https://github.com/ecotoneframework/ecotone-dev/blob/main/CONTRIBUTING.md).