### PR TITLE
fix: Avoid breaking compatibility for dead letter headers

### DIFF
--- a/packages/Ecotone/src/Messaging/Handler/Recoverability/ErrorContext.php
+++ b/packages/Ecotone/src/Messaging/Handler/Recoverability/ErrorContext.php
@@ -19,12 +19,12 @@ class ErrorContext
     ];
 
     public const EXCEPTION = 'exception';
-    public const EXCEPTION_MESSAGE = 'ecotone.exception.message';
-    public const EXCEPTION_CLASS = 'ecotone.exception.class';
-    public const EXCEPTION_STACKTRACE = 'ecotone.exception.stacktrace';
-    public const EXCEPTION_FILE = 'ecotone.exception.file';
-    public const EXCEPTION_LINE = 'ecotone.exception.line';
-    public const EXCEPTION_CODE = 'ecotone.exception.code';
+    public const EXCEPTION_CLASS = 'ecotone-class';
+    public const EXCEPTION_STACKTRACE = 'exception-stacktrace';
+    public const EXCEPTION_FILE = 'exception-file';
+    public const EXCEPTION_LINE = 'exception-line';
+    public const EXCEPTION_CODE = 'exception-code';
+    public const EXCEPTION_MESSAGE = 'exception-message';
     public const DLQ_MESSAGE_REPLIED = 'ecotone.dlq.message_replied';
 
     private string $exceptionClass;


### PR DESCRIPTION
## Why is this change proposed?

Error Context headers could be already stored in Dead Letter, therefore we can't change them without doing B/C. 
Restoring to previous naming.

## Pull Request Contribution Terms

- [X] I have read and agree to the contribution terms outlined in [CONTRIBUTING](https://github.com/ecotoneframework/ecotone-dev/blob/main/CONTRIBUTING.md).