### PR TITLE
Fix NamedEvent resolution for route aliasing

### DIFF
--- a/packages/Ecotone/src/Messaging/Config/Annotation/ModuleConfiguration/AsynchronousModule.php
+++ b/packages/Ecotone/src/Messaging/Config/Annotation/ModuleConfiguration/AsynchronousModule.php
@@ -255,7 +255,7 @@ class AsynchronousModule implements AnnotationModule, RoutingEventHandler
         return $endpointChannels;
     }
 
-    public function handleRoutingEvent(RoutingEvent $event, ?Configuration $messagingConfiguration = null): void
+    public function handleRoutingEvent(RoutingEvent $event): void
     {
         $registration = $event->getRegistration();
         $isAsynchronous = $registration->hasMethodAnnotation(Asynchronous::class);

--- a/packages/Ecotone/src/Modelling/Config/AggregrateModule.php
+++ b/packages/Ecotone/src/Modelling/Config/AggregrateModule.php
@@ -496,13 +496,15 @@ class AggregrateModule implements AnnotationModule, RoutingEventHandler
         }
     }
 
-    public function handleRoutingEvent(RoutingEvent $event, ?Configuration $messagingConfiguration = null): void
+    public function handleRoutingEvent(RoutingEvent $event): void
     {
         $registration = $event->getRegistration();
 
         if (! $registration->hasAnnotation(Aggregate::class)) {
             return;
         }
+
+        $messagingConfiguration = $event->getBusRoutingMapBuilder()->getMessagingConfiguration();
 
         Assert::notNull($messagingConfiguration, 'RoutingEvent should be handled with messaging configuration, but it is null. Did you forget to pass it?');
 

--- a/packages/Ecotone/src/Modelling/Config/Routing/BusRoutingMapBuilder.php
+++ b/packages/Ecotone/src/Modelling/Config/Routing/BusRoutingMapBuilder.php
@@ -7,6 +7,9 @@ declare(strict_types=1);
 
 namespace Ecotone\Modelling\Config\Routing;
 
+use Ecotone\Messaging\Handler\Type;
+use Ecotone\Messaging\Handler\TypeDescriptor;
+use Ecotone\Modelling\Attribute\NamedEvent;
 use function array_map;
 use function array_unique;
 
@@ -49,19 +52,15 @@ class BusRoutingMapBuilder extends BusRoutingMap
             return [$routingKey];
         }
 
-        $interfaceToCall = $interfaceToCallRegistry->getFor($registration->getClassName(), $registration->getMethodName());
-        if ($interfaceToCall->hasNoParameters()) {
+        $type = $this->getFirstParameterType($interfaceToCallRegistry, $registration);
+        if (!$type) {
             return [];
-        }
-        $type = $interfaceToCall->getFirstParameter()->getTypeDescriptor();
-        if ($type->isUnionType()) {
+        } else {
             $routes = [];
             foreach ($type->getUnionTypes() as $unionType) {
                 $routes[] = (string) $unionType;
             }
             return $routes;
-        } else {
-            return [(string) $type];
         }
     }
 
@@ -76,9 +75,36 @@ class BusRoutingMapBuilder extends BusRoutingMap
         $routes = $this->getRoutesFromAnnotatedFinding($registration, $interfaceToCallRegistry);
         $priority = PriorityBasedOnType::fromAnnotatedFinding($registration);
 
-        $routingEvent = new RoutingEvent($registration, $destinationChannel, $routes, $priority->getPriorityArray());
+        $routingEvent = new RoutingEvent($this, $registration, $destinationChannel, $routes, $priority->getPriorityArray());
 
-        return $this->dispatchRoutingEvent($routingEvent);
+        $this->dispatchRoutingEvent($routingEvent);
+
+        if ($routingEvent->isCanceled()) {
+            return null; // event is canceled, no routing
+        }
+        $destinationChannel = $routingEvent->getDestinationChannel();
+        $priority = $routingEvent->getPriority();
+
+        foreach ($routingEvent->getRoutingKeys() as $routingKey) {
+            $this->addRoute($routingKey, $destinationChannel, $priority);
+        }
+
+        // add object alias if the routing key is a class and has a NamedEvent annotation
+        $type = $this->getFirstParameterType($interfaceToCallRegistry, $registration);
+        if ($type) {
+            foreach ($type->getUnionTypes() as $unionType) {
+                $className = (string) $unionType;
+                if (class_exists($className)) {
+                    $classDefinition = $interfaceToCallRegistry->getClassDefinitionFor(TypeDescriptor::create($className));
+                    if ($classDefinition->hasClassAnnotation(TypeDescriptor::create(NamedEvent::class))) {
+                        $namedEvent = $classDefinition->getSingleClassAnnotation(TypeDescriptor::create(NamedEvent::class));
+                        $this->addObjectAlias($className, $namedEvent->getName());
+                    }
+                }
+            }
+        }
+
+        return $destinationChannel;
     }
 
     /**
@@ -166,6 +192,9 @@ class BusRoutingMapBuilder extends BusRoutingMap
     public function addObjectAlias(string $class, string $routingKey): void
     {
         if (isset($this->classToNameAliases[$class])) {
+            if ($this->classToNameAliases[$class] === $routingKey) {
+                return; // already registered
+            }
             throw ConfigurationException::create("Class $class already has an alias registered: " . $this->classToNameAliases[$class]);
         }
         if (isset($this->nameToClassAliases[$routingKey])) {
@@ -243,6 +272,11 @@ class BusRoutingMapBuilder extends BusRoutingMap
         ]);
     }
 
+    public function getMessagingConfiguration(): ?Configuration
+    {
+        return $this->messagingConfiguration;
+    }
+
     private function channelName(string $channel): string
     {
         if (isset($this->channelsName[$channel])) {
@@ -263,25 +297,22 @@ class BusRoutingMapBuilder extends BusRoutingMap
     /**
      * @return ?string the destination channel name or null if the event is canceled
      */
-    private function dispatchRoutingEvent(RoutingEvent $routingEvent): ?string
+    private function dispatchRoutingEvent(RoutingEvent $routingEvent): void
     {
         foreach ($this->routingEventHandlers as $routingEventHandler) {
-            $routingEventHandler->handleRoutingEvent($routingEvent, $this->messagingConfiguration);
-            if ($routingEvent->isCanceled()) {
-                return null;
-            }
-            if ($routingEvent->isPropagationStopped()) {
-                break;
+            $routingEventHandler->handleRoutingEvent($routingEvent);
+            if ($routingEvent->isCanceled() || $routingEvent->isPropagationStopped()) {
+                return;
             }
         }
+    }
 
-        $destinationChannel = $routingEvent->getDestinationChannel();
-        $priority = $routingEvent->getPriority();
-
-        foreach ($routingEvent->getRoutingKeys() as $routingKey) {
-            $this->addRoute($routingKey, $destinationChannel, $priority);
+    private function getFirstParameterType(InterfaceToCallRegistry $interfaceToCallRegistry, AnnotatedFinding $registration): ?Type
+    {
+        $interfaceToCall = $interfaceToCallRegistry->getFor($registration->getClassName(), $registration->getMethodName());
+        if ($interfaceToCall->hasNoParameters()) {
+            return null;
         }
-
-        return $destinationChannel;
+        return $interfaceToCall->getFirstParameter()->getTypeDescriptor();
     }
 }

--- a/packages/Ecotone/src/Modelling/Config/Routing/RoutingEvent.php
+++ b/packages/Ecotone/src/Modelling/Config/Routing/RoutingEvent.php
@@ -19,6 +19,7 @@ class RoutingEvent
      * @param int|int[] $priority
      */
     public function __construct(
+        private BusRoutingMapBuilder $busRoutingMapBuilder,
         private readonly AnnotatedFinding $registration,
         private string $destinationChannel,
         private array $routingKeys,
@@ -82,5 +83,10 @@ class RoutingEvent
     public function stopPropagation(): void
     {
         $this->isPropagationStopped = true;
+    }
+
+    public function getBusRoutingMapBuilder(): BusRoutingMapBuilder
+    {
+        return $this->busRoutingMapBuilder;
     }
 }

--- a/packages/Ecotone/src/Modelling/Config/Routing/RoutingEventHandler.php
+++ b/packages/Ecotone/src/Modelling/Config/Routing/RoutingEventHandler.php
@@ -7,9 +7,7 @@ declare(strict_types=1);
 
 namespace Ecotone\Modelling\Config\Routing;
 
-use Ecotone\Messaging\Config\Configuration;
-
 interface RoutingEventHandler
 {
-    public function handleRoutingEvent(RoutingEvent $event, ?Configuration $messagingConfiguration = null): void;
+    public function handleRoutingEvent(RoutingEvent $event): void;
 }

--- a/packages/Ecotone/src/Modelling/Config/ServiceHandlerModule.php
+++ b/packages/Ecotone/src/Modelling/Config/ServiceHandlerModule.php
@@ -62,7 +62,7 @@ final class ServiceHandlerModule implements AnnotationModule, RoutingEventHandle
     {
     }
 
-    public function handleRoutingEvent(RoutingEvent $event, ?Configuration $messagingConfiguration = null): void
+    public function handleRoutingEvent(RoutingEvent $event): void
     {
         $registration = $event->getRegistration();
         if ($registration->hasClassAnnotation(Aggregate::class)) {
@@ -80,7 +80,7 @@ final class ServiceHandlerModule implements AnnotationModule, RoutingEventHandle
             ? TransformerBuilder::create(AnnotatedDefinitionReference::getReferenceFor($registration), $this->interfaceToCallRegistry->getFor($registration->getClassName(), $registration->getMethodName()))
             : ServiceActivatorBuilder::create(AnnotatedDefinitionReference::getReferenceFor($registration), $this->interfaceToCallRegistry->getFor($registration->getClassName(), $registration->getMethodName()));
 
-        $messagingConfiguration->registerMessageHandler(
+        $event->getBusRoutingMapBuilder()->getMessagingConfiguration()->registerMessageHandler(
             $handler
                 ->withInputChannelName($event->getDestinationChannel())
                 ->withOutputMessageChannel($methodAnnotation->getOutputChannelName())

--- a/packages/Ecotone/tests/Messaging/Unit/Handler/Router/BusRoutingMapTest.php
+++ b/packages/Ecotone/tests/Messaging/Unit/Handler/Router/BusRoutingMapTest.php
@@ -14,7 +14,7 @@ use PHPUnit\Framework\TestCase;
 /**
  * @internal
  */
-class BusRoutingConfigTest extends TestCase
+class BusRoutingMapTest extends TestCase
 {
     public static function optimizedProvider(): iterable
     {

--- a/packages/PdoEventSourcing/src/Config/EventSourcingModuleRoutingExtension.php
+++ b/packages/PdoEventSourcing/src/Config/EventSourcingModuleRoutingExtension.php
@@ -8,7 +8,6 @@ declare(strict_types=1);
 namespace Ecotone\EventSourcing\Config;
 
 use Ecotone\EventSourcing\Attribute\Projection;
-use Ecotone\Messaging\Config\Configuration;
 use Ecotone\Modelling\Attribute\CommandHandler;
 use Ecotone\Modelling\Attribute\EventHandler;
 use Ecotone\Modelling\Config\Routing\RoutingEvent;
@@ -26,7 +25,7 @@ class EventSourcingModuleRoutingExtension implements RoutingEventHandler
     {
     }
 
-    public function handleRoutingEvent(RoutingEvent $event, ?Configuration $messagingConfiguration = null): void
+    public function handleRoutingEvent(RoutingEvent $event): void
     {
         $registration = $event->getRegistration();
         $isCommandOrEventHandler = $registration->hasAnnotation(CommandHandler::class) || $registration->hasAnnotation(EventHandler::class);


### PR DESCRIPTION
## Why is this change proposed?

Fix `NamedEvent` resolution for routing aliasing to avoid BC

## Description of Changes

Routing aliasing introduced in #479 requires `NamedEvent` classes to be added to resolved classes to parse attributes. This was not required before because `NamedEvent` attribute was resolved at runtime.

## Pull Request Contribution Terms

- [X] I have read and agree to the contribution terms outlined in [CONTRIBUTING](https://github.com/ecotoneframework/ecotone-dev/blob/main/CONTRIBUTING.md).