### PR TITLE
fix: aggregate id resolver

### DIFF
--- a/packages/Ecotone/src/Modelling/AggregateIdentifierRetrevingService.php
+++ b/packages/Ecotone/src/Modelling/AggregateIdentifierRetrevingService.php
@@ -57,6 +57,7 @@ class AggregateIdentifierRetrevingService implements MessageProcessor
         $mediaType = $message->getHeaders()->containsKey(MessageHeaders::CONTENT_TYPE)
             ? MediaType::parseMediaType($message->getHeaders()->get(MessageHeaders::CONTENT_TYPE))
             : MediaType::createApplicationXPHPWithTypeParameter(TypeDescriptor::createFromVariable($payload)->toString());
+
         if ($this->conversionService->canConvert(
             TypeDescriptor::createFromVariable($payload),
             $mediaType,

--- a/packages/Ecotone/src/Modelling/Config/AggregrateModule.php
+++ b/packages/Ecotone/src/Modelling/Config/AggregrateModule.php
@@ -551,11 +551,20 @@ class AggregrateModule implements AnnotationModule, RoutingEventHandler
         $parameterConverters   = $parameterConverterAnnotationFactory->createParameterWithDefaults($relatedClassInterface);
         $aggregateClassDefinition = $this->interfaceToCallRegistry->getClassDefinitionFor(TypeDescriptor::create($registration->getClassName()));
 
+        $handledPayloadType       = MessageHandlerRoutingModule::getFirstParameterClassIfAny($registration, $this->interfaceToCallRegistry);
+        $handledPayloadType       = $handledPayloadType ? $this->interfaceToCallRegistry->getClassDefinitionFor(TypeDescriptor::create($handledPayloadType)) : null;
+
         // This is executed before sending to async channel
         $aggregateIdentifierHandlerPreCheck = MessageProcessorActivatorBuilder::create()
             ->withInputChannelName($destinationChannel)
             ->withOutputMessageChannel($connectionChannel = $destinationChannel . '-connection')
-            ->chain(AggregateIdentifierRetrevingServiceBuilder::createWith($aggregateClassDefinition, $annotation->getIdentifierMetadataMapping(), $annotation->getIdentifierMapping(), null, $this->interfaceToCallRegistry))
+            ->chain(AggregateIdentifierRetrevingServiceBuilder::createWith(
+                $aggregateClassDefinition,
+                $annotation->getIdentifierMetadataMapping(),
+                $annotation->getIdentifierMapping(),
+                $handledPayloadType,
+                $this->interfaceToCallRegistry
+            ))
         ;
         $messagingConfiguration->registerMessageHandler($aggregateIdentifierHandlerPreCheck);
 

--- a/packages/Ecotone/tests/Modelling/Fixture/IdentifierMapping/AttributeMapping/ChangeStatus.php
+++ b/packages/Ecotone/tests/Modelling/Fixture/IdentifierMapping/AttributeMapping/ChangeStatus.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Ecotone\Modelling\Fixture\IdentifierMapping\AttributeMapping;
+
+final class ChangeStatus
+{
+    public function __construct(
+        public string $orderId,
+        public string $status
+    ) {
+
+    }
+}

--- a/packages/Ecotone/tests/Modelling/Fixture/IdentifierMapping/AttributeMapping/ChangeStatusConverter.php
+++ b/packages/Ecotone/tests/Modelling/Fixture/IdentifierMapping/AttributeMapping/ChangeStatusConverter.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Ecotone\Modelling\Fixture\IdentifierMapping\AttributeMapping;
+
+use Ecotone\Messaging\Attribute\Converter;
+use Test\Ecotone\Modelling\Fixture\IdentifierMapping\AttributeMapping\ChangeStatus;
+
+final class ChangeStatusConverter
+{
+    #[Converter]
+    public function from(ChangeStatus $changeStatus): array
+    {
+        throw new \RuntimeException('Should not be called');
+    }
+}

--- a/packages/Ecotone/tests/Modelling/Fixture/IdentifierMapping/AttributeMapping/OrderId.php
+++ b/packages/Ecotone/tests/Modelling/Fixture/IdentifierMapping/AttributeMapping/OrderId.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Ecotone\Modelling\Fixture\IdentifierMapping\AttributeMapping;
+
+final class OrderId
+{
+    public function __construct(private string $id)
+    {
+
+    }
+
+    public function __toString(): string
+    {
+        return $this->id;
+    }
+}

--- a/packages/Ecotone/tests/Modelling/Fixture/IdentifierMapping/AttributeMapping/OrderProcessWithAttributeHeadersMapping.php
+++ b/packages/Ecotone/tests/Modelling/Fixture/IdentifierMapping/AttributeMapping/OrderProcessWithAttributeHeadersMapping.php
@@ -37,6 +37,12 @@ final class OrderProcessWithAttributeHeadersMapping
         $this->status = $event->status;
     }
 
+    #[CommandHandler]
+    public function changeStatus(ChangeStatus $command): void
+    {
+        $this->status = $command->status;
+    }
+
     public function getOrderId(): string
     {
         return $this->orderId;


### PR DESCRIPTION
## Why is this change proposed?

Currently when Command is sent we are trying to serialize it to array, as we lost the context of expected Command Class. 
This use case was not covered by test case, therefore that behaviour was lost with latest refactor.

Solves #484 

## Pull Request Contribution Terms

- [X] I have read and agree to the contribution terms outlined in [CONTRIBUTING](https://github.com/ecotoneframework/ecotone-dev/blob/main/CONTRIBUTING.md).