### PR TITLE
Feat: Final Failure Strategy

### DIFF
--- a/packages/Amqp/src/AmqpBackedMessageChannelBuilder.php
+++ b/packages/Amqp/src/AmqpBackedMessageChannelBuilder.php
@@ -3,6 +3,7 @@
 namespace Ecotone\Amqp;
 
 use Ecotone\Enqueue\EnqueueMessageChannelBuilder;
+use Ecotone\Messaging\Endpoint\FinalFailureStrategy;
 use Enqueue\AmqpExt\AmqpConnectionFactory;
 
 /**
@@ -56,6 +57,13 @@ class AmqpBackedMessageChannelBuilder extends EnqueueMessageChannelBuilder
     public function withPublisherAcknowledgments(bool $enabled): self
     {
         $this->getAmqpOutboundChannelAdapter()->withPublisherAcknowledgments($enabled);
+
+        return $this;
+    }
+
+    public function withFinalFailureStrategy(FinalFailureStrategy $finalFailureStrategy): self
+    {
+        $this->getInboundChannelAdapter()->withFinalFailureStrategy($finalFailureStrategy);
 
         return $this;
     }

--- a/packages/Amqp/src/AmqpBackedMessageChannelBuilder.php
+++ b/packages/Amqp/src/AmqpBackedMessageChannelBuilder.php
@@ -61,13 +61,6 @@ class AmqpBackedMessageChannelBuilder extends EnqueueMessageChannelBuilder
         return $this;
     }
 
-    public function withFinalFailureStrategy(FinalFailureStrategy $finalFailureStrategy): self
-    {
-        $this->getInboundChannelAdapter()->withFinalFailureStrategy($finalFailureStrategy);
-
-        return $this;
-    }
-
     public function getMessageChannelName(): string
     {
         return $this->channelName;

--- a/packages/Amqp/src/AmqpInboundChannelAdapterBuilder.php
+++ b/packages/Amqp/src/AmqpInboundChannelAdapterBuilder.php
@@ -46,6 +46,7 @@ class AmqpInboundChannelAdapterBuilder extends EnqueueInboundChannelAdapterBuild
             DefaultHeaderMapper::createWith($this->headerMapper, []),
             EnqueueHeader::HEADER_ACKNOWLEDGE,
             Reference::to(LoggingGateway::class),
+            $this->finalFailureStrategy,
         ]);
 
         return new Definition(AmqpInboundChannelAdapter::class, [

--- a/packages/Amqp/tests/FinalFailureStrategyTest.php
+++ b/packages/Amqp/tests/FinalFailureStrategyTest.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Ecotone\Amqp;
+
+use Ecotone\Amqp\AmqpBackedMessageChannelBuilder;
+use Ecotone\Lite\EcotoneLite;
+use Ecotone\Messaging\Attribute\Asynchronous;
+use Ecotone\Messaging\Attribute\ServiceActivator;
+use Ecotone\Messaging\Channel\PollableChannel\InMemory\InMemoryAcknowledgeStatus;
+use Ecotone\Messaging\Channel\PollableChannel\InMemory\InMemoryQueueAcknowledgeInterceptor;
+use Ecotone\Messaging\Channel\SimpleMessageChannelBuilder;
+use Ecotone\Messaging\Config\ModulePackageList;
+use Ecotone\Messaging\Config\ServiceConfiguration;
+use Ecotone\Messaging\Endpoint\ExecutionPollingMetadata;
+use Ecotone\Messaging\Endpoint\FinalFailureStrategy;
+use Ecotone\Messaging\Message;
+use Enqueue\AmqpExt\AmqpConnectionFactory;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @internal
+ */
+/**
+ * licence Apache-2.0
+ */
+final class FinalFailureStrategyTest extends AmqpMessagingTestCase
+{
+    public function test_reject_failure_strategy_rejects_message_on_exception()
+    {
+        $ecotoneTestSupport = EcotoneLite::bootstrapFlowTesting(
+            [FailingService::class],
+            [new FailingService(), AmqpConnectionFactory::class => $this->getCachedConnectionFactory(),],
+            configuration: ServiceConfiguration::createWithDefaults()
+                ->withSkippedModulePackageNames(ModulePackageList::allPackagesExcept([ModulePackageList::AMQP_PACKAGE, ModulePackageList::ASYNCHRONOUS_PACKAGE]))
+                ->withExtensionObjects([
+                    AmqpBackedMessageChannelBuilder::create(channelName: 'async')
+                        ->withFinalFailureStrategy(FinalFailureStrategy::IGNORE)
+                        ->withReceiveTimeout(100),
+                ])
+        );
+
+        $ecotoneTestSupport->sendDirectToChannel('executionChannel', 'some');
+        $ecotoneTestSupport->run('async', ExecutionPollingMetadata::createWithTestingSetup(failAtError: false));
+
+        $messageChannel = $ecotoneTestSupport->getMessageChannel('async');
+        $this->assertNull($messageChannel->receive());
+    }
+
+    public function test_resend_failure_strategy_rejects_message_on_exception()
+    {
+        $ecotoneTestSupport = EcotoneLite::bootstrapFlowTesting(
+            [FailingService::class],
+            [new FailingService(), AmqpConnectionFactory::class => $this->getCachedConnectionFactory(),],
+            configuration: ServiceConfiguration::createWithDefaults()
+                ->withSkippedModulePackageNames(ModulePackageList::allPackagesExcept([ModulePackageList::AMQP_PACKAGE, ModulePackageList::ASYNCHRONOUS_PACKAGE]))
+                ->withExtensionObjects([
+                    AmqpBackedMessageChannelBuilder::create(channelName: 'async')
+                        ->withFinalFailureStrategy(FinalFailureStrategy::RESEND)
+                        ->withReceiveTimeout(100),
+                ])
+        );
+
+        $ecotoneTestSupport->sendDirectToChannel('executionChannel', 'some');
+        $ecotoneTestSupport->run('async', ExecutionPollingMetadata::createWithTestingSetup(failAtError: false));
+
+        $messageChannel = $ecotoneTestSupport->getMessageChannel('async');
+        $this->assertNotNull($messageChannel->receive());
+    }
+}
+
+
+class FailingService
+{
+    private Message $message;
+
+    #[Asynchronous('async')]
+    #[ServiceActivator('executionChannel')]
+    public function handle(Message $message): void
+    {
+        $this->message = $message;
+
+        throw new \Exception('Service failed');
+    }
+
+    public function getMessage(): Message
+    {
+        return $this->message;
+    }
+}

--- a/packages/Ecotone/src/Messaging/Channel/PollableChannel/InMemory/InMemoryAcknowledgeCallback.php
+++ b/packages/Ecotone/src/Messaging/Channel/PollableChannel/InMemory/InMemoryAcknowledgeCallback.php
@@ -20,6 +20,7 @@ final class InMemoryAcknowledgeCallback implements AcknowledgementCallback
         private PollableChannel           $queueChannel,
         private Message                   $message,
         private FinalFailureStrategy      $failureStrategy = FinalFailureStrategy::RESEND,
+        private bool                      $isAutoAcked = true,
         private InMemoryAcknowledgeStatus $status = InMemoryAcknowledgeStatus::AWAITING
     ) {
     }
@@ -30,6 +31,14 @@ final class InMemoryAcknowledgeCallback implements AcknowledgementCallback
     public function getFailureStrategy(): FinalFailureStrategy
     {
         return $this->failureStrategy;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function isAutoAcked(): bool
+    {
+        return $this->isAutoAcked;
     }
 
     public function getStatus(): InMemoryAcknowledgeStatus

--- a/packages/Ecotone/src/Messaging/Channel/PollableChannel/InMemory/InMemoryAcknowledgeCallback.php
+++ b/packages/Ecotone/src/Messaging/Channel/PollableChannel/InMemory/InMemoryAcknowledgeCallback.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Ecotone\Messaging\Channel\PollableChannel\InMemory;
 
 use Ecotone\Messaging\Endpoint\AcknowledgementCallback;
+use Ecotone\Messaging\Endpoint\FinalFailureStrategy;
 use Ecotone\Messaging\Message;
 use Ecotone\Messaging\PollableChannel;
 use Ecotone\Messaging\Support\Assert;
@@ -16,27 +17,24 @@ use RuntimeException;
 final class InMemoryAcknowledgeCallback implements AcknowledgementCallback
 {
     public function __construct(
-        private PollableChannel $queueChannel,
-        private Message $message,
-        private bool $isAutoAck = true,
-        private bool $wasAcked = false
+        private PollableChannel           $queueChannel,
+        private Message                   $message,
+        private FinalFailureStrategy      $failureStrategy = FinalFailureStrategy::RESEND,
+        private InMemoryAcknowledgeStatus $status = InMemoryAcknowledgeStatus::AWAITING
     ) {
     }
 
     /**
-     * @return bool
+     * @inheritDoc
      */
-    public function isAutoAck(): bool
+    public function getFailureStrategy(): FinalFailureStrategy
     {
-        return $this->isAutoAck;
+        return $this->failureStrategy;
     }
 
-    /**
-     * Disable auto acknowledgment
-     */
-    public function disableAutoAck(): void
+    public function getStatus(): InMemoryAcknowledgeStatus
     {
-        $this->isAutoAck = false;
+        return $this->status;
     }
 
     /**
@@ -44,9 +42,8 @@ final class InMemoryAcknowledgeCallback implements AcknowledgementCallback
      */
     public function accept(): void
     {
-        Assert::isFalse($this->wasAcked, 'Trying to acknowledge message that was already acknowledged');
-
-        $this->wasAcked = true;
+        Assert::isTrue(in_array($this->status, [InMemoryAcknowledgeStatus::AWAITING, InMemoryAcknowledgeStatus::RESENT], true), "Message was already acknowledged.");
+        $this->status = InMemoryAcknowledgeStatus::ACKED;
     }
 
     /**
@@ -54,9 +51,8 @@ final class InMemoryAcknowledgeCallback implements AcknowledgementCallback
      */
     public function reject(): void
     {
-        Assert::isFalse($this->wasAcked, 'Trying to acknowledge message that was already acknowledged');
-
-        $this->wasAcked = true;
+        Assert::isTrue(in_array($this->status, [InMemoryAcknowledgeStatus::AWAITING, InMemoryAcknowledgeStatus::RESENT], true), "Message was already acknowledged.");
+        $this->status = InMemoryAcknowledgeStatus::IGNORED;
     }
 
     private int $requeueCount = 0;
@@ -66,6 +62,9 @@ final class InMemoryAcknowledgeCallback implements AcknowledgementCallback
      */
     public function requeue(): void
     {
+        Assert::isTrue(in_array($this->status, [InMemoryAcknowledgeStatus::AWAITING, InMemoryAcknowledgeStatus::RESENT], true), "Message was already acknowledged.");
+
+        $this->status = InMemoryAcknowledgeStatus::RESENT;
         $this->requeueCount++;
 
         if ($this->requeueCount > 100) {

--- a/packages/Ecotone/src/Messaging/Channel/PollableChannel/InMemory/InMemoryAcknowledgeStatus.php
+++ b/packages/Ecotone/src/Messaging/Channel/PollableChannel/InMemory/InMemoryAcknowledgeStatus.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Ecotone\Messaging\Channel\PollableChannel\InMemory;
 
+/**
+ * licence Apache-2.0
+ */
 enum InMemoryAcknowledgeStatus: int
 {
     case AWAITING = 0;

--- a/packages/Ecotone/src/Messaging/Channel/PollableChannel/InMemory/InMemoryAcknowledgeStatus.php
+++ b/packages/Ecotone/src/Messaging/Channel/PollableChannel/InMemory/InMemoryAcknowledgeStatus.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ecotone\Messaging\Channel\PollableChannel\InMemory;
+
+enum InMemoryAcknowledgeStatus: int
+{
+    case AWAITING = 0;
+    case ACKED = 1;
+    case RESENT = 2;
+    case IGNORED = 3;
+}

--- a/packages/Ecotone/src/Messaging/Channel/PollableChannel/InMemory/InMemoryQueueAcknowledgeInterceptor.php
+++ b/packages/Ecotone/src/Messaging/Channel/PollableChannel/InMemory/InMemoryQueueAcknowledgeInterceptor.php
@@ -6,6 +6,7 @@ namespace Ecotone\Messaging\Channel\PollableChannel\InMemory;
 
 use Ecotone\Messaging\Channel\AbstractChannelInterceptor;
 use Ecotone\Messaging\Channel\ChannelInterceptor;
+use Ecotone\Messaging\Endpoint\FinalFailureStrategy;
 use Ecotone\Messaging\Message;
 use Ecotone\Messaging\MessageChannel;
 use Ecotone\Messaging\MessageHeaders;
@@ -18,6 +19,11 @@ final class InMemoryQueueAcknowledgeInterceptor extends AbstractChannelIntercept
 {
     public const ECOTONE_IN_MEMORY_QUEUE_ACK = 'ecotone.in_memory_queue.ack';
 
+    public function __construct(private FinalFailureStrategy $finalFailureStrategy)
+    {
+
+    }
+
     /**
      * @inheritDoc
      */
@@ -29,7 +35,7 @@ final class InMemoryQueueAcknowledgeInterceptor extends AbstractChannelIntercept
 
         return MessageBuilder::fromMessage($message)
             ->setHeader(MessageHeaders::CONSUMER_ACK_HEADER_LOCATION, self::ECOTONE_IN_MEMORY_QUEUE_ACK)
-            ->setHeader(self::ECOTONE_IN_MEMORY_QUEUE_ACK, new InMemoryAcknowledgeCallback($messageChannel, $message))
+            ->setHeader(self::ECOTONE_IN_MEMORY_QUEUE_ACK, new InMemoryAcknowledgeCallback($messageChannel, $message, failureStrategy: $this->finalFailureStrategy))
             ->build();
     }
 }

--- a/packages/Ecotone/src/Messaging/Channel/PollableChannel/InMemory/InMemoryQueueAcknowledgeInterceptorBuilder.php
+++ b/packages/Ecotone/src/Messaging/Channel/PollableChannel/InMemory/InMemoryQueueAcknowledgeInterceptorBuilder.php
@@ -17,7 +17,7 @@ use Ecotone\Messaging\PrecedenceChannelInterceptor;
  */
 final class InMemoryQueueAcknowledgeInterceptorBuilder implements ChannelInterceptorBuilder
 {
-    public function __construct(private string $relatedChannel, private FinalFailureStrategy $finalFailureStrategy)
+    public function __construct(private string $relatedChannel, private FinalFailureStrategy $finalFailureStrategy, private bool $isAutoAcked)
     {
     }
 
@@ -35,6 +35,7 @@ final class InMemoryQueueAcknowledgeInterceptorBuilder implements ChannelInterce
     {
         return new Definition(InMemoryQueueAcknowledgeInterceptor::class, [
             $this->finalFailureStrategy,
+            $this->isAutoAcked,
         ]);
     }
 }

--- a/packages/Ecotone/src/Messaging/Channel/PollableChannel/InMemory/InMemoryQueueAcknowledgeInterceptorBuilder.php
+++ b/packages/Ecotone/src/Messaging/Channel/PollableChannel/InMemory/InMemoryQueueAcknowledgeInterceptorBuilder.php
@@ -5,8 +5,11 @@ declare(strict_types=1);
 namespace Ecotone\Messaging\Channel\PollableChannel\InMemory;
 
 use Ecotone\Messaging\Channel\ChannelInterceptorBuilder;
+use Ecotone\Messaging\Config\Container\ChannelReference;
 use Ecotone\Messaging\Config\Container\Definition;
 use Ecotone\Messaging\Config\Container\MessagingContainerBuilder;
+use Ecotone\Messaging\Config\Container\Reference;
+use Ecotone\Messaging\Endpoint\FinalFailureStrategy;
 use Ecotone\Messaging\PrecedenceChannelInterceptor;
 
 /**
@@ -14,7 +17,7 @@ use Ecotone\Messaging\PrecedenceChannelInterceptor;
  */
 final class InMemoryQueueAcknowledgeInterceptorBuilder implements ChannelInterceptorBuilder
 {
-    public function __construct(private string $relatedChannel)
+    public function __construct(private string $relatedChannel, private FinalFailureStrategy $finalFailureStrategy)
     {
     }
 
@@ -30,6 +33,8 @@ final class InMemoryQueueAcknowledgeInterceptorBuilder implements ChannelInterce
 
     public function compile(MessagingContainerBuilder $builder): Definition
     {
-        return new Definition(InMemoryQueueAcknowledgeInterceptor::class);
+        return new Definition(InMemoryQueueAcknowledgeInterceptor::class, [
+            $this->finalFailureStrategy,
+        ]);
     }
 }

--- a/packages/Ecotone/src/Messaging/Channel/PollableChannel/InMemory/InMemoryQueueAcknowledgeModule.php
+++ b/packages/Ecotone/src/Messaging/Channel/PollableChannel/InMemory/InMemoryQueueAcknowledgeModule.php
@@ -31,10 +31,12 @@ final class InMemoryQueueAcknowledgeModule extends NoExternalConfigurationModule
     {
         $pollableMessageChannels = ExtensionObjectResolver::resolve(MessageChannelBuilder::class, $extensionObjects);
 
+        /** @var SimpleMessageChannelBuilder $pollableMessageChannel */
         foreach ($pollableMessageChannels as $pollableMessageChannel) {
             $messagingConfiguration->registerChannelInterceptor(
                 new InMemoryQueueAcknowledgeInterceptorBuilder(
-                    $pollableMessageChannel->getMessageChannelName()
+                    $pollableMessageChannel->getMessageChannelName(),
+                    $pollableMessageChannel->getFinalFailureStrategy()
                 )
             );
         }

--- a/packages/Ecotone/src/Messaging/Channel/PollableChannel/InMemory/InMemoryQueueAcknowledgeModule.php
+++ b/packages/Ecotone/src/Messaging/Channel/PollableChannel/InMemory/InMemoryQueueAcknowledgeModule.php
@@ -36,7 +36,8 @@ final class InMemoryQueueAcknowledgeModule extends NoExternalConfigurationModule
             $messagingConfiguration->registerChannelInterceptor(
                 new InMemoryQueueAcknowledgeInterceptorBuilder(
                     $pollableMessageChannel->getMessageChannelName(),
-                    $pollableMessageChannel->getFinalFailureStrategy()
+                    $pollableMessageChannel->getFinalFailureStrategy(),
+                    $pollableMessageChannel->isAutoAcked()
                 )
             );
         }

--- a/packages/Ecotone/src/Messaging/Channel/SimpleMessageChannelBuilder.php
+++ b/packages/Ecotone/src/Messaging/Channel/SimpleMessageChannelBuilder.php
@@ -8,6 +8,7 @@ use Ecotone\Messaging\Config\Container\Definition;
 use Ecotone\Messaging\Config\Container\MessagingContainerBuilder;
 use Ecotone\Messaging\Config\DefinedObjectWrapper;
 use Ecotone\Messaging\Conversion\MediaType;
+use Ecotone\Messaging\Endpoint\FinalFailureStrategy;
 use Ecotone\Messaging\MessageChannel;
 use Ecotone\Messaging\MessageConverter\DefaultHeaderMapper;
 use Ecotone\Messaging\MessageConverter\HeaderMapper;
@@ -25,15 +26,16 @@ use Ecotone\Messaging\PollableChannel;
 class SimpleMessageChannelBuilder implements MessageChannelWithSerializationBuilder
 {
     private function __construct(
-        private string $messageChannelName,
-        private MessageChannel $messageChannel,
-        private bool $isPollable,
-        private ?MediaType $conversionMediaType,
-        private HeaderMapper $headerMapper,
+        private string               $messageChannelName,
+        private MessageChannel       $messageChannel,
+        private bool                 $isPollable,
+        private ?MediaType           $conversionMediaType,
+        private HeaderMapper         $headerMapper,
+        private FinalFailureStrategy $finalFailureStrategy,
     ) {
     }
 
-    public static function create(string $messageChannelName, MessageChannel $messageChannel, string|MediaType|null $conversionMediaType = null): self
+    public static function create(string $messageChannelName, MessageChannel $messageChannel, string|MediaType|null $conversionMediaType = null, FinalFailureStrategy $finalFailureStrategy = FinalFailureStrategy::RESEND): self
     {
         return new self(
             $messageChannelName,
@@ -41,6 +43,7 @@ class SimpleMessageChannelBuilder implements MessageChannelWithSerializationBuil
             $messageChannel instanceof PollableChannel,
             $conversionMediaType ? (is_string($conversionMediaType) ? MediaType::parseMediaType($conversionMediaType) : $conversionMediaType) : null,
             DefaultHeaderMapper::createAllHeadersMapping(),
+            $finalFailureStrategy,
         );
     }
 
@@ -54,11 +57,11 @@ class SimpleMessageChannelBuilder implements MessageChannelWithSerializationBuil
         return self::create($messageChannelName, PublishSubscribeChannel::create($messageChannelName), null);
     }
 
-    public static function createQueueChannel(string $messageChannelName, bool $delayable = false, string|MediaType|null $conversionMediaType = null): self
+    public static function createQueueChannel(string $messageChannelName, bool $delayable = false, string|MediaType|null $conversionMediaType = null, FinalFailureStrategy $finalFailureStrategy = FinalFailureStrategy::RESEND): self
     {
         $messageChannel = $delayable ? DelayableQueueChannel::create($messageChannelName) : QueueChannel::create($messageChannelName);
 
-        return self::create($messageChannelName, $messageChannel, $conversionMediaType);
+        return self::create($messageChannelName, $messageChannel, $conversionMediaType, $finalFailureStrategy);
     }
 
     public static function createNullableChannel(string $messageChannelName): self
@@ -77,6 +80,11 @@ class SimpleMessageChannelBuilder implements MessageChannelWithSerializationBuil
     public function isPollable(): bool
     {
         return $this->isPollable;
+    }
+
+    public function getFinalFailureStrategy(): FinalFailureStrategy
+    {
+        return $this->finalFailureStrategy;
     }
 
     public function withDefaultConversionMediaType(string $mediaType): self

--- a/packages/Ecotone/src/Messaging/Channel/SimpleMessageChannelBuilder.php
+++ b/packages/Ecotone/src/Messaging/Channel/SimpleMessageChannelBuilder.php
@@ -32,10 +32,11 @@ class SimpleMessageChannelBuilder implements MessageChannelWithSerializationBuil
         private ?MediaType           $conversionMediaType,
         private HeaderMapper         $headerMapper,
         private FinalFailureStrategy $finalFailureStrategy,
+        private bool                 $isAutoAcked,
     ) {
     }
 
-    public static function create(string $messageChannelName, MessageChannel $messageChannel, string|MediaType|null $conversionMediaType = null, FinalFailureStrategy $finalFailureStrategy = FinalFailureStrategy::RESEND): self
+    public static function create(string $messageChannelName, MessageChannel $messageChannel, string|MediaType|null $conversionMediaType = null, FinalFailureStrategy $finalFailureStrategy = FinalFailureStrategy::RESEND, bool $isAutoAcked = true): self
     {
         return new self(
             $messageChannelName,
@@ -44,6 +45,7 @@ class SimpleMessageChannelBuilder implements MessageChannelWithSerializationBuil
             $conversionMediaType ? (is_string($conversionMediaType) ? MediaType::parseMediaType($conversionMediaType) : $conversionMediaType) : null,
             DefaultHeaderMapper::createAllHeadersMapping(),
             $finalFailureStrategy,
+            $isAutoAcked,
         );
     }
 
@@ -57,11 +59,11 @@ class SimpleMessageChannelBuilder implements MessageChannelWithSerializationBuil
         return self::create($messageChannelName, PublishSubscribeChannel::create($messageChannelName), null);
     }
 
-    public static function createQueueChannel(string $messageChannelName, bool $delayable = false, string|MediaType|null $conversionMediaType = null, FinalFailureStrategy $finalFailureStrategy = FinalFailureStrategy::RESEND): self
+    public static function createQueueChannel(string $messageChannelName, bool $delayable = false, string|MediaType|null $conversionMediaType = null, FinalFailureStrategy $finalFailureStrategy = FinalFailureStrategy::RESEND, bool $isAutoAcked = true): self
     {
         $messageChannel = $delayable ? DelayableQueueChannel::create($messageChannelName) : QueueChannel::create($messageChannelName);
 
-        return self::create($messageChannelName, $messageChannel, $conversionMediaType, $finalFailureStrategy);
+        return self::create($messageChannelName, $messageChannel, $conversionMediaType, $finalFailureStrategy, $isAutoAcked);
     }
 
     public static function createNullableChannel(string $messageChannelName): self
@@ -85,6 +87,11 @@ class SimpleMessageChannelBuilder implements MessageChannelWithSerializationBuil
     public function getFinalFailureStrategy(): FinalFailureStrategy
     {
         return $this->finalFailureStrategy;
+    }
+
+    public function isAutoAcked(): bool
+    {
+        return $this->isAutoAcked;
     }
 
     public function withDefaultConversionMediaType(string $mediaType): self

--- a/packages/Ecotone/src/Messaging/Endpoint/AcknowledgeConfirmationInterceptor.php
+++ b/packages/Ecotone/src/Messaging/Endpoint/AcknowledgeConfirmationInterceptor.php
@@ -65,23 +65,21 @@ class AcknowledgeConfirmationInterceptor
         try {
             $methodInvocation->proceed();
         } catch (RejectMessageException) {
-            if ($acknowledgementCallback->isAutoAck()) {
-                $this->retryRunner->runWithRetry(function () use ($message, $logger, $messageChannelName, $acknowledgementCallback) {
-                    $acknowledgementCallback->reject();
+            $this->retryRunner->runWithRetry(function () use ($message, $logger, $messageChannelName, $acknowledgementCallback) {
+                $acknowledgementCallback->reject();
 
-                    $logger->info(
-                        sprintf('Message with id `%s` rejected in Message Channel `%s`', $message->getHeaders()->getMessageId(), $messageChannelName),
-                        $message
-                    );
-                }, $retryStrategy, $message, Exception::class, sprintf('Rejecting Message in Message Channel `%s` failed. Trying to self-heal and retry.', $messageChannelName));
-            }
+                $logger->info(
+                    sprintf('Message with id `%s` rejected in Message Channel `%s`', $message->getHeaders()->getMessageId(), $messageChannelName),
+                    $message
+                );
+            }, $retryStrategy, $message, Exception::class, sprintf('Rejecting Message in Message Channel `%s` failed. Trying to self-heal and retry.', $messageChannelName));
 
             return;
         } catch (Throwable $exception) {
-            if (! $acknowledgementCallback->isAutoAck()) {
+            if ($acknowledgementCallback->getFailureStrategy() === FinalFailureStrategy::STOP || $pollingMetadata->isStoppedOnError()) {
                 $logger->critical(
                     sprintf(
-                        'Acknowledgment mode is not auto and unrecoverable error happened. Stopping Message Consumer without acknowledgment to avoid Message loss.  Error: %s',
+                        'Acknowledgment mode is set to stop on failure. Stopping Message Consumer without acknowledgment to avoid Message loss.  Error: %s',
                         $exception->getMessage()
                     ),
                     $message,
@@ -92,11 +90,21 @@ class AcknowledgeConfirmationInterceptor
             }
 
             $this->retryRunner->runWithRetry(function () use ($message, $logger, $messageChannelName, $acknowledgementCallback, $exception) {
-                $acknowledgementCallback->requeue();
 
+                if ($acknowledgementCallback->getFailureStrategy() === FinalFailureStrategy::IGNORE) {
+                    $acknowledgementCallback->reject();
+                    $logger->info(
+                        sprintf('Message with id `%s` rejected in Message Channel `%s`', $message->getHeaders()->getMessageId(), $messageChannelName),
+                        $message
+                    );
+
+                    return;
+                }
+
+                $acknowledgementCallback->requeue();
                 $logger->info(
                     sprintf(
-                        'Message with id `%s` requeued in Message Channel `%s`. Due to %s',
+                        'Message with id `%s` resent to Message Channel `%s`. Due to %s',
                         $message->getHeaders()->getMessageId(),
                         $messageChannelName,
                         $exception->getMessage()
@@ -104,30 +112,18 @@ class AcknowledgeConfirmationInterceptor
                     $message,
                     ['exception' => $exception, 'channel' => $messageChannelName]
                 );
-            }, $retryStrategy, $message, Exception::class, sprintf('Re-queuing Message in Message Channel `%s` failed. Trying to self-heal and retry.', $messageChannelName));
-
-            if ($pollingMetadata->isStoppedOnError() === true) {
-                $logger->info(
-                    'Should stop on error configuration enabled, stopping Message Consumer.',
-                    $message,
-                    ['channel' => $messageChannelName]
-                );
-
-                throw $exception;
-            }
+            }, $retryStrategy, $message, Exception::class, sprintf('Re-sending Message in Message Channel `%s` failed. Trying to self-heal and retry.', $messageChannelName));
 
             return;
         }
 
-        if ($acknowledgementCallback->isAutoAck()) {
-            $this->retryRunner->runWithRetry(function () use ($message, $logger, $messageChannelName, $acknowledgementCallback) {
-                $acknowledgementCallback->accept();
+        $this->retryRunner->runWithRetry(function () use ($message, $logger, $messageChannelName, $acknowledgementCallback) {
+            $acknowledgementCallback->accept();
 
-                $logger->info(
-                    sprintf('Message with id `%s` was acknowledged in Message Channel `%s`', $message->getHeaders()->getMessageId(), $messageChannelName),
-                    $message
-                );
-            }, $retryStrategy, $message, Exception::class, sprintf('Acknowledging Message in Message Channel `%s` failed. Trying to self-heal and retry.', $messageChannelName));
-        }
+            $logger->info(
+                sprintf('Message with id `%s` was acknowledged in Message Channel `%s`', $message->getHeaders()->getMessageId(), $messageChannelName),
+                $message
+            );
+        }, $retryStrategy, $message, Exception::class, sprintf('Acknowledging Message in Message Channel `%s` failed. Trying to self-heal and retry.', $messageChannelName));
     }
 }

--- a/packages/Ecotone/src/Messaging/Endpoint/AcknowledgeConfirmationInterceptor.php
+++ b/packages/Ecotone/src/Messaging/Endpoint/AcknowledgeConfirmationInterceptor.php
@@ -117,13 +117,16 @@ class AcknowledgeConfirmationInterceptor
             return;
         }
 
-        $this->retryRunner->runWithRetry(function () use ($message, $logger, $messageChannelName, $acknowledgementCallback) {
-            $acknowledgementCallback->accept();
+        // Only auto-acknowledge if auto-ack is enabled
+        if ($acknowledgementCallback->isAutoAcked()) {
+            $this->retryRunner->runWithRetry(function () use ($message, $logger, $messageChannelName, $acknowledgementCallback) {
+                $acknowledgementCallback->accept();
 
-            $logger->info(
-                sprintf('Message with id `%s` was acknowledged in Message Channel `%s`', $message->getHeaders()->getMessageId(), $messageChannelName),
-                $message
-            );
-        }, $retryStrategy, $message, Exception::class, sprintf('Acknowledging Message in Message Channel `%s` failed. Trying to self-heal and retry.', $messageChannelName));
+                $logger->info(
+                    sprintf('Message with id `%s` was acknowledged in Message Channel `%s`', $message->getHeaders()->getMessageId(), $messageChannelName),
+                    $message
+                );
+            }, $retryStrategy, $message, Exception::class, sprintf('Acknowledging Message in Message Channel `%s` failed. Trying to self-heal and retry.', $messageChannelName));
+        }
     }
 }

--- a/packages/Ecotone/src/Messaging/Endpoint/AcknowledgementCallback.php
+++ b/packages/Ecotone/src/Messaging/Endpoint/AcknowledgementCallback.php
@@ -22,6 +22,11 @@ interface AcknowledgementCallback
     public function getFailureStrategy(): FinalFailureStrategy;
 
     /**
+     * Check if this acknowledgement callback is in auto-ack mode
+     */
+    public function isAutoAcked(): bool;
+
+    /**
      * Mark the message as accepted
      */
     public function accept(): void;

--- a/packages/Ecotone/src/Messaging/Endpoint/AcknowledgementCallback.php
+++ b/packages/Ecotone/src/Messaging/Endpoint/AcknowledgementCallback.php
@@ -17,14 +17,9 @@ namespace Ecotone\Messaging\Endpoint;
 interface AcknowledgementCallback
 {
     /**
-     * @return bool
+     * Get the failure strategy for this acknowledgement callback
      */
-    public function isAutoAck(): bool;
-
-    /**
-     * Disable auto acknowledgment
-     */
-    public function disableAutoAck(): void;
+    public function getFailureStrategy(): FinalFailureStrategy;
 
     /**
      * Mark the message as accepted

--- a/packages/Ecotone/src/Messaging/Endpoint/FinalFailureStrategy.php
+++ b/packages/Ecotone/src/Messaging/Endpoint/FinalFailureStrategy.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ecotone\Messaging\Endpoint;
+
+use Ecotone\Messaging\Config\Container\DefinedObject;
+use Ecotone\Messaging\Config\Container\Definition;
+
+/**
+ * Defines how to handle failures when processing messages.
+ * This is final failure strategy as it's used in case, when there is no other way to handle the failure.
+ * For example, when there is no retry policy, or when the retry policy has reached its maximum number of attempts.
+ * Also, when the destination of Error Channel is not defined, or sending to Error Channel fails.
+ *
+ * @author Dariusz Gafka <support@simplycodedsoftware.com>
+ */
+/**
+ * licence Apache-2.0
+ */
+enum FinalFailureStrategy: string implements DefinedObject
+{
+    /**
+     * Ignores the failed message - it will not be redelivered
+     */
+    case IGNORE = 'ignore';
+    
+    /**
+     * Resends the failed message back to original Message Channel - it will be redelivered
+     */
+    case RESEND = 'resend';
+    
+    /**
+     * Stop the consumer by rethrowing the exception
+     */
+    case STOP = 'stop';
+
+    public function getDefinition(): Definition
+    {
+        return new Definition(self::class, [$this->value], 'from');
+    }
+}

--- a/packages/Ecotone/src/Messaging/Endpoint/NullAcknowledgementCallback.php
+++ b/packages/Ecotone/src/Messaging/Endpoint/NullAcknowledgementCallback.php
@@ -23,18 +23,16 @@ class NullAcknowledgementCallback implements AcknowledgementCallback
 
     private int $status = self::AWAITING;
 
-    private bool $isAutoAck = true;
-
-    private function __construct()
+    private function __construct(private FinalFailureStrategy $failureStrategy)
     {
     }
 
     /**
      * @return NullAcknowledgementCallback
      */
-    public static function create(): self
+    public static function create(FinalFailureStrategy $failureStrategy = FinalFailureStrategy::RESEND): self
     {
-        return new self();
+        return new self($failureStrategy);
     }
 
     public function isAcked(): bool
@@ -55,17 +53,9 @@ class NullAcknowledgementCallback implements AcknowledgementCallback
     /**
      * @inheritDoc
      */
-    public function isAutoAck(): bool
+    public function getFailureStrategy(): FinalFailureStrategy
     {
-        return $this->isAutoAck;
-    }
-
-    /**
-     * @inheritDoc
-     */
-    public function disableAutoAck(): void
-    {
-        $this->isAutoAck = false;
+        return $this->failureStrategy;
     }
 
     /**

--- a/packages/Ecotone/src/Messaging/Endpoint/NullAcknowledgementCallback.php
+++ b/packages/Ecotone/src/Messaging/Endpoint/NullAcknowledgementCallback.php
@@ -23,7 +23,7 @@ class NullAcknowledgementCallback implements AcknowledgementCallback
 
     private int $status = self::AWAITING;
 
-    private function __construct(private FinalFailureStrategy $failureStrategy)
+    private function __construct(private FinalFailureStrategy $failureStrategy, private bool $isAutoAcked = true)
     {
     }
 
@@ -33,6 +33,22 @@ class NullAcknowledgementCallback implements AcknowledgementCallback
     public static function create(FinalFailureStrategy $failureStrategy = FinalFailureStrategy::RESEND): self
     {
         return new self($failureStrategy);
+    }
+
+    /**
+     * @return NullAcknowledgementCallback
+     */
+    public static function createWithAutoAck(FinalFailureStrategy $failureStrategy = FinalFailureStrategy::RESEND): self
+    {
+        return new self($failureStrategy, true);
+    }
+
+    /**
+     * @return NullAcknowledgementCallback
+     */
+    public static function createWithManualAck(FinalFailureStrategy $failureStrategy = FinalFailureStrategy::RESEND): self
+    {
+        return new self($failureStrategy, false);
     }
 
     public function isAcked(): bool
@@ -56,6 +72,14 @@ class NullAcknowledgementCallback implements AcknowledgementCallback
     public function getFailureStrategy(): FinalFailureStrategy
     {
         return $this->failureStrategy;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function isAutoAcked(): bool
+    {
+        return $this->isAutoAcked;
     }
 
     /**

--- a/packages/Ecotone/tests/Messaging/Unit/Endpoint/FinalFailureStrategyTest.php
+++ b/packages/Ecotone/tests/Messaging/Unit/Endpoint/FinalFailureStrategyTest.php
@@ -1,0 +1,202 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Ecotone\Messaging\Unit\Endpoint;
+
+use Ecotone\Lite\EcotoneLite;
+use Ecotone\Messaging\Attribute\Asynchronous;
+use Ecotone\Messaging\Attribute\ServiceActivator;
+use Ecotone\Messaging\Channel\PollableChannel\InMemory\InMemoryAcknowledgeStatus;
+use Ecotone\Messaging\Channel\PollableChannel\InMemory\InMemoryQueueAcknowledgeInterceptor;
+use Ecotone\Messaging\Channel\SimpleMessageChannelBuilder;
+use Ecotone\Messaging\Config\ServiceConfiguration;
+use Ecotone\Messaging\Endpoint\ExecutionPollingMetadata;
+use Ecotone\Messaging\Endpoint\FinalFailureStrategy;
+use Ecotone\Messaging\Endpoint\NullAcknowledgementCallback;
+use Ecotone\Messaging\Endpoint\PollingConsumer\RejectMessageException;
+use Ecotone\Messaging\MessageHeaders;
+use Ecotone\Messaging\Support\MessageBuilder;
+use Exception;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Ecotone\Messaging\Message;
+
+/**
+ * @internal
+ */
+/**
+ * licence Apache-2.0
+ */
+#[CoversClass(FinalFailureStrategy::class)]
+final class FinalFailureStrategyTest extends TestCase
+{
+    public function test_reject_failure_strategy_rejects_message_on_exception()
+    {
+        $ecotoneTestSupport = EcotoneLite::bootstrapFlowTesting(
+            [FailingService::class],
+            [$service = new FailingService()],
+            enableAsynchronousProcessing: [
+                SimpleMessageChannelBuilder::createQueueChannel(messageChannelName: 'async', finalFailureStrategy: FinalFailureStrategy::IGNORE),
+            ]
+        );
+
+        $ecotoneTestSupport->sendDirectToChannel('executionChannel', 'some');
+        $ecotoneTestSupport->run('async', ExecutionPollingMetadata::createWithTestingSetup(failAtError: false));
+
+        $this->assertSame(
+            InMemoryAcknowledgeStatus::IGNORED,
+            $service->getMessage()->getHeaders()->get(InMemoryQueueAcknowledgeInterceptor::ECOTONE_IN_MEMORY_QUEUE_ACK)->getStatus()
+        );
+    }
+
+    public function test_requeue_failure_strategy_requeues_message_on_exception()
+    {
+        $ecotoneTestSupport = EcotoneLite::bootstrapFlowTesting(
+            [FailingService::class],
+            [$service = new FailingService()],
+            enableAsynchronousProcessing: [
+                SimpleMessageChannelBuilder::createQueueChannel(messageChannelName: 'async', finalFailureStrategy: FinalFailureStrategy::RESEND),
+            ]
+        );
+
+        $ecotoneTestSupport->sendDirectToChannel('executionChannel', 'some');
+        $ecotoneTestSupport->run('async', ExecutionPollingMetadata::createWithTestingSetup(failAtError: false));
+
+        $this->assertSame(
+            InMemoryAcknowledgeStatus::RESENT,
+            $service->getMessage()->getHeaders()->get(InMemoryQueueAcknowledgeInterceptor::ECOTONE_IN_MEMORY_QUEUE_ACK)->getStatus()
+        );
+    }
+
+    public function test_stop_failure_strategy_stops_consumer_on_exception()
+    {
+        $ecotoneTestSupport = EcotoneLite::bootstrapFlowTesting(
+            [FailingService::class],
+            [$service = new FailingService()],
+            enableAsynchronousProcessing: [
+                SimpleMessageChannelBuilder::createQueueChannel(messageChannelName: 'async', finalFailureStrategy: FinalFailureStrategy::STOP),
+            ]
+        );
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Service failed');
+
+        $ecotoneTestSupport->sendDirectToChannel('executionChannel', 'some');
+        $ecotoneTestSupport->run('async', ExecutionPollingMetadata::createWithTestingSetup(failAtError: false));
+    }
+
+    public function test_successful_processing_always_acknowledges_message()
+    {
+        $ecotoneTestSupport = EcotoneLite::bootstrapFlowTesting(
+            [SuccessService::class],
+            [$service = new SuccessService()],
+            enableAsynchronousProcessing: [
+                SimpleMessageChannelBuilder::createQueueChannel(messageChannelName: 'async', finalFailureStrategy: FinalFailureStrategy::IGNORE),
+            ]
+        );
+
+        $ecotoneTestSupport->sendDirectToChannel('executionChannel', 'some');
+        $ecotoneTestSupport->run('async', ExecutionPollingMetadata::createWithTestingSetup(failAtError: false));
+
+        $this->assertSame(
+            InMemoryAcknowledgeStatus::ACKED,
+            $service->getMessage()->getHeaders()->get(InMemoryQueueAcknowledgeInterceptor::ECOTONE_IN_MEMORY_QUEUE_ACK)->getStatus()
+        );
+    }
+
+    public function test_reject_message_exception_triggers_reject_strategy()
+    {
+        $ecotoneTestSupport = EcotoneLite::bootstrapFlowTesting(
+            [RejectingService::class],
+            [$service = new RejectingService()],
+            enableAsynchronousProcessing: [
+                SimpleMessageChannelBuilder::createQueueChannel(messageChannelName: 'async', finalFailureStrategy: FinalFailureStrategy::IGNORE),
+            ]
+        );
+
+        $ecotoneTestSupport->sendDirectToChannel('executionChannel', 'some');
+        $ecotoneTestSupport->run('async', ExecutionPollingMetadata::createWithTestingSetup(failAtError: false));
+
+        $this->assertSame(
+            InMemoryAcknowledgeStatus::IGNORED,
+            $service->getMessage()->getHeaders()->get(InMemoryQueueAcknowledgeInterceptor::ECOTONE_IN_MEMORY_QUEUE_ACK)->getStatus()
+        );
+    }
+
+    public function test_setting_execution_metadata_to_stop_on_error()
+    {
+        $ecotoneTestSupport = EcotoneLite::bootstrapFlowTesting(
+            [RejectingService::class],
+            [$service = new RejectingService()],
+            enableAsynchronousProcessing: [
+                SimpleMessageChannelBuilder::createQueueChannel(messageChannelName: 'async', finalFailureStrategy: FinalFailureStrategy::IGNORE),
+            ]
+        );
+
+        $ecotoneTestSupport->sendDirectToChannel('executionChannel', 'some');
+        $ecotoneTestSupport->run('async', ExecutionPollingMetadata::createWithTestingSetup(failAtError: true));
+
+        $this->assertSame(
+            InMemoryAcknowledgeStatus::IGNORED,
+            $service->getMessage()->getHeaders()->get(InMemoryQueueAcknowledgeInterceptor::ECOTONE_IN_MEMORY_QUEUE_ACK)->getStatus()
+        );
+    }
+}
+
+class FailingService
+{
+    private Message $message;
+
+    #[Asynchronous('async')]
+    #[ServiceActivator('executionChannel')]
+    public function handle(Message $message): void
+    {
+        $this->message = $message;
+
+        throw new Exception('Service failed');
+    }
+
+    public function getMessage(): Message
+    {
+        return $this->message;
+    }
+}
+
+class SuccessService
+{
+    private Message $message;
+
+    #[Asynchronous('async')]
+    #[ServiceActivator('executionChannel')]
+    public function handle(Message $message): void
+    {
+        $this->message = $message;
+
+        // Success - do nothing
+    }
+
+    public function getMessage(): Message
+    {
+        return $this->message;
+    }
+}
+
+class RejectingService
+{
+    private Message $message;
+
+    #[Asynchronous('async')]
+    #[ServiceActivator('executionChannel')]
+    public function handle(Message $message): void
+    {
+        $this->message = $message;
+
+        throw new RejectMessageException('Reject this message');
+    }
+
+    public function getMessage(): Message
+    {
+        return $this->message;
+    }
+}

--- a/packages/Enqueue/src/EnqueueAcknowledgementCallback.php
+++ b/packages/Enqueue/src/EnqueueAcknowledgementCallback.php
@@ -30,6 +30,10 @@ class EnqueueAcknowledgementCallback implements AcknowledgementCallback
      */
     private $failureStrategy;
     /**
+     * @var bool
+     */
+    private $isAutoAcked;
+    /**
      * @var EnqueueConsumer
      */
     private $enqueueConsumer;
@@ -41,12 +45,14 @@ class EnqueueAcknowledgementCallback implements AcknowledgementCallback
     /**
      * EnqueueAcknowledgementCallback constructor.
      * @param FinalFailureStrategy $failureStrategy
+     * @param bool $isAutoAcked
      * @param EnqueueConsumer $enqueueConsumer
      * @param EnqueueMessage $enqueueMessage
      */
-    private function __construct(FinalFailureStrategy $failureStrategy, EnqueueConsumer $enqueueConsumer, EnqueueMessage $enqueueMessage, private CachedConnectionFactory $connectionFactory, private LoggingGateway $loggingGateway)
+    private function __construct(FinalFailureStrategy $failureStrategy, bool $isAutoAcked, EnqueueConsumer $enqueueConsumer, EnqueueMessage $enqueueMessage, private CachedConnectionFactory $connectionFactory, private LoggingGateway $loggingGateway)
     {
         $this->failureStrategy = $failureStrategy;
+        $this->isAutoAcked = $isAutoAcked;
         $this->enqueueConsumer = $enqueueConsumer;
         $this->enqueueMessage = $enqueueMessage;
     }
@@ -58,7 +64,7 @@ class EnqueueAcknowledgementCallback implements AcknowledgementCallback
      */
     public static function createWithAutoAck(EnqueueConsumer $enqueueConsumer, EnqueueMessage $enqueueMessage, CachedConnectionFactory $connectionFactory, LoggingGateway $loggingGateway): self
     {
-        return new self(FinalFailureStrategy::RESEND, $enqueueConsumer, $enqueueMessage, $connectionFactory, $loggingGateway);
+        return new self(FinalFailureStrategy::RESEND, true, $enqueueConsumer, $enqueueMessage, $connectionFactory, $loggingGateway);
     }
 
     /**
@@ -68,7 +74,7 @@ class EnqueueAcknowledgementCallback implements AcknowledgementCallback
      */
     public static function createWithManualAck(EnqueueConsumer $enqueueConsumer, EnqueueMessage $enqueueMessage, CachedConnectionFactory $connectionFactory, LoggingGateway $loggingGateway): self
     {
-        return new self(FinalFailureStrategy::STOP, $enqueueConsumer, $enqueueMessage, $connectionFactory, $loggingGateway);
+        return new self(FinalFailureStrategy::STOP, false, $enqueueConsumer, $enqueueMessage, $connectionFactory, $loggingGateway);
     }
 
     /**
@@ -77,6 +83,14 @@ class EnqueueAcknowledgementCallback implements AcknowledgementCallback
     public function getFailureStrategy(): FinalFailureStrategy
     {
         return $this->failureStrategy;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function isAutoAcked(): bool
+    {
+        return $this->isAutoAcked;
     }
 
     /**

--- a/packages/Enqueue/src/EnqueueAcknowledgementCallback.php
+++ b/packages/Enqueue/src/EnqueueAcknowledgementCallback.php
@@ -60,31 +60,11 @@ class EnqueueAcknowledgementCallback implements AcknowledgementCallback
     /**
      * @param EnqueueConsumer $enqueueConsumer
      * @param EnqueueMessage $enqueueMessage
-     * @return EnqueueAcknowledgementCallback
-     */
-    public static function createWithAutoAck(EnqueueConsumer $enqueueConsumer, EnqueueMessage $enqueueMessage, CachedConnectionFactory $connectionFactory, LoggingGateway $loggingGateway): self
-    {
-        return new self(FinalFailureStrategy::RESEND, true, $enqueueConsumer, $enqueueMessage, $connectionFactory, $loggingGateway);
-    }
-
-    /**
-     * @param EnqueueConsumer $enqueueConsumer
-     * @param EnqueueMessage $enqueueMessage
-     * @return EnqueueAcknowledgementCallback
-     */
-    public static function createWithManualAck(EnqueueConsumer $enqueueConsumer, EnqueueMessage $enqueueMessage, CachedConnectionFactory $connectionFactory, LoggingGateway $loggingGateway): self
-    {
-        return new self(FinalFailureStrategy::STOP, false, $enqueueConsumer, $enqueueMessage, $connectionFactory, $loggingGateway);
-    }
-
-    /**
-     * @param EnqueueConsumer $enqueueConsumer
-     * @param EnqueueMessage $enqueueMessage
      * @param FinalFailureStrategy $finalFailureStrategy
      * @param bool $isAutoAcked
      * @return EnqueueAcknowledgementCallback
      */
-    public static function createWithFailureStrategy(EnqueueConsumer $enqueueConsumer, EnqueueMessage $enqueueMessage, CachedConnectionFactory $connectionFactory, LoggingGateway $loggingGateway, FinalFailureStrategy $finalFailureStrategy, bool $isAutoAcked): self
+    public static function create(EnqueueConsumer $enqueueConsumer, EnqueueMessage $enqueueMessage, CachedConnectionFactory $connectionFactory, LoggingGateway $loggingGateway, FinalFailureStrategy $finalFailureStrategy, bool $isAutoAcked): self
     {
         return new self($finalFailureStrategy, $isAutoAcked, $enqueueConsumer, $enqueueMessage, $connectionFactory, $loggingGateway);
     }

--- a/packages/Enqueue/src/EnqueueAcknowledgementCallback.php
+++ b/packages/Enqueue/src/EnqueueAcknowledgementCallback.php
@@ -78,6 +78,18 @@ class EnqueueAcknowledgementCallback implements AcknowledgementCallback
     }
 
     /**
+     * @param EnqueueConsumer $enqueueConsumer
+     * @param EnqueueMessage $enqueueMessage
+     * @param FinalFailureStrategy $finalFailureStrategy
+     * @param bool $isAutoAcked
+     * @return EnqueueAcknowledgementCallback
+     */
+    public static function createWithFailureStrategy(EnqueueConsumer $enqueueConsumer, EnqueueMessage $enqueueMessage, CachedConnectionFactory $connectionFactory, LoggingGateway $loggingGateway, FinalFailureStrategy $finalFailureStrategy, bool $isAutoAcked): self
+    {
+        return new self($finalFailureStrategy, $isAutoAcked, $enqueueConsumer, $enqueueMessage, $connectionFactory, $loggingGateway);
+    }
+
+    /**
      * @inheritDoc
      */
     public function getFailureStrategy(): FinalFailureStrategy

--- a/packages/Enqueue/src/EnqueueInboundChannelAdapterBuilder.php
+++ b/packages/Enqueue/src/EnqueueInboundChannelAdapterBuilder.php
@@ -6,6 +6,7 @@ use Ecotone\Messaging\Config\Container\DefinedObject;
 use Ecotone\Messaging\Config\Container\Definition;
 use Ecotone\Messaging\Config\Container\MessagingContainerBuilder;
 use Ecotone\Messaging\Config\Container\Reference;
+use Ecotone\Messaging\Endpoint\FinalFailureStrategy;
 use Ecotone\Messaging\Endpoint\InboundChannelAdapterEntrypoint;
 use Ecotone\Messaging\Endpoint\InterceptedChannelAdapterBuilder;
 use Ecotone\Messaging\Handler\Gateway\GatewayProxyBuilder;
@@ -31,6 +32,10 @@ abstract class EnqueueInboundChannelAdapterBuilder extends InterceptedChannelAda
      * @var string
      */
     protected $acknowledgeMode = EnqueueAcknowledgementCallback::AUTO_ACK;
+    /**
+     * @var FinalFailureStrategy
+     */
+    protected $finalFailureStrategy = FinalFailureStrategy::RESEND;
 
     protected bool $declareOnStartup = self::DECLARE_ON_STARTUP_DEFAULT;
 
@@ -90,6 +95,19 @@ abstract class EnqueueInboundChannelAdapterBuilder extends InterceptedChannelAda
     public function withReceiveTimeout(int $timeoutInMilliseconds): self
     {
         $this->receiveTimeoutInMilliseconds = $timeoutInMilliseconds;
+
+        return $this;
+    }
+
+    /**
+     * Set the final failure strategy for message acknowledgment
+     *
+     * @param FinalFailureStrategy $finalFailureStrategy
+     * @return static
+     */
+    public function withFinalFailureStrategy(FinalFailureStrategy $finalFailureStrategy): self
+    {
+        $this->finalFailureStrategy = $finalFailureStrategy;
 
         return $this;
     }

--- a/packages/Enqueue/src/EnqueueMessageChannelBuilder.php
+++ b/packages/Enqueue/src/EnqueueMessageChannelBuilder.php
@@ -6,6 +6,7 @@ use Ecotone\Messaging\Channel\MessageChannelWithSerializationBuilder;
 use Ecotone\Messaging\Config\Container\Definition;
 use Ecotone\Messaging\Config\Container\MessagingContainerBuilder;
 use Ecotone\Messaging\Conversion\MediaType;
+use Ecotone\Messaging\Endpoint\FinalFailureStrategy;
 use Ecotone\Messaging\MessageConverter\HeaderMapper;
 
 /**
@@ -43,6 +44,13 @@ abstract class EnqueueMessageChannelBuilder implements MessageChannelWithSeriali
     {
         $this->getInboundChannelAdapter()->withHeaderMapper($headerMapper);
         $this->getOutboundChannelAdapter()->withHeaderMapper($headerMapper);
+
+        return $this;
+    }
+
+    public function withFinalFailureStrategy(FinalFailureStrategy $finalFailureStrategy): self
+    {
+        $this->getInboundChannelAdapter()->withFinalFailureStrategy($finalFailureStrategy);
 
         return $this;
     }

--- a/packages/Enqueue/src/InboundMessageConverter.php
+++ b/packages/Enqueue/src/InboundMessageConverter.php
@@ -33,20 +33,17 @@ class InboundMessageConverter
         $messageBuilder = MessageBuilder::withPayload($source->getBody())
             ->setMultipleHeaders($this->headerMapper->mapToMessageHeaders($enqueueMessageHeaders, $conversionService));
 
-        if (in_array($this->acknowledgeMode, [EnqueueAcknowledgementCallback::AUTO_ACK, EnqueueAcknowledgementCallback::MANUAL_ACK])) {
-            $isAutoAcked = $this->acknowledgeMode == EnqueueAcknowledgementCallback::AUTO_ACK;
-            $amqpAcknowledgeCallback = EnqueueAcknowledgementCallback::createWithFailureStrategy(
-                $consumer,
-                $source,
-                $connectionFactory,
-                $this->loggingGateway,
-                $this->finalFailureStrategy,
-                $isAutoAcked
-            );
+        $amqpAcknowledgeCallback = EnqueueAcknowledgementCallback::create(
+            $consumer,
+            $source,
+            $connectionFactory,
+            $this->loggingGateway,
+            $this->finalFailureStrategy,
+            $this->acknowledgeMode == EnqueueAcknowledgementCallback::AUTO_ACK
+        );
 
-            $messageBuilder = $messageBuilder
-                ->setHeader($this->acknowledgeHeaderName, $amqpAcknowledgeCallback);
-        }
+        $messageBuilder = $messageBuilder
+            ->setHeader($this->acknowledgeHeaderName, $amqpAcknowledgeCallback);
 
         if (isset($enqueueMessageHeaders[MessageHeaders::MESSAGE_ID])) {
             $messageBuilder = $messageBuilder

--- a/packages/Kafka/src/Channel/KafkaMessageChannelBuilder.php
+++ b/packages/Kafka/src/Channel/KafkaMessageChannelBuilder.php
@@ -12,6 +12,7 @@ use Ecotone\Messaging\Config\Container\Definition;
 use Ecotone\Messaging\Config\Container\MessagingContainerBuilder;
 use Ecotone\Messaging\Config\Container\Reference;
 use Ecotone\Messaging\Conversion\MediaType;
+use Ecotone\Messaging\Endpoint\FinalFailureStrategy;
 use Ecotone\Messaging\MessageConverter\DefaultHeaderMapper;
 use Ecotone\Messaging\MessageConverter\HeaderMapper;
 
@@ -81,6 +82,13 @@ final class KafkaMessageChannelBuilder implements MessageChannelWithSerializatio
     public function withHeaderMapping(string $headerMapper): self
     {
         $this->headerMapper = $headerMapper;
+
+        return $this;
+    }
+
+    public function withFinalFailureStrategy(FinalFailureStrategy $finalFailureStrategy): self
+    {
+        $this->inboundChannelAdapterBuilder->withFinalFailureStrategy($finalFailureStrategy);
 
         return $this;
     }

--- a/packages/Kafka/src/Inbound/KafkaAcknowledgementCallback.php
+++ b/packages/Kafka/src/Inbound/KafkaAcknowledgementCallback.php
@@ -28,18 +28,13 @@ class KafkaAcknowledgementCallback implements AcknowledgementCallback
         private KafkaMessage         $message,
         private LoggingGateway       $loggingGateway,
         private KafkaAdmin           $kafkaAdmin,
-        private string               $endpointId
+        private string               $endpointId,
     ) {
     }
 
-    public static function createWithAutoAck(KafkaConsumer $consumer, KafkaMessage $message, LoggingGateway $loggingGateway, KafkaAdmin $kafkaAdmin, string $endpointId): self
+    public static function create(KafkaConsumer $consumer, KafkaMessage $message, LoggingGateway $loggingGateway, KafkaAdmin $kafkaAdmin, string $endpointId, FinalFailureStrategy $finalFailureStrategy, bool $isAutoAcked): self
     {
-        return new self(FinalFailureStrategy::RESEND, true, $consumer, $message, $loggingGateway, $kafkaAdmin, $endpointId);
-    }
-
-    public static function createWithManualAck(KafkaConsumer $consumer, KafkaMessage $message, LoggingGateway $loggingGateway, KafkaAdmin $kafkaAdmin, string $endpointId): self
-    {
-        return new self(FinalFailureStrategy::STOP, false, $consumer, $message, $loggingGateway, $kafkaAdmin, $endpointId);
+        return new self($finalFailureStrategy, $isAutoAcked, $consumer, $message, $loggingGateway, $kafkaAdmin, $endpointId);
     }
 
     /**

--- a/packages/Kafka/src/Inbound/KafkaAcknowledgementCallback.php
+++ b/packages/Kafka/src/Inbound/KafkaAcknowledgementCallback.php
@@ -23,6 +23,7 @@ class KafkaAcknowledgementCallback implements AcknowledgementCallback
 
     private function __construct(
         private FinalFailureStrategy $failureStrategy,
+        private bool $isAutoAcked,
         private KafkaConsumer        $consumer,
         private KafkaMessage         $message,
         private LoggingGateway       $loggingGateway,
@@ -33,12 +34,12 @@ class KafkaAcknowledgementCallback implements AcknowledgementCallback
 
     public static function createWithAutoAck(KafkaConsumer $consumer, KafkaMessage $message, LoggingGateway $loggingGateway, KafkaAdmin $kafkaAdmin, string $endpointId): self
     {
-        return new self(FinalFailureStrategy::RESEND, $consumer, $message, $loggingGateway, $kafkaAdmin, $endpointId);
+        return new self(FinalFailureStrategy::RESEND, true, $consumer, $message, $loggingGateway, $kafkaAdmin, $endpointId);
     }
 
     public static function createWithManualAck(KafkaConsumer $consumer, KafkaMessage $message, LoggingGateway $loggingGateway, KafkaAdmin $kafkaAdmin, string $endpointId): self
     {
-        return new self(FinalFailureStrategy::STOP, $consumer, $message, $loggingGateway, $kafkaAdmin, $endpointId);
+        return new self(FinalFailureStrategy::STOP, false, $consumer, $message, $loggingGateway, $kafkaAdmin, $endpointId);
     }
 
     /**
@@ -47,6 +48,14 @@ class KafkaAcknowledgementCallback implements AcknowledgementCallback
     public function getFailureStrategy(): FinalFailureStrategy
     {
         return $this->failureStrategy;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function isAutoAcked(): bool
+    {
+        return $this->isAutoAcked;
     }
 
     /**

--- a/packages/Kafka/src/Outbound/KafkaOutboundChannelAdapter.php
+++ b/packages/Kafka/src/Outbound/KafkaOutboundChannelAdapter.php
@@ -58,7 +58,7 @@ final class KafkaOutboundChannelAdapter implements MessageHandler
             RD_KAFKA_PARTITION_UA,
             0,
             $outboundMessage->getPayload(),
-            $partitionKey,
+            (string)$partitionKey,
             array_merge(
                 $headers,
                 [

--- a/packages/Kafka/tests/Integration/FinalFailureStrategyTest.php
+++ b/packages/Kafka/tests/Integration/FinalFailureStrategyTest.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Ecotone\Kafka\Integration;
+
+use Ecotone\Amqp\AmqpBackedMessageChannelBuilder;
+use Ecotone\Kafka\Channel\KafkaMessageChannelBuilder;
+use Ecotone\Kafka\Configuration\KafkaBrokerConfiguration;
+use Ecotone\Lite\EcotoneLite;
+use Ecotone\Messaging\Attribute\Asynchronous;
+use Ecotone\Messaging\Attribute\ServiceActivator;
+use Ecotone\Messaging\Channel\PollableChannel\InMemory\InMemoryAcknowledgeStatus;
+use Ecotone\Messaging\Channel\PollableChannel\InMemory\InMemoryQueueAcknowledgeInterceptor;
+use Ecotone\Messaging\Channel\SimpleMessageChannelBuilder;
+use Ecotone\Messaging\Config\ModulePackageList;
+use Ecotone\Messaging\Config\ServiceConfiguration;
+use Ecotone\Messaging\Endpoint\ExecutionPollingMetadata;
+use Ecotone\Messaging\Endpoint\FinalFailureStrategy;
+use Ecotone\Messaging\Message;
+use Ecotone\Test\LicenceTesting;
+use Enqueue\AmqpExt\AmqpConnectionFactory;
+use PHPUnit\Framework\TestCase;
+use Ramsey\Uuid\Nonstandard\Uuid;
+use Test\Ecotone\Kafka\ConnectionTestCase;
+
+/**
+ * @internal
+ */
+/**
+ * licence Apache-2.0
+ */
+final class FinalFailureStrategyTest extends TestCase
+{
+    public function test_reject_failure_strategy_rejects_message_on_exception()
+    {
+        $ecotoneTestSupport = EcotoneLite::bootstrapFlowTesting(
+            [FailingService::class],
+            [new FailingService(), KafkaBrokerConfiguration::class => ConnectionTestCase::getConnection()],
+            configuration: ServiceConfiguration::createWithDefaults()
+                ->withSkippedModulePackageNames(ModulePackageList::allPackagesExcept([ModulePackageList::KAFKA_PACKAGE, ModulePackageList::ASYNCHRONOUS_PACKAGE]))
+                ->withExtensionObjects([
+                    KafkaMessageChannelBuilder::create(channelName: 'async', topicName: Uuid::uuid4()->toString())
+                        ->withFinalFailureStrategy(FinalFailureStrategy::IGNORE)
+                        ->withReceiveTimeout(3000),
+                ]),
+            licenceKey: LicenceTesting::VALID_LICENCE,
+        );
+
+        $ecotoneTestSupport->sendDirectToChannel('executionChannel', 'some');
+        $ecotoneTestSupport->run('async', ExecutionPollingMetadata::createWithTestingSetup(failAtError: false));
+
+        $messageChannel = $ecotoneTestSupport->getMessageChannel('async');
+        $this->assertNull($messageChannel->receive());
+    }
+
+    public function test_resend_failure_strategy_rejects_message_on_exception()
+    {
+        $ecotoneTestSupport = EcotoneLite::bootstrapFlowTesting(
+            [FailingService::class],
+            [new FailingService(), KafkaBrokerConfiguration::class => ConnectionTestCase::getConnection()],
+            configuration: ServiceConfiguration::createWithDefaults()
+                ->withSkippedModulePackageNames(ModulePackageList::allPackagesExcept([ModulePackageList::KAFKA_PACKAGE, ModulePackageList::ASYNCHRONOUS_PACKAGE]))
+                ->withExtensionObjects([
+                    KafkaMessageChannelBuilder::create(channelName: 'async', topicName: Uuid::uuid4()->toString())
+                        ->withFinalFailureStrategy(FinalFailureStrategy::RESEND)
+                        ->withReceiveTimeout(3000),
+                ]),
+            licenceKey: LicenceTesting::VALID_LICENCE,
+        );
+
+        $ecotoneTestSupport->sendDirectToChannel('executionChannel', 'some');
+        $ecotoneTestSupport->run('async', ExecutionPollingMetadata::createWithTestingSetup(failAtError: false));
+
+        $messageChannel = $ecotoneTestSupport->getMessageChannel('async');
+        $this->assertNotNull($messageChannel->receive());
+    }
+}
+
+
+class FailingService
+{
+    private Message $message;
+
+    #[Asynchronous('async')]
+    #[ServiceActivator('executionChannel')]
+    public function handle(Message $message): void
+    {
+        $this->message = $message;
+
+        throw new \Exception('Service failed');
+    }
+
+    public function getMessage(): Message
+    {
+        return $this->message;
+    }
+}

--- a/packages/Kafka/tests/Integration/KafkaChannelAdapterTest.php
+++ b/packages/Kafka/tests/Integration/KafkaChannelAdapterTest.php
@@ -83,6 +83,7 @@ final class KafkaChannelAdapterTest extends TestCase
         $aggregateId = Uuid::uuid4()->toString();
         $eventAggregateId = Uuid::uuid4()->toString();
         $customKey = Uuid::uuid4()->toString();
+        $intKey = 2;
 
         yield 'with no partition key, message id is used' => [
             'metadata' => [MessageHeaders::MESSAGE_ID => $messageId],
@@ -99,6 +100,10 @@ final class KafkaChannelAdapterTest extends TestCase
         yield 'with custom partition key' => [
             'metadata' => [MessageHeaders::MESSAGE_ID => $messageId, MessageHeaders::EVENT_AGGREGATE_ID => $eventAggregateId, AggregateMessage::AGGREGATE_ID => ['orderId' => $aggregateId], KafkaHeader::KAFKA_TARGET_PARTITION_KEY_HEADER_NAME => $customKey],
             'expectedKey' => $customKey,
+        ];
+        yield 'with partition being int' => [
+            'metadata' => [MessageHeaders::MESSAGE_ID => $messageId, KafkaHeader::KAFKA_TARGET_PARTITION_KEY_HEADER_NAME => $intKey],
+            'expectedKey' => (string)$intKey,
         ];
     }
 

--- a/packages/Laravel/src/EcotoneProvider.php
+++ b/packages/Laravel/src/EcotoneProvider.php
@@ -2,6 +2,7 @@
 
 namespace Ecotone\Laravel;
 
+use Illuminate\Foundation\Application;
 use function class_exists;
 
 use const DIRECTORY_SEPARATOR;
@@ -188,7 +189,7 @@ class EcotoneProvider extends ServiceProvider
         $this->registerOptimizationHooks();
     }
 
-    private function getCacheDirectoryPath(): string
+    public static function getCacheDirectoryPath(): string
     {
         return App::storagePath() . DIRECTORY_SEPARATOR . 'framework' . DIRECTORY_SEPARATOR . 'cache' . DIRECTORY_SEPARATOR . 'data';
     }

--- a/packages/Laravel/src/Queue/LaravelQueueAcknowledgementCallback.php
+++ b/packages/Laravel/src/Queue/LaravelQueueAcknowledgementCallback.php
@@ -19,6 +19,7 @@ class LaravelQueueAcknowledgementCallback implements AcknowledgementCallback
 
     private function __construct(
         private FinalFailureStrategy $failureStrategy,
+        private bool $isAutoAcked,
         private Job                  $job
     ) {
 
@@ -26,12 +27,12 @@ class LaravelQueueAcknowledgementCallback implements AcknowledgementCallback
 
     public static function createWithAutoAck(Job $job): self
     {
-        return new self(FinalFailureStrategy::RESEND, $job);
+        return new self(FinalFailureStrategy::RESEND, true, $job);
     }
 
     public static function createWithManualAck(Job $job): self
     {
-        return new self(FinalFailureStrategy::STOP, $job);
+        return new self(FinalFailureStrategy::STOP, false, $job);
     }
 
     /**
@@ -40,6 +41,14 @@ class LaravelQueueAcknowledgementCallback implements AcknowledgementCallback
     public function getFailureStrategy(): FinalFailureStrategy
     {
         return $this->failureStrategy;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function isAutoAcked(): bool
+    {
+        return $this->isAutoAcked;
     }
 
     /**

--- a/packages/Laravel/src/Queue/LaravelQueueAcknowledgementCallback.php
+++ b/packages/Laravel/src/Queue/LaravelQueueAcknowledgementCallback.php
@@ -25,14 +25,15 @@ class LaravelQueueAcknowledgementCallback implements AcknowledgementCallback
 
     }
 
-    public static function createWithAutoAck(Job $job): self
+    /**
+     * @param Job $job
+     * @param FinalFailureStrategy $finalFailureStrategy
+     * @param bool $isAutoAcked
+     * @return LaravelQueueAcknowledgementCallback
+     */
+    public static function create(Job $job, FinalFailureStrategy $finalFailureStrategy, bool $isAutoAcked): self
     {
-        return new self(FinalFailureStrategy::RESEND, true, $job);
-    }
-
-    public static function createWithManualAck(Job $job): self
-    {
-        return new self(FinalFailureStrategy::STOP, false, $job);
+        return new self($finalFailureStrategy, $isAutoAcked, $job);
     }
 
     /**

--- a/packages/Laravel/src/Queue/LaravelQueueAcknowledgementCallback.php
+++ b/packages/Laravel/src/Queue/LaravelQueueAcknowledgementCallback.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Ecotone\Laravel\Queue;
 
 use Ecotone\Messaging\Endpoint\AcknowledgementCallback;
+use Ecotone\Messaging\Endpoint\FinalFailureStrategy;
 use Illuminate\Contracts\Queue\Job;
 
 /**
@@ -17,36 +18,28 @@ class LaravelQueueAcknowledgementCallback implements AcknowledgementCallback
     public const NONE = 'none';
 
     private function __construct(
-        private bool $isAutoAck,
-        private Job $job
+        private FinalFailureStrategy $failureStrategy,
+        private Job                  $job
     ) {
 
     }
 
     public static function createWithAutoAck(Job $job): self
     {
-        return new self(true, $job);
+        return new self(FinalFailureStrategy::RESEND, $job);
     }
 
     public static function createWithManualAck(Job $job): self
     {
-        return new self(false, $job);
+        return new self(FinalFailureStrategy::STOP, $job);
     }
 
     /**
      * @inheritDoc
      */
-    public function isAutoAck(): bool
+    public function getFailureStrategy(): FinalFailureStrategy
     {
-        return $this->isAutoAck;
-    }
-
-    /**
-     * @inheritDoc
-     */
-    public function disableAutoAck(): void
-    {
-        $this->isAutoAck = false;
+        return $this->failureStrategy;
     }
 
     /**

--- a/packages/Laravel/tests/Application/Execution/ApplicationTest.php
+++ b/packages/Laravel/tests/Application/Execution/ApplicationTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Test\Ecotone\Laravel\Application\Execution;
 
 use Ecotone\Laravel\EcotoneCacheClear;
+use Ecotone\Laravel\EcotoneProvider;
 use Ecotone\Lite\Test\MessagingTestSupport;
 use Ecotone\Messaging\Config\ConfiguredMessagingSystem;
 use Ecotone\Modelling\CommandBus;
@@ -32,8 +33,6 @@ final class ApplicationTest extends TestCase
             CommandBus::class,
             $app->get(CommandBus::class)
         );
-
-        EcotoneCacheClear::clearEcotoneCacheDirectories($app->storagePath());
     }
 
     public function createApplication()
@@ -41,6 +40,8 @@ final class ApplicationTest extends TestCase
         $app = require __DIR__ . '/../bootstrap/app.php';
 
         $app->make(Kernel::class)->bootstrap();
+
+        EcotoneCacheClear::clearEcotoneCacheDirectories(EcotoneProvider::getCacheDirectoryPath());
 
         return $app;
     }

--- a/packages/Laravel/tests/Application/Execution/EloquentIntegrationTest.php
+++ b/packages/Laravel/tests/Application/Execution/EloquentIntegrationTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Test\Ecotone\Laravel\Application\Execution;
 
+use Ecotone\Laravel\EcotoneCacheClear;
+use Ecotone\Laravel\EcotoneProvider;
 use Ecotone\Messaging\Config\ConfiguredMessagingSystem;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Foundation\Http\Kernel;
@@ -104,6 +106,7 @@ final class EloquentIntegrationTest extends TestCase
         $app = require __DIR__ . '/../bootstrap/app.php';
 
         $app->make(Kernel::class)->bootstrap();
+        EcotoneCacheClear::clearEcotoneCacheDirectories(EcotoneProvider::getCacheDirectoryPath());
 
         return $app;
     }

--- a/packages/Laravel/tests/Licence/LicenceTest.php
+++ b/packages/Laravel/tests/Licence/LicenceTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Test\Ecotone\Laravel\Licence;
 
 use Ecotone\Laravel\EcotoneCacheClear;
+use Ecotone\Laravel\EcotoneProvider;
 use Ecotone\Modelling\CommandBus;
 use Ecotone\Modelling\QueryBus;
 use Ecotone\Test\LicenceTesting;
@@ -28,11 +29,11 @@ final class LicenceTest extends TestCase
 
         $app = require __DIR__ . '/bootstrap/app.php';
         $app->make(Kernel::class)->bootstrap();
+        EcotoneCacheClear::clearEcotoneCacheDirectories(EcotoneProvider::getCacheDirectoryPath());
+
         $this->app = $app;
         $this->queryBus = $app->get(QueryBus::class);
         $this->commandBus = $app->get(CommandBus::class);
-
-        EcotoneCacheClear::clearEcotoneCacheDirectories($app->storagePath());
     }
 
     protected function tearDown(): void

--- a/packages/Laravel/tests/MultiTenant/MultiTenantTest.php
+++ b/packages/Laravel/tests/MultiTenant/MultiTenantTest.php
@@ -6,6 +6,7 @@ namespace Test\Ecotone\Laravel\MultiTenant;
 
 use App\MultiTenant\Application\Command\RegisterCustomer;
 use Ecotone\Laravel\EcotoneCacheClear;
+use Ecotone\Laravel\EcotoneProvider;
 use Ecotone\Modelling\CommandBus;
 use Ecotone\Modelling\QueryBus;
 use Illuminate\Foundation\Application;
@@ -37,10 +38,9 @@ final class MultiTenantTest extends TestCase
         $app->make(Kernel::class)->bootstrap();
         runMigrationForTenants(DB::connection('tenant_a_connection'), DB::connection('tenant_b_connection'));
         $this->app = $app;
+        EcotoneCacheClear::clearEcotoneCacheDirectories(EcotoneProvider::getCacheDirectoryPath());
         $this->queryBus = $app->get(QueryBus::class);
         $this->commandBus = $app->get(CommandBus::class);
-
-        EcotoneCacheClear::clearEcotoneCacheDirectories($app->storagePath());
     }
 
     public function test_optimize_clear_triggers_ecotone_cache_clear_via_event(): void

--- a/packages/Symfony/SymfonyBundle/Messenger/SymfonyAcknowledgementCallback.php
+++ b/packages/Symfony/SymfonyBundle/Messenger/SymfonyAcknowledgementCallback.php
@@ -6,6 +6,7 @@ namespace Ecotone\SymfonyBundle\Messenger;
 
 use Ecotone\Enqueue\EnqueueAcknowledgementCallback;
 use Ecotone\Messaging\Endpoint\AcknowledgementCallback;
+use Ecotone\Messaging\Endpoint\FinalFailureStrategy;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Transport\TransportInterface;
 
@@ -24,37 +25,29 @@ class SymfonyAcknowledgementCallback implements AcknowledgementCallback
     public const NONE = 'none';
 
     private function __construct(
-        private bool $isAutoAck,
-        private TransportInterface $symfonyTransport,
-        private Envelope $envelope
+        private FinalFailureStrategy $failureStrategy,
+        private TransportInterface   $symfonyTransport,
+        private Envelope             $envelope
     ) {
 
     }
 
     public static function createWithAutoAck(TransportInterface $symfonyTransport, Envelope $envelope): self
     {
-        return new self(true, $symfonyTransport, $envelope);
+        return new self(FinalFailureStrategy::RESEND, $symfonyTransport, $envelope);
     }
 
     public static function createWithManualAck(TransportInterface $symfonyTransport, Envelope $envelope): self
     {
-        return new self(false, $symfonyTransport, $envelope);
+        return new self(FinalFailureStrategy::STOP, $symfonyTransport, $envelope);
     }
 
     /**
      * @inheritDoc
      */
-    public function isAutoAck(): bool
+    public function getFailureStrategy(): FinalFailureStrategy
     {
-        return $this->isAutoAck;
-    }
-
-    /**
-     * @inheritDoc
-     */
-    public function disableAutoAck(): void
-    {
-        $this->isAutoAck = false;
+        return $this->failureStrategy;
     }
 
     /**

--- a/packages/Symfony/SymfonyBundle/Messenger/SymfonyAcknowledgementCallback.php
+++ b/packages/Symfony/SymfonyBundle/Messenger/SymfonyAcknowledgementCallback.php
@@ -26,6 +26,7 @@ class SymfonyAcknowledgementCallback implements AcknowledgementCallback
 
     private function __construct(
         private FinalFailureStrategy $failureStrategy,
+        private bool $isAutoAcked,
         private TransportInterface   $symfonyTransport,
         private Envelope             $envelope
     ) {
@@ -34,12 +35,12 @@ class SymfonyAcknowledgementCallback implements AcknowledgementCallback
 
     public static function createWithAutoAck(TransportInterface $symfonyTransport, Envelope $envelope): self
     {
-        return new self(FinalFailureStrategy::RESEND, $symfonyTransport, $envelope);
+        return new self(FinalFailureStrategy::RESEND, true, $symfonyTransport, $envelope);
     }
 
     public static function createWithManualAck(TransportInterface $symfonyTransport, Envelope $envelope): self
     {
-        return new self(FinalFailureStrategy::STOP, $symfonyTransport, $envelope);
+        return new self(FinalFailureStrategy::STOP, false, $symfonyTransport, $envelope);
     }
 
     /**
@@ -48,6 +49,14 @@ class SymfonyAcknowledgementCallback implements AcknowledgementCallback
     public function getFailureStrategy(): FinalFailureStrategy
     {
         return $this->failureStrategy;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function isAutoAcked(): bool
+    {
+        return $this->isAutoAcked;
     }
 
     /**

--- a/packages/Symfony/SymfonyBundle/Messenger/SymfonyAcknowledgementCallback.php
+++ b/packages/Symfony/SymfonyBundle/Messenger/SymfonyAcknowledgementCallback.php
@@ -44,6 +44,18 @@ class SymfonyAcknowledgementCallback implements AcknowledgementCallback
     }
 
     /**
+     * @param TransportInterface $symfonyTransport
+     * @param Envelope $envelope
+     * @param FinalFailureStrategy $finalFailureStrategy
+     * @param bool $isAutoAcked
+     * @return SymfonyAcknowledgementCallback
+     */
+    public static function createWithFailureStrategy(TransportInterface $symfonyTransport, Envelope $envelope, FinalFailureStrategy $finalFailureStrategy, bool $isAutoAcked): self
+    {
+        return new self($finalFailureStrategy, $isAutoAcked, $symfonyTransport, $envelope);
+    }
+
+    /**
      * @inheritDoc
      */
     public function getFailureStrategy(): FinalFailureStrategy

--- a/packages/Symfony/SymfonyBundle/Messenger/SymfonyMessengerMessageChannelBuilder.php
+++ b/packages/Symfony/SymfonyBundle/Messenger/SymfonyMessengerMessageChannelBuilder.php
@@ -9,6 +9,7 @@ use Ecotone\Messaging\Config\Container\Definition;
 use Ecotone\Messaging\Config\Container\MessagingContainerBuilder;
 use Ecotone\Messaging\Config\Container\Reference;
 use Ecotone\Messaging\Conversion\ConversionService;
+use Ecotone\Messaging\Endpoint\FinalFailureStrategy;
 use Ecotone\Messaging\MessageConverter\DefaultHeaderMapper;
 use Ecotone\Messaging\MessageConverter\HeaderMapper;
 
@@ -26,6 +27,8 @@ final class SymfonyMessengerMessageChannelBuilder implements MessageChannelBuild
     private HeaderMapper $headerMapper;
 
     private string $acknowledgeMode = SymfonyAcknowledgementCallback::AUTO_ACK;
+
+    private FinalFailureStrategy $finalFailureStrategy = FinalFailureStrategy::RESEND;
 
     private function __construct(private string $transportName)
     {
@@ -59,6 +62,13 @@ final class SymfonyMessengerMessageChannelBuilder implements MessageChannelBuild
         return $this;
     }
 
+    public function withFinalFailureStrategy(FinalFailureStrategy $finalFailureStrategy): self
+    {
+        $this->finalFailureStrategy = $finalFailureStrategy;
+
+        return $this;
+    }
+
     public function compile(MessagingContainerBuilder $builder): Definition
     {
         return new Definition(
@@ -69,6 +79,7 @@ final class SymfonyMessengerMessageChannelBuilder implements MessageChannelBuild
                     $this->headerMapper,
                     $this->acknowledgeMode,
                     new Reference(ConversionService::REFERENCE_NAME),
+                    $this->finalFailureStrategy,
                 ]),
             ]
         );


### PR DESCRIPTION
## Why is this change proposed?

### Overview
This PR introduces Final Failure Strategy configuration for MessageChannelBuilders, giving you control over what happens when message processing fails and there's no other way to handle the failure.

### What is Final Failure Strategy?

Defines how to handle failures when processing messages. This is final failure strategy as it's used in case, when there is no other way to handle the failure. For example, when there is no retry policy, or when the retry policy has reached its maximum number of attempts. Also, when the destination of Error Channel is not defined, or sending to Error Channel fails.

_**This is your last line of defense for handling message failures.**_

### Available configurations

- RESEND (default) - Message is requeued for another attempt	This is default strategy, this should be used to unblock processing. This way next messages can be consumed without system being stuck preventing next business actions from happening.
- IGNORE - Message is discarded, processing continues. Non-critical message.
- STOP - Consumer stops, message preserved. This strategy can be applied when our system depends heavily on the order of the Messages to work correctly. In that case we can stop the Consumer, resulting in Message being kept in order.

```php
// Analytics events - retry for eventual consistency
$analyticsChannel = SymfonyMessengerMessageChannelBuilder::create('analytics')
    ->withFinalFailureStrategy(FinalFailureStrategy::RESEND);
```

## Pull Request Contribution Terms

- [X] I have read and agree to the contribution terms outlined in [CONTRIBUTING](https://github.com/ecotoneframework/ecotone-dev/blob/main/CONTRIBUTING.md).