### PR TITLE
Allow Error Handler to execute asynchronously

### DIFF
--- a/packages/Dbal/tests/Integration/DbalErrorChannelCommandBusTest.php
+++ b/packages/Dbal/tests/Integration/DbalErrorChannelCommandBusTest.php
@@ -12,6 +12,7 @@ use Ecotone\Messaging\Config\Annotation\ModuleConfiguration\MessagingGatewayModu
 use Ecotone\Messaging\Config\ModulePackageList;
 use Ecotone\Messaging\Config\ServiceConfiguration;
 use Ecotone\Messaging\Endpoint\ExecutionPollingMetadata;
+use Ecotone\Messaging\Handler\MessageHandlingException;
 use Ecotone\Messaging\Handler\Recoverability\ErrorContext;
 use Ecotone\Modelling\Attribute\InstantRetry;
 use Ecotone\Test\LicenceTesting;
@@ -189,7 +190,7 @@ final class DbalErrorChannelCommandBusTest extends DbalMessagingTestCase
         $exception = false;
         try {
             $commandBus->sendWithRouting('order.place', 'coffee');
-        } catch (InvalidArgumentException) {
+        } catch (MessageHandlingException) {
             $exception = true;
         }
 

--- a/packages/Ecotone/src/Messaging/Config/Annotation/ModuleConfiguration/ErrorHandlerModule.php
+++ b/packages/Ecotone/src/Messaging/Config/Annotation/ModuleConfiguration/ErrorHandlerModule.php
@@ -16,7 +16,7 @@ use Ecotone\Messaging\Config\ModuleReferenceSearchService;
 use Ecotone\Messaging\Handler\InterfaceToCallRegistry;
 use Ecotone\Messaging\Handler\Logger\LoggingGateway;
 use Ecotone\Messaging\Handler\Processor\MethodInvoker\Converter\ReferenceBuilder;
-use Ecotone\Messaging\Handler\Recoverability\ErrorHandler;
+use Ecotone\Messaging\Handler\Recoverability\DelayedRetryErrorHandler;
 use Ecotone\Messaging\Handler\Recoverability\ErrorHandlerConfiguration;
 use Ecotone\Messaging\Handler\Router\HeaderRouter;
 use Ecotone\Messaging\Handler\Router\RouterBuilder;
@@ -57,7 +57,7 @@ class ErrorHandlerModule extends NoExternalConfigurationModule implements Annota
             }
 
             $errorHandler = ServiceActivatorBuilder::createWithDefinition(
-                new Definition(ErrorHandler::class, [
+                new Definition(DelayedRetryErrorHandler::class, [
                     $extensionObject->getDelayedRetryTemplate(),
                     (bool)$extensionObject->getDeadLetterQueueChannel(),
                     Reference::to(LoggingGateway::class),

--- a/packages/Ecotone/src/Messaging/Handler/Gateway/GatewayInternalProcessor.php
+++ b/packages/Ecotone/src/Messaging/Handler/Gateway/GatewayInternalProcessor.php
@@ -4,6 +4,7 @@ namespace Ecotone\Messaging\Handler\Gateway;
 
 use Ecotone\Messaging\Channel\QueueChannel;
 use Ecotone\Messaging\Future;
+use Ecotone\Messaging\Handler\MessageHandlingException;
 use Ecotone\Messaging\Handler\MessageProcessor;
 use Ecotone\Messaging\Handler\Processor\MethodInvoker\AroundInterceptable;
 use Ecotone\Messaging\Handler\Type;
@@ -104,7 +105,10 @@ class GatewayInternalProcessor implements MessageProcessor, AroundInterceptable
                 throw InvalidArgumentException::create("{$this->interfaceToCallName} expects value, but null was returned. Have you consider changing return value to nullable?");
             }
             if ($replyMessage instanceof ErrorMessage) {
-                throw $replyMessage->getException();
+                throw MessageHandlingException::create(
+                    $replyMessage->getExceptionMessage(),
+                    $replyMessage->getExceptionCode(),
+                );
             }
 
             return $replyMessage;

--- a/packages/Ecotone/src/Messaging/Handler/Processor/MethodInvoker/Converter/MessageConverter.php
+++ b/packages/Ecotone/src/Messaging/Handler/Processor/MethodInvoker/Converter/MessageConverter.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace Ecotone\Messaging\Handler\Processor\MethodInvoker\Converter;
 
 use Ecotone\Messaging\Handler\ParameterConverter;
+use Ecotone\Messaging\Handler\Recoverability\ErrorContext;
 use Ecotone\Messaging\Message;
+use Ecotone\Messaging\Support\ErrorMessage;
 
 /**
  * Class MessageArgument
@@ -28,6 +30,10 @@ class MessageConverter implements ParameterConverter
      */
     public function getArgumentFrom(Message $message): Message
     {
+        if (ErrorMessage::isErrorMessage($message)) {
+            return ErrorMessage::createFromMessage($message);
+        }
+
         return $message;
     }
 }

--- a/packages/Ecotone/src/Messaging/Handler/Recoverability/DelayedRetryErrorHandler.php
+++ b/packages/Ecotone/src/Messaging/Handler/Recoverability/DelayedRetryErrorHandler.php
@@ -7,22 +7,19 @@ namespace Ecotone\Messaging\Handler\Recoverability;
 use Ecotone\Messaging\Attribute\Parameter\Reference;
 use Ecotone\Messaging\Handler\ChannelResolver;
 use Ecotone\Messaging\Handler\Logger\LoggingGateway;
+use Ecotone\Messaging\Handler\MessageHandlingException;
 use Ecotone\Messaging\Message;
 use Ecotone\Messaging\MessageChannel;
 use Ecotone\Messaging\MessageHeaders;
+use Ecotone\Messaging\Support\ErrorMessage;
 use Ecotone\Messaging\Support\MessageBuilder;
 
 /**
  * licence Apache-2.0
  */
-class ErrorHandler
+class DelayedRetryErrorHandler
 {
     public const ECOTONE_RETRY_HEADER = 'ecotone_retry_number';
-    public const EXCEPTION_STACKTRACE = 'exception-stacktrace';
-    public const EXCEPTION_FILE = 'exception-file';
-    public const EXCEPTION_LINE = 'exception-line';
-    public const EXCEPTION_CODE = 'exception-code';
-    public const EXCEPTION_MESSAGE = 'exception-message';
 
     public function __construct(
         private RetryTemplate $delayedRetryTemplate,
@@ -32,12 +29,11 @@ class ErrorHandler
     }
 
     public function handle(
-        Message $errorMessage,
+        ErrorMessage $errorMessage,
         ChannelResolver $channelResolver,
         #[Reference] LoggingGateway $logger
     ): ?Message {
         $failedMessage = $errorMessage;
-        $cause = $errorMessage->getHeaders()->get(ErrorContext::EXCEPTION);
         $retryNumber = $failedMessage->getHeaders()->containsKey(self::ECOTONE_RETRY_HEADER) ? $failedMessage->getHeaders()->get(self::ECOTONE_RETRY_HEADER) + 1 : 1;
 
         if (! $failedMessage->getHeaders()->containsKey(MessageHeaders::POLLED_CHANNEL_NAME)) {
@@ -45,10 +41,9 @@ class ErrorHandler
                 'Failed to handle Error Message via your Retry Configuration, as it does not contain information about origination channel from which it was polled.
                     This means that most likely Synchronous Dead Letter is configured with Retry Configuration which works only for Asynchronous configuration.',
                 $failedMessage,
-                ['exception' => $cause],
             );
 
-            throw $cause;
+            throw MessageHandlingException::create('Failed to handle Error Message via Retry Configuration, as it does not contain information about origination channel from which it was polled.');
         }
         /** @var MessageChannel $messageChannel */
         $messageChannel = $channelResolver->resolve($failedMessage->getHeaders()->get(MessageHeaders::POLLED_CHANNEL_NAME));
@@ -62,7 +57,6 @@ class ErrorHandler
             MessageHeaders::DELIVERY_DELAY,
             MessageHeaders::TIME_TO_LIVE,
             MessageHeaders::CONSUMER_ACK_HEADER_LOCATION,
-            ErrorContext::EXCEPTION,
             self::ECOTONE_RETRY_HEADER,
         ]);
 
@@ -73,10 +67,10 @@ class ErrorHandler
                         'Discarding message %s as no dead letter channel was defined. Retried maximum number of `%s` times. Due to: %s',
                         $failedMessage->getHeaders()->getMessageId(),
                         $retryNumber,
-                        $cause->getMessage()
+                        $errorMessage->getExceptionMessage()
                     ),
                     $failedMessage,
-                    ['exception' => $cause],
+                    $errorMessage->getErrorContext()->toArray(),
                 );
 
                 return null;
@@ -87,10 +81,10 @@ class ErrorHandler
                     'Sending message `%s` to dead letter channel, as retried maximum number of `%s` times. Due to: %s',
                     $failedMessage->getHeaders()->getMessageId(),
                     $retryNumber,
-                    $cause->getMessage()
+                    $errorMessage->getExceptionMessage()
                 ),
                 $failedMessage,
-                ['exception' => $cause],
+                [ErrorContext::EXCEPTION_CLASS => $errorMessage->getExceptionClass()],
             );
 
             return $messageBuilder->build();
@@ -105,10 +99,10 @@ class ErrorHandler
                 $this->delayedRetryTemplate->getMaxAttempts()
                     ? sprintf('Try %d out of %s', $retryNumber, $this->delayedRetryTemplate->getMaxAttempts())
                     : '',
-                $cause->getMessage()
+                $errorMessage->getExceptionMessage()
             ),
             $failedMessage,
-            ['exception' => $cause],
+            [ErrorContext::EXCEPTION_CLASS => $errorMessage->getExceptionClass()],
         );
         $messageChannel->send(
             $messageBuilder

--- a/packages/Ecotone/src/Messaging/Handler/Recoverability/DelayedRetryErrorHandler.php
+++ b/packages/Ecotone/src/Messaging/Handler/Recoverability/DelayedRetryErrorHandler.php
@@ -43,7 +43,7 @@ class DelayedRetryErrorHandler
                 $failedMessage,
             );
 
-            throw MessageHandlingException::create('Failed to handle Error Message via Retry Configuration, as it does not contain information about origination channel from which it was polled.');
+            throw MessageHandlingException::create('Failed to handle Error Message via Retry Configuration, as it does not contain information about origination channel from which it was polled. Original error message: ' . $failedMessage->getExceptionMessage());
         }
         /** @var MessageChannel $messageChannel */
         $messageChannel = $channelResolver->resolve($failedMessage->getHeaders()->get(MessageHeaders::POLLED_CHANNEL_NAME));

--- a/packages/Ecotone/src/Messaging/Handler/Recoverability/ErrorContext.php
+++ b/packages/Ecotone/src/Messaging/Handler/Recoverability/ErrorContext.php
@@ -10,7 +10,7 @@ use Ecotone\Messaging\MessageHeaders;
 class ErrorContext
 {
     public const WHOLE_ERROR_CONTEXT = [
-        self::EXCEPTION,
+        self::EXCEPTION_CLASS,
         self::EXCEPTION_STACKTRACE,
         self::EXCEPTION_FILE,
         self::EXCEPTION_LINE,
@@ -19,13 +19,15 @@ class ErrorContext
     ];
 
     public const EXCEPTION = 'exception';
-    public const EXCEPTION_STACKTRACE = 'exception-stacktrace';
-    public const EXCEPTION_FILE = 'exception-file';
-    public const EXCEPTION_LINE = 'exception-line';
-    public const EXCEPTION_CODE = 'exception-code';
-    public const EXCEPTION_MESSAGE = 'exception-message';
+    public const EXCEPTION_MESSAGE = 'ecotone.exception.message';
+    public const EXCEPTION_CLASS = 'ecotone.exception.class';
+    public const EXCEPTION_STACKTRACE = 'ecotone.exception.stacktrace';
+    public const EXCEPTION_FILE = 'ecotone.exception.file';
+    public const EXCEPTION_LINE = 'ecotone.exception.line';
+    public const EXCEPTION_CODE = 'ecotone.exception.code';
     public const DLQ_MESSAGE_REPLIED = 'ecotone.dlq.message_replied';
 
+    private string $exceptionClass;
     private string $messageId;
     private int $failedTimestamp;
     private string $stackTrace;
@@ -34,10 +36,11 @@ class ErrorContext
     private string $code;
     private string $message;
 
-    private function __construct(string $messageId, int $failedTimestamp, string $message, string $stackTrace, string $code, string $file, string $line)
+    private function __construct(string $messageId, int $failedTimestamp, string $exceptionClass, string $message, string $stackTrace, string $code, string $file, string $line)
     {
         $this->messageId = $messageId;
         $this->failedTimestamp = $failedTimestamp;
+        $this->exceptionClass = $exceptionClass;
         $this->stackTrace = $stackTrace;
         $this->file       = $file;
         $this->line       = $line;
@@ -50,6 +53,7 @@ class ErrorContext
         return new self(
             $messageHeaders[MessageHeaders::MESSAGE_ID],
             $messageHeaders[MessageHeaders::TIMESTAMP],
+            $messageHeaders[self::EXCEPTION_CLASS] ?? '',
             $messageHeaders[self::EXCEPTION_MESSAGE],
             $messageHeaders[self::EXCEPTION_STACKTRACE],
             $messageHeaders[self::EXCEPTION_CODE],
@@ -66,6 +70,11 @@ class ErrorContext
     public function getFailedTimestamp(): int
     {
         return $this->failedTimestamp;
+    }
+
+    public function getExceptionClass(): string
+    {
+        return $this->exceptionClass;
     }
 
     public function getStackTrace(): string
@@ -91,5 +100,17 @@ class ErrorContext
     public function getMessage(): string
     {
         return $this->message;
+    }
+
+    public function toArray(): array
+    {
+        return [
+            self::EXCEPTION_CLASS => $this->exceptionClass,
+            self::EXCEPTION_MESSAGE => $this->message,
+            self::EXCEPTION_STACKTRACE => $this->stackTrace,
+            self::EXCEPTION_FILE => $this->file,
+            self::EXCEPTION_LINE => $this->line,
+            self::EXCEPTION_CODE => $this->code,
+        ];
     }
 }

--- a/packages/Ecotone/src/Messaging/MessageHeaders.php
+++ b/packages/Ecotone/src/Messaging/MessageHeaders.php
@@ -178,7 +178,6 @@ final class MessageHeaders
             self::STREAM_BASED_SOURCED,
             MessagingEntrypoint::ENTRYPOINT,
             self::CHANNEL_SEND_RETRY_NUMBER,
-            ErrorContext::EXCEPTION,
         ];
     }
 
@@ -252,7 +251,7 @@ final class MessageHeaders
             $metadata[self::POLLED_CHANNEL_NAME],
             $metadata[self::CONSUMER_POLLING_METADATA],
             $metadata[self::REPLY_CHANNEL],
-            $metadata[self::TEMPORARY_SPAN_CONTEXT_HEADER]
+            $metadata[self::TEMPORARY_SPAN_CONTEXT_HEADER],
         );
 
         return $metadata;

--- a/packages/Ecotone/src/Messaging/Support/ErrorMessage.php
+++ b/packages/Ecotone/src/Messaging/Support/ErrorMessage.php
@@ -24,9 +24,15 @@ final class ErrorMessage implements Message
 
     public static function create(Message $message, Throwable $cause): self
     {
+        $builder = MessageBuilder::fromMessage($message);
+        if ($cause->getPrevious()) {
+            $builder = $builder
+                ->setHeader(ErrorContext::EXCEPTION_PREVIOUS_CLASS, get_class($cause->getPrevious()));
+        }
+
         return new self(
-            MessageBuilder::fromMessage($message)
-                ->setHeader(ErrorContext::EXCEPTION, $cause)
+            $builder
+                ->setHeader(ErrorContext::EXCEPTION_CLASS, get_class($cause))
                 ->setHeader(ErrorContext::EXCEPTION_MESSAGE, $cause->getMessage())
                 ->setHeader(ErrorContext::EXCEPTION_STACKTRACE, $cause->getTraceAsString())
                 ->setHeader(ErrorContext::EXCEPTION_FILE, $cause->getFile())
@@ -52,8 +58,38 @@ final class ErrorMessage implements Message
         return $this->message->getPayload();
     }
 
-    public function getException(): Throwable
+    public function getErrorContext(): ErrorContext
     {
-        return $this->getHeaders()->get(ErrorContext::EXCEPTION);
+        return ErrorContext::fromHeaders($this->getHeaders()->headers());
+    }
+
+    public function getExceptionClass(): string
+    {
+        return $this->getHeaders()->get(ErrorContext::EXCEPTION_CLASS);
+    }
+
+    public function getExceptionMessage(): string
+    {
+        return $this->getHeaders()->get(ErrorContext::EXCEPTION_MESSAGE);
+    }
+
+    public function getExceptionStackTrace(): string
+    {
+        return $this->getHeaders()->get(ErrorContext::EXCEPTION_STACKTRACE);
+    }
+
+    public function getExceptionFile(): string
+    {
+        return $this->getHeaders()->get(ErrorContext::EXCEPTION_FILE);
+    }
+
+    public function getExceptionLine(): string
+    {
+        return $this->getHeaders()->get(ErrorContext::EXCEPTION_LINE);
+    }
+
+    public function getExceptionCode(): string
+    {
+        return $this->getHeaders()->get(ErrorContext::EXCEPTION_CODE);
     }
 }

--- a/packages/Ecotone/src/Messaging/Support/ErrorMessage.php
+++ b/packages/Ecotone/src/Messaging/Support/ErrorMessage.php
@@ -5,6 +5,7 @@ namespace Ecotone\Messaging\Support;
 use Ecotone\Messaging\Handler\Recoverability\ErrorContext;
 use Ecotone\Messaging\Message;
 use Ecotone\Messaging\MessageHeaders;
+use Ecotone\Messaging\MessagingException;
 use Throwable;
 
 /**
@@ -20,6 +21,26 @@ final class ErrorMessage implements Message
     private function __construct(
         private Message $message
     ) {
+    }
+
+    public static function createFromMessage(Message $message): self
+    {
+        if (!self::isErrorMessage($message)) {
+            throw MessagingException::create('Trying to create error message from message that is not generic message.');
+        }
+
+        return new self($message);
+    }
+
+    public static function isErrorMessage(Message $message): bool
+    {
+        foreach (ErrorContext::WHOLE_ERROR_CONTEXT as $errorContextKey) {
+            if (!$message->getHeaders()->containsKey($errorContextKey)) {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     public static function create(Message $message, Throwable $cause): self

--- a/packages/Ecotone/src/Messaging/Support/ErrorMessage.php
+++ b/packages/Ecotone/src/Messaging/Support/ErrorMessage.php
@@ -45,14 +45,8 @@ final class ErrorMessage implements Message
 
     public static function create(Message $message, Throwable $cause): self
     {
-        $builder = MessageBuilder::fromMessage($message);
-        if ($cause->getPrevious()) {
-            $builder = $builder
-                ->setHeader(ErrorContext::EXCEPTION_PREVIOUS_CLASS, get_class($cause->getPrevious()));
-        }
-
         return new self(
-            $builder
+            MessageBuilder::fromMessage($message)
                 ->setHeader(ErrorContext::EXCEPTION_CLASS, get_class($cause))
                 ->setHeader(ErrorContext::EXCEPTION_MESSAGE, $cause->getMessage())
                 ->setHeader(ErrorContext::EXCEPTION_STACKTRACE, $cause->getTraceAsString())

--- a/packages/Ecotone/tests/Messaging/Fixture/Handler/FailureHandler/FailureErrorHandler.php
+++ b/packages/Ecotone/tests/Messaging/Fixture/Handler/FailureHandler/FailureErrorHandler.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Ecotone\Messaging\Fixture\Handler\FailureHandler;
+
+use Ecotone\Messaging\Attribute\Asynchronous;
+use Ecotone\Messaging\Attribute\InternalHandler;
+use Ecotone\Messaging\Support\ErrorMessage;
+use Monolog\ErrorHandler;
+
+final class FailureErrorHandler
+{
+    private ?ErrorMessage $message = null;
+
+    #[Asynchronous('async')]
+    #[InternalHandler('errorHandler', endpointId: 'errorHandlerEndpoint')]
+    public function handle(ErrorMessage $message): void
+    {
+        $this->message = $message;
+    }
+
+    public function getMessage(): ?ErrorMessage
+    {
+        return $this->message;
+    }
+}

--- a/packages/Ecotone/tests/Messaging/Unit/Endpoint/Poller/PollingConsumerBuilderTest.php
+++ b/packages/Ecotone/tests/Messaging/Unit/Endpoint/Poller/PollingConsumerBuilderTest.php
@@ -14,6 +14,7 @@ use Ecotone\Messaging\Config\ServiceConfiguration;
 use Ecotone\Messaging\Endpoint\ExecutionPollingMetadata;
 use Ecotone\Messaging\Endpoint\NullAcknowledgementCallback;
 use Ecotone\Messaging\Endpoint\PollingMetadata;
+use Ecotone\Messaging\Handler\Logger\EchoLogger;
 use Ecotone\Messaging\Handler\MessageHandlerBuilder;
 use Ecotone\Messaging\Handler\Recoverability\ErrorContext;
 use Ecotone\Messaging\Handler\Recoverability\RetryTemplateBuilder;
@@ -29,6 +30,7 @@ use Test\Ecotone\Messaging\Fixture\Endpoint\ConsumerStoppingService;
 use Test\Ecotone\Messaging\Fixture\Endpoint\ConsumerThrowingExceptionService;
 use Test\Ecotone\Messaging\Fixture\Handler\DataReturningService;
 use Test\Ecotone\Messaging\Fixture\Handler\FailureHandler\ExampleFailureCommandHandler;
+use Test\Ecotone\Messaging\Fixture\Handler\FailureHandler\FailureErrorHandler;
 use Test\Ecotone\Messaging\Fixture\Handler\SuccessServiceActivator;
 use Test\Ecotone\Messaging\Unit\MessagingTestCase;
 
@@ -313,6 +315,34 @@ class PollingConsumerBuilderTest extends MessagingTestCase
         $this->assertTrue($message->getHeaders()->containsKey(ErrorContext::EXCEPTION_MESSAGE));
     }
 
+    public function test_receiving_error_message_with_asynchronous_handler()
+    {
+        $asyncChannelName = 'async';
+
+        $messaging = EcotoneLite::bootstrapFlowTesting(
+            [ExampleFailureCommandHandler::class, FailureErrorHandler::class],
+            [new ExampleFailureCommandHandler(), $failureHandler = new FailureErrorHandler()],
+            ServiceConfiguration::createWithDefaults()
+                ->withExtensionObjects([
+                    SimpleMessageChannelBuilder::createQueueChannel($asyncChannelName),
+                    PollingMetadata::create('async')
+                        ->setStopOnError(false)
+                        ->setExecutionAmountLimit(1)
+                        ->setErrorChannelName('errorHandler'),
+                ]),
+            enableAsynchronousProcessing: true,
+        );
+
+        $messaging->sendCommandWithRoutingKey('handler.fail', ['command' => 0]);
+
+        // process message, end up with error message
+        $messaging->run($asyncChannelName);
+        $this->assertNull($failureHandler->getMessage());
+
+        // handle error message
+        $messaging->run($asyncChannelName);
+        $this->assertNotNull($failureHandler->getMessage());
+    }
 
     public function test_requeing_when_error_channel_throws_exception_with_in_memory_channel()
     {

--- a/packages/Ecotone/tests/Messaging/Unit/Endpoint/Poller/PollingConsumerBuilderTest.php
+++ b/packages/Ecotone/tests/Messaging/Unit/Endpoint/Poller/PollingConsumerBuilderTest.php
@@ -15,6 +15,7 @@ use Ecotone\Messaging\Endpoint\ExecutionPollingMetadata;
 use Ecotone\Messaging\Endpoint\NullAcknowledgementCallback;
 use Ecotone\Messaging\Endpoint\PollingMetadata;
 use Ecotone\Messaging\Handler\MessageHandlerBuilder;
+use Ecotone\Messaging\Handler\Recoverability\ErrorContext;
 use Ecotone\Messaging\Handler\Recoverability\RetryTemplateBuilder;
 use Ecotone\Messaging\Handler\ServiceActivator\ServiceActivatorBuilder;
 use Ecotone\Messaging\MessageHeaders;
@@ -303,12 +304,13 @@ class PollingConsumerBuilderTest extends MessagingTestCase
             enableAsynchronousProcessing: true,
         );
 
-        $originalNessage = MessageBuilder::withPayload('some')->build();
         $messaging->sendCommandWithRoutingKey('handler.fail', ['command' => 0]);
 
         $messaging->run($asyncChannelName);
 
-        $this->assertNotNull($messaging->getMessageChannel($errorChannelName)->receive());
+        $message = $messaging->getMessageChannel($errorChannelName)->receive();
+        $this->assertNotNull($message);
+        $this->assertTrue($message->getHeaders()->containsKey(ErrorContext::EXCEPTION_MESSAGE));
     }
 
 

--- a/packages/Ecotone/tests/Messaging/Unit/Handler/ErrorHandler/ErrorHandlerTest.php
+++ b/packages/Ecotone/tests/Messaging/Unit/Handler/ErrorHandler/ErrorHandlerTest.php
@@ -8,7 +8,8 @@ use Ecotone\Messaging\Channel\QueueChannel;
 use Ecotone\Messaging\Config\InMemoryChannelResolver;
 use Ecotone\Messaging\Handler\Logger\StubLoggingGateway;
 use Ecotone\Messaging\Handler\MessageHandlingException;
-use Ecotone\Messaging\Handler\Recoverability\ErrorHandler;
+use Ecotone\Messaging\Handler\Recoverability\ErrorContext;
+use Ecotone\Messaging\Handler\Recoverability\DelayedRetryErrorHandler;
 use Ecotone\Messaging\Handler\Recoverability\RetryTemplateBuilder;
 use Ecotone\Messaging\Message;
 use Ecotone\Messaging\MessageHeaders;
@@ -35,7 +36,7 @@ class ErrorHandlerTest extends TestCase
 
         $consumedChannel = QueueChannel::create();
         $logger = StubLoggingGateway::create();
-        $errorHandler = new ErrorHandler($retryTemplate, false, StubLoggingGateway::create());
+        $errorHandler = new DelayedRetryErrorHandler($retryTemplate, false, StubLoggingGateway::create());
 
         $this->assertNull(
             $errorHandler->handle(
@@ -74,13 +75,13 @@ class ErrorHandlerTest extends TestCase
         $retryTemplate = RetryTemplateBuilder::exponentialBackoff(10, 2)->build();
 
         $consumedChannel = QueueChannel::create();
-        $errorHandler = new ErrorHandler($retryTemplate, false, StubLoggingGateway::create());
+        $errorHandler = new DelayedRetryErrorHandler($retryTemplate, false, StubLoggingGateway::create());
 
         $errorHandler->handle(
             $this->createFailedMessage(
                 MessageBuilder::withPayload('some')
                     ->setHeader(MessageHeaders::POLLED_CHANNEL_NAME, 'errorChannel')
-                    ->setHeader(ErrorHandler::ECOTONE_RETRY_HEADER, 2)
+                    ->setHeader(DelayedRetryErrorHandler::ECOTONE_RETRY_HEADER, 2)
                     ->build()
             ),
             InMemoryChannelResolver::createFromAssociativeArray(['errorChannel' => $consumedChannel]),
@@ -98,13 +99,13 @@ class ErrorHandlerTest extends TestCase
 
         $consumedChannel = QueueChannel::create();
         $logger = StubLoggingGateway::create();
-        $errorHandler = new ErrorHandler($retryTemplate, true, StubLoggingGateway::create());
+        $errorHandler = new DelayedRetryErrorHandler($retryTemplate, true, StubLoggingGateway::create());
 
         $resultMessage = $errorHandler->handle(
             $this->createFailedMessage(
                 MessageBuilder::withPayload('payload')
                     ->setHeader(MessageHeaders::POLLED_CHANNEL_NAME, 'errorChannel')
-                    ->setHeader(ErrorHandler::ECOTONE_RETRY_HEADER, 2)
+                    ->setHeader(DelayedRetryErrorHandler::ECOTONE_RETRY_HEADER, 2)
                     ->build(),
                 new InvalidArgumentException('exceptionMessage')
             ),
@@ -112,8 +113,13 @@ class ErrorHandlerTest extends TestCase
             $logger
         );
 
-        $this->assertEquals('exceptionMessage', $resultMessage->getHeaders()->get(ErrorHandler::EXCEPTION_MESSAGE));
-        $this->assertNotEmpty($resultMessage->getHeaders()->get(ErrorHandler::EXCEPTION_STACKTRACE));
+        $this->assertEquals('exceptionMessage', $resultMessage->getHeaders()->get(ErrorContext::EXCEPTION_MESSAGE));
+        $this->assertNotEmpty($resultMessage->getHeaders()->get(ErrorContext::EXCEPTION_STACKTRACE));
+        $this->assertNotEmpty($resultMessage->getHeaders()->get(ErrorContext::EXCEPTION_MESSAGE));
+        $this->assertNotEmpty($resultMessage->getHeaders()->get(ErrorContext::EXCEPTION_CLASS));
+        $this->assertNotEmpty($resultMessage->getHeaders()->get(ErrorContext::EXCEPTION_FILE));
+        $this->assertNotEmpty($resultMessage->getHeaders()->get(ErrorContext::EXCEPTION_LINE));
+        $this->assertIsInt($resultMessage->getHeaders()->get(ErrorContext::EXCEPTION_CODE));
         $this->assertCount(1, $logger->getError());
     }
 
@@ -125,13 +131,13 @@ class ErrorHandlerTest extends TestCase
 
         $consumedChannel = QueueChannel::create();
         $logger = StubLoggingGateway::create();
-        $errorHandler = new ErrorHandler($retryTemplate, false, StubLoggingGateway::create());
+        $errorHandler = new DelayedRetryErrorHandler($retryTemplate, false, StubLoggingGateway::create());
 
         $resultMessage = $errorHandler->handle(
             $this->createFailedMessage(
                 MessageBuilder::withPayload('payload')
                     ->setHeader(MessageHeaders::POLLED_CHANNEL_NAME, 'errorChannel')
-                    ->setHeader(ErrorHandler::ECOTONE_RETRY_HEADER, 2)
+                    ->setHeader(DelayedRetryErrorHandler::ECOTONE_RETRY_HEADER, 2)
                     ->build(),
                 new InvalidArgumentException('exceptionMessage')
             ),
@@ -150,13 +156,13 @@ class ErrorHandlerTest extends TestCase
             ->build();
 
         $consumedChannel = QueueChannel::create();
-        $errorHandler = new ErrorHandler($retryTemplate, true, StubLoggingGateway::create());
+        $errorHandler = new DelayedRetryErrorHandler($retryTemplate, true, StubLoggingGateway::create());
 
         $resultMessage = $errorHandler->handle(
             $this->createFailedMessage(
                 MessageBuilder::withPayload('payload')
                     ->setHeader(MessageHeaders::POLLED_CHANNEL_NAME, 'errorChannel')
-                    ->setHeader(ErrorHandler::ECOTONE_RETRY_HEADER, 2)
+                    ->setHeader(DelayedRetryErrorHandler::ECOTONE_RETRY_HEADER, 2)
                     ->build(),
                 new InvalidArgumentException('causation')
             ),
@@ -164,13 +170,13 @@ class ErrorHandlerTest extends TestCase
             StubLoggingGateway::create()
         );
 
-        $this->assertEquals('causation', $resultMessage->getHeaders()->get(ErrorHandler::EXCEPTION_MESSAGE));
-        $this->assertNotEmpty($resultMessage->getHeaders()->get(ErrorHandler::EXCEPTION_STACKTRACE));
+        $this->assertEquals('causation', $resultMessage->getHeaders()->get(ErrorContext::EXCEPTION_MESSAGE));
+        $this->assertNotEmpty($resultMessage->getHeaders()->get(ErrorContext::EXCEPTION_STACKTRACE));
     }
 
     public function test_rethrowing_exception_if_no_polled_channel_exists()
     {
-        $errorHandler = new ErrorHandler(
+        $errorHandler = new DelayedRetryErrorHandler(
             RetryTemplateBuilder::exponentialBackoff(1, 2)
                 ->maxRetryAttempts(2)
                 ->build(),
@@ -178,7 +184,7 @@ class ErrorHandlerTest extends TestCase
             StubLoggingGateway::create()
         );
 
-        $this->expectException(InvalidArgumentException::class);
+        $this->expectException(MessageHandlingException::class);
 
         $errorHandler->handle(
             $this->createFailedMessage(


### PR DESCRIPTION
## Why is this change proposed?

This does allow to handle error messages asynchronously. Previous Error Message was not serializable due to containing of Exception instance itself. Right now ErrorMessage carry exception details in simple serializable format.

## Pull Request Contribution Terms

- [X] I have read and agree to the contribution terms outlined in [CONTRIBUTING](https://github.com/ecotoneframework/ecotone-dev/blob/main/CONTRIBUTING.md).