### PR TITLE
Kafka and Rabbit Consumers with advanced failures handling

### DIFF
--- a/packages/Amqp/examples/AmqpConsumerAttributeExample.php
+++ b/packages/Amqp/examples/AmqpConsumerAttributeExample.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Ecotone\Amqp\Examples;
 
-use Ecotone\Amqp\Attribute\AmqpConsumer;
+use Ecotone\Amqp\Attribute\RabbitConsumer;
 use Ecotone\Messaging\Attribute\Parameter\Payload;
 use Ecotone\Modelling\Attribute\QueryHandler;
 
@@ -23,7 +23,7 @@ final class AmqpConsumerAttributeExample
      * This method will consume messages from the 'order_queue' AMQP queue.
      * The endpointId 'order_processor' is used to identify this consumer.
      */
-    #[AmqpConsumer('order_processor', 'order_queue')]
+    #[RabbitConsumer('order_processor', 'order_queue')]
     public function processOrder(#[Payload] string $orderData): void
     {
         // Process the order

--- a/packages/Amqp/examples/AmqpConsumerAttributeExample.php
+++ b/packages/Amqp/examples/AmqpConsumerAttributeExample.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ecotone\Amqp\Examples;
+
+use Ecotone\Amqp\Attribute\AmqpConsumer;
+use Ecotone\Messaging\Attribute\Parameter\Payload;
+use Ecotone\Modelling\Attribute\QueryHandler;
+
+/**
+ * licence Enterprise
+ * 
+ * Example demonstrating the usage of AmqpConsumer attribute
+ * for consuming messages from AMQP queues.
+ */
+final class AmqpConsumerAttributeExample
+{
+    /** @var string[] */
+    private array $processedOrders = [];
+
+    /**
+     * This method will consume messages from the 'order_queue' AMQP queue.
+     * The endpointId 'order_processor' is used to identify this consumer.
+     */
+    #[AmqpConsumer('order_processor', 'order_queue')]
+    public function processOrder(#[Payload] string $orderData): void
+    {
+        // Process the order
+        $this->processedOrders[] = $orderData;
+        
+        // Your business logic here
+        echo "Processing order: " . $orderData . "\n";
+    }
+
+    /**
+     * Query handler to retrieve processed orders for testing/monitoring
+     */
+    #[QueryHandler('orders.getProcessed')]
+    public function getProcessedOrders(): array
+    {
+        return $this->processedOrders;
+    }
+}

--- a/packages/Amqp/src/Attribute/AmqpConsumer.php
+++ b/packages/Amqp/src/Attribute/AmqpConsumer.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ecotone\Amqp\Attribute;
+
+use Attribute;
+use Ecotone\Messaging\Attribute\MessageConsumer;
+use Ecotone\Messaging\Config\Container\DefinedObject;
+use Ecotone\Messaging\Config\Container\Definition;
+use Ecotone\Messaging\Endpoint\FinalFailureStrategy;
+use Ecotone\Messaging\Support\Assert;
+use Enqueue\AmqpExt\AmqpConnectionFactory;
+
+/**
+ * licence Enterprise
+ */
+#[Attribute]
+final class AmqpConsumer extends MessageConsumer implements DefinedObject
+{
+    public function __construct(
+        string $endpointId,
+        private string $queueName,
+        private FinalFailureStrategy $finalFailureStrategy = FinalFailureStrategy::STOP,
+        private string $connectionReference = AmqpConnectionFactory::class,
+    ) {
+        Assert::notNullAndEmpty($queueName, "Queue name can't be empty");
+
+        parent::__construct($endpointId);
+    }
+
+    public function getQueueName(): string
+    {
+        return $this->queueName;
+    }
+
+    public function getConnectionReference(): string
+    {
+        return $this->connectionReference;
+    }
+
+    public function getFinalFailureStrategy(): FinalFailureStrategy
+    {
+        return $this->finalFailureStrategy;
+    }
+
+    public function getDefinition(): Definition
+    {
+        return new Definition(
+            self::class,
+            [
+                $this->getEndpointId(),
+                $this->queueName,
+                $this->connectionReference,
+            ]
+        );
+    }
+}

--- a/packages/Amqp/src/Attribute/RabbitConsumer.php
+++ b/packages/Amqp/src/Attribute/RabbitConsumer.php
@@ -16,7 +16,7 @@ use Enqueue\AmqpExt\AmqpConnectionFactory;
  * licence Enterprise
  */
 #[Attribute]
-final class AmqpConsumer extends MessageConsumer implements DefinedObject
+final class RabbitConsumer extends MessageConsumer implements DefinedObject
 {
     public function __construct(
         string $endpointId,

--- a/packages/Amqp/src/Configuration/AmqpConsumerModule.php
+++ b/packages/Amqp/src/Configuration/AmqpConsumerModule.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Ecotone\Amqp\Configuration;
 
 use Ecotone\Amqp\AmqpInboundChannelAdapterBuilder;
-use Ecotone\Amqp\Attribute\AmqpConsumer;
+use Ecotone\Amqp\Attribute\RabbitConsumer;
 use Ecotone\AnnotationFinder\AnnotationFinder;
 use Ecotone\Messaging\Attribute\ModuleAnnotation;
 use Ecotone\Messaging\Config\Annotation\AnnotationModule;
@@ -24,7 +24,7 @@ use Enqueue\AmqpExt\AmqpConnectionFactory;
 final class AmqpConsumerModule extends NoExternalConfigurationModule implements AnnotationModule
 {
     /**
-     * @param AmqpConsumer[] $amqpConsumers
+     * @param RabbitConsumer[] $amqpConsumers
      */
     private function __construct(
         private array $amqpConsumers,
@@ -34,8 +34,8 @@ final class AmqpConsumerModule extends NoExternalConfigurationModule implements 
     public static function create(AnnotationFinder $annotationRegistrationService, InterfaceToCallRegistry $interfaceToCallRegistry): static
     {
         $amqpConsumers = [];
-        foreach ($annotationRegistrationService->findAnnotatedMethods(AmqpConsumer::class) as $annotatedMethod) {
-            /** @var AmqpConsumer $amqpConsumer */
+        foreach ($annotationRegistrationService->findAnnotatedMethods(RabbitConsumer::class) as $annotatedMethod) {
+            /** @var RabbitConsumer $amqpConsumer */
             $amqpConsumer = $annotatedMethod->getAnnotationForMethod();
 
             $amqpConsumers[$amqpConsumer->getEndpointId()] = $amqpConsumer;

--- a/packages/Amqp/src/Configuration/AmqpConsumerModule.php
+++ b/packages/Amqp/src/Configuration/AmqpConsumerModule.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ecotone\Amqp\Configuration;
+
+use Ecotone\Amqp\AmqpInboundChannelAdapterBuilder;
+use Ecotone\Amqp\Attribute\AmqpConsumer;
+use Ecotone\AnnotationFinder\AnnotationFinder;
+use Ecotone\Messaging\Attribute\ModuleAnnotation;
+use Ecotone\Messaging\Config\Annotation\AnnotationModule;
+use Ecotone\Messaging\Config\Annotation\ModuleConfiguration\NoExternalConfigurationModule;
+use Ecotone\Messaging\Config\Configuration;
+use Ecotone\Messaging\Config\ModulePackageList;
+use Ecotone\Messaging\Config\ModuleReferenceSearchService;
+use Ecotone\Messaging\Handler\InterfaceToCallRegistry;
+use Ecotone\Messaging\Support\LicensingException;
+use Enqueue\AmqpExt\AmqpConnectionFactory;
+
+/**
+ * licence Enterprise
+ */
+#[ModuleAnnotation]
+final class AmqpConsumerModule extends NoExternalConfigurationModule implements AnnotationModule
+{
+    /**
+     * @param AmqpConsumer[] $amqpConsumers
+     */
+    private function __construct(
+        private array $amqpConsumers,
+    ) {
+    }
+
+    public static function create(AnnotationFinder $annotationRegistrationService, InterfaceToCallRegistry $interfaceToCallRegistry): static
+    {
+        $amqpConsumers = [];
+        foreach ($annotationRegistrationService->findAnnotatedMethods(AmqpConsumer::class) as $annotatedMethod) {
+            /** @var AmqpConsumer $amqpConsumer */
+            $amqpConsumer = $annotatedMethod->getAnnotationForMethod();
+
+            $amqpConsumers[$amqpConsumer->getEndpointId()] = $amqpConsumer;
+        }
+
+        return new self($amqpConsumers);
+    }
+
+    public function prepare(Configuration $messagingConfiguration, array $extensionObjects, ModuleReferenceSearchService $moduleReferenceSearchService, InterfaceToCallRegistry $interfaceToCallRegistry): void
+    {
+        if (empty($this->amqpConsumers)) {
+            return;
+        }
+
+        if (! $messagingConfiguration->isRunningForEnterpriseLicence()) {
+            throw LicensingException::create('AmqpConsumer attribute is available only with Ecotone Enterprise licence.');
+        }
+
+        foreach ($this->amqpConsumers as $amqpConsumer) {
+            $messagingConfiguration->registerConsumer(
+                AmqpInboundChannelAdapterBuilder::createWith(
+                    $amqpConsumer->getEndpointId(),
+                    $amqpConsumer->getQueueName(),
+                    $amqpConsumer->getEndpointId(),
+                    $amqpConsumer->getConnectionReference(),
+                )
+                    ->withHeaderMapper("*")
+                    ->withFinalFailureStrategy($amqpConsumer->getFinalFailureStrategy())
+                    ->withDeclareOnStartup(true)
+            );
+        }
+    }
+
+    public function canHandle($extensionObject): bool
+    {
+        return false;
+    }
+
+    public function getModulePackageName(): string
+    {
+        return ModulePackageList::AMQP_PACKAGE;
+    }
+}

--- a/packages/Amqp/src/Configuration/AmqpModule.php
+++ b/packages/Amqp/src/Configuration/AmqpModule.php
@@ -9,7 +9,7 @@ use Ecotone\Amqp\AmqpBackedMessageChannelBuilder;
 use Ecotone\Amqp\AmqpBinding;
 use Ecotone\Amqp\AmqpExchange;
 use Ecotone\Amqp\AmqpQueue;
-use Ecotone\Amqp\Attribute\AmqpConsumer;
+use Ecotone\Amqp\Attribute\RabbitConsumer;
 use Ecotone\Amqp\Distribution\AmqpDistributionModule;
 use Ecotone\AnnotationFinder\AnnotationFinder;
 use Ecotone\Messaging\Attribute\ModuleAnnotation;
@@ -43,8 +43,8 @@ class AmqpModule implements AnnotationModule
     public static function create(AnnotationFinder $annotationRegistrationService, InterfaceToCallRegistry $interfaceToCallRegistry): static
     {
         $amqpQueues = [];
-        foreach ($annotationRegistrationService->findAnnotatedMethods(AmqpConsumer::class) as $annotatedMethod) {
-            /** @var AmqpConsumer $amqpConsumer */
+        foreach ($annotationRegistrationService->findAnnotatedMethods(RabbitConsumer::class) as $annotatedMethod) {
+            /** @var RabbitConsumer $amqpConsumer */
             $amqpConsumer = $annotatedMethod->getAnnotationForMethod();
 
             $amqpQueues[] = AmqpQueue::createWith($amqpConsumer->getQueueName());

--- a/packages/Amqp/tests/AmqpMessagingTestCase.php
+++ b/packages/Amqp/tests/AmqpMessagingTestCase.php
@@ -65,6 +65,7 @@ abstract class AmqpMessagingTestCase extends TestCase
         $this->deleteQueue(new AmqpQueue('ecotone_1_delay'));
         $this->deleteQueue(new AmqpQueue('async'));
         $this->deleteQueue(new AmqpQueue('notification_channel'));
+        $this->deleteQueue(new AmqpQueue('test_queue'));
     }
 
     private function deleteQueue(AmqpQueue $queue): void

--- a/packages/Amqp/tests/Fixture/AmqpConsumer/AmqpConsumerAttributeExample.php
+++ b/packages/Amqp/tests/Fixture/AmqpConsumer/AmqpConsumerAttributeExample.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Test\Ecotone\Amqp\Fixture\AmqpConsumer;
 
-use Ecotone\Amqp\Attribute\AmqpConsumer;
+use Ecotone\Amqp\Attribute\RabbitConsumer;
 use Ecotone\Messaging\Attribute\Parameter\Header;
 use Ecotone\Messaging\Attribute\Parameter\Payload;
 use Ecotone\Modelling\Attribute\QueryHandler;
@@ -17,7 +17,7 @@ final class AmqpConsumerAttributeExample
     /** @var string[] */
     private array $messagePayloads = [];
 
-    #[AmqpConsumer(
+    #[RabbitConsumer(
         endpointId: 'amqp_consumer_attribute',
         queueName: 'test_queue'
     )]

--- a/packages/Amqp/tests/Fixture/AmqpConsumer/AmqpConsumerAttributeExample.php
+++ b/packages/Amqp/tests/Fixture/AmqpConsumer/AmqpConsumerAttributeExample.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Ecotone\Amqp\Fixture\AmqpConsumer;
+
+use Ecotone\Amqp\Attribute\AmqpConsumer;
+use Ecotone\Messaging\Attribute\Parameter\Header;
+use Ecotone\Messaging\Attribute\Parameter\Payload;
+use Ecotone\Modelling\Attribute\QueryHandler;
+
+/**
+ * licence Enterprise
+ */
+final class AmqpConsumerAttributeExample
+{
+    /** @var string[] */
+    private array $messagePayloads = [];
+
+    #[AmqpConsumer(
+        endpointId: 'amqp_consumer_attribute',
+        queueName: 'test_queue')
+    ]
+    public function handle(#[Payload] string $payload, #[Header('fail')] bool $fail = false): void
+    {
+        if ($fail) {
+            throw new \RuntimeException('Failed');
+        }
+
+        $this->messagePayloads[] = $payload;
+    }
+
+    /**
+     * @return string[]
+     */
+    #[QueryHandler('consumer.getAttributeMessagePayloads')]
+    public function getMessagePayloads(): array
+    {
+        return $this->messagePayloads;
+    }
+}

--- a/packages/Amqp/tests/Fixture/AmqpConsumer/AmqpConsumerAttributeWithObject.php
+++ b/packages/Amqp/tests/Fixture/AmqpConsumer/AmqpConsumerAttributeWithObject.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Test\Ecotone\Amqp\Fixture\AmqpConsumer;
 
-use Ecotone\Amqp\Attribute\AmqpConsumer;
+use Ecotone\Amqp\Attribute\RabbitConsumer;
 use Ecotone\Messaging\Attribute\Parameter\Header;
 use Ecotone\Messaging\Attribute\Parameter\Payload;
 use Ecotone\Modelling\Attribute\QueryHandler;
@@ -17,7 +17,7 @@ final class AmqpConsumerAttributeWithObject
     /** @var string[] */
     private array $messagePayloads = [];
 
-    #[AmqpConsumer(
+    #[RabbitConsumer(
         endpointId: 'amqp_consumer_attribute',
         queueName: 'test_queue')
     ]

--- a/packages/Amqp/tests/Fixture/AmqpConsumer/AmqpConsumerAttributeWithObject.php
+++ b/packages/Amqp/tests/Fixture/AmqpConsumer/AmqpConsumerAttributeWithObject.php
@@ -12,21 +12,17 @@ use Ecotone\Modelling\Attribute\QueryHandler;
 /**
  * licence Enterprise
  */
-final class AmqpConsumerAttributeExample
+final class AmqpConsumerAttributeWithObject
 {
     /** @var string[] */
     private array $messagePayloads = [];
 
     #[AmqpConsumer(
         endpointId: 'amqp_consumer_attribute',
-        queueName: 'test_queue'
-    )]
-    public function handle(#[Payload] string $payload, #[Header('fail')] bool $fail = false): void
+        queueName: 'test_queue')
+    ]
+    public function handle(\stdClass $payload): void
     {
-        if ($fail) {
-            throw new \RuntimeException('Failed');
-        }
-
         $this->messagePayloads[] = $payload;
     }
 

--- a/packages/Amqp/tests/Fixture/AmqpConsumer/AmqpConsumerWithFailStrategyAttributeExample.php
+++ b/packages/Amqp/tests/Fixture/AmqpConsumer/AmqpConsumerWithFailStrategyAttributeExample.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Ecotone\Amqp\Fixture\AmqpConsumer;
+
+use Ecotone\Amqp\Attribute\AmqpConsumer;
+use Ecotone\Messaging\Attribute\Parameter\Header;
+use Ecotone\Messaging\Attribute\Parameter\Payload;
+use Ecotone\Messaging\Endpoint\FinalFailureStrategy;
+use Ecotone\Modelling\Attribute\QueryHandler;
+
+/**
+ * licence Enterprise
+ */
+final class AmqpConsumerWithFailStrategyAttributeExample
+{
+    /** @var string[] */
+    private array $messagePayloads = [];
+
+    #[AmqpConsumer('amqp_consumer_attribute', 'test_queue', finalFailureStrategy: FinalFailureStrategy::IGNORE)]
+    public function handle(#[Payload] string $payload, #[Header('fail')] bool $fail = false): void
+    {
+        if ($fail) {
+            throw new \RuntimeException('Failed');
+        }
+
+        $this->messagePayloads[] = $payload;
+    }
+
+    /**
+     * @return string[]
+     */
+    #[QueryHandler('consumer.getAttributeMessagePayloads')]
+    public function getMessagePayloads(): array
+    {
+        return $this->messagePayloads;
+    }
+}

--- a/packages/Amqp/tests/Fixture/AmqpConsumer/AmqpConsumerWithFailStrategyAttributeExample.php
+++ b/packages/Amqp/tests/Fixture/AmqpConsumer/AmqpConsumerWithFailStrategyAttributeExample.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Test\Ecotone\Amqp\Fixture\AmqpConsumer;
 
-use Ecotone\Amqp\Attribute\AmqpConsumer;
+use Ecotone\Amqp\Attribute\RabbitConsumer;
 use Ecotone\Messaging\Attribute\Parameter\Header;
 use Ecotone\Messaging\Attribute\Parameter\Payload;
 use Ecotone\Messaging\Endpoint\FinalFailureStrategy;
@@ -18,7 +18,7 @@ final class AmqpConsumerWithFailStrategyAttributeExample
     /** @var string[] */
     private array $messagePayloads = [];
 
-    #[AmqpConsumer('amqp_consumer_attribute', 'test_queue', finalFailureStrategy: FinalFailureStrategy::IGNORE)]
+    #[RabbitConsumer('amqp_consumer_attribute', 'test_queue', finalFailureStrategy: FinalFailureStrategy::IGNORE)]
     public function handle(#[Payload] string $payload, #[Header('fail')] bool $fail = false): void
     {
         if ($fail) {

--- a/packages/Amqp/tests/Fixture/AmqpConsumer/AmqpConsumerWithInstantRetryAndErrorChannelExample.php
+++ b/packages/Amqp/tests/Fixture/AmqpConsumer/AmqpConsumerWithInstantRetryAndErrorChannelExample.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Ecotone\Amqp\Fixture\AmqpConsumer;
+
+use Ecotone\Amqp\Attribute\RabbitConsumer;
+use Ecotone\Messaging\Attribute\ErrorChannel;
+use Ecotone\Messaging\Attribute\Parameter\Header;
+use Ecotone\Messaging\Attribute\Parameter\Payload;
+use Ecotone\Messaging\Endpoint\FinalFailureStrategy;
+use Ecotone\Modelling\Attribute\InstantRetry;
+use Ecotone\Modelling\Attribute\QueryHandler;
+
+/**
+ * licence Enterprise
+ */
+final class AmqpConsumerWithInstantRetryAndErrorChannelExample
+{
+    /** @var string[] */
+    private array $messagePayloads = [];
+
+    #[InstantRetry(retryTimes: 1)]
+    #[ErrorChannel('customErrorChannel')]
+    #[RabbitConsumer('amqp_consumer_attribute', 'test_queue', finalFailureStrategy: FinalFailureStrategy::RESEND)]
+    public function handle(#[Payload] string $payload, #[Header('fail')] bool $fail = false): void
+    {
+        $this->messagePayloads[] = $payload;
+
+        if ($fail) {
+            throw new \RuntimeException('Failed');
+        }
+    }
+
+    /**
+     * @return string[]
+     */
+    #[QueryHandler('consumer.getAttributeMessagePayloads')]
+    public function getMessagePayloads(): array
+    {
+        return $this->messagePayloads;
+    }
+}

--- a/packages/Amqp/tests/Fixture/AmqpConsumer/AmqpConsumerWithInstantRetryExample.php
+++ b/packages/Amqp/tests/Fixture/AmqpConsumer/AmqpConsumerWithInstantRetryExample.php
@@ -8,16 +8,18 @@ use Ecotone\Amqp\Attribute\RabbitConsumer;
 use Ecotone\Messaging\Attribute\Parameter\Header;
 use Ecotone\Messaging\Attribute\Parameter\Payload;
 use Ecotone\Messaging\Endpoint\FinalFailureStrategy;
+use Ecotone\Modelling\Attribute\InstantRetry;
 use Ecotone\Modelling\Attribute\QueryHandler;
 
 /**
  * licence Enterprise
  */
-final class AmqpConsumerWithFailStrategyAttributeExample
+final class AmqpConsumerWithInstantRetryExample
 {
     /** @var string[] */
     private array $messagePayloads = [];
 
+    #[InstantRetry(retryTimes: 1)]
     #[RabbitConsumer('amqp_consumer_attribute', 'test_queue', finalFailureStrategy: FinalFailureStrategy::IGNORE)]
     public function handle(#[Payload] string $payload, #[Header('fail')] bool $fail = false): void
     {

--- a/packages/Amqp/tests/Integration/AmqpConsumerAttributeTest.php
+++ b/packages/Amqp/tests/Integration/AmqpConsumerAttributeTest.php
@@ -1,0 +1,196 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Ecotone\Amqp\Integration;
+
+use Ecotone\Amqp\AmqpQueue;
+use Ecotone\Amqp\Attribute\AmqpConsumer;
+use Ecotone\Amqp\Publisher\AmqpMessagePublisherConfiguration;
+use Ecotone\Lite\EcotoneLite;
+use Ecotone\Messaging\Config\ModulePackageList;
+use Ecotone\Messaging\Config\ServiceConfiguration;
+use Ecotone\Messaging\Endpoint\ExecutionPollingMetadata;
+use Ecotone\Messaging\MessagePublisher;
+use Ecotone\Messaging\Support\LicensingException;
+use Ecotone\Test\LicenceTesting;
+use Enqueue\AmqpExt\AmqpConnectionFactory;
+use PHPUnit\Framework\Attributes\CoversClass;
+use Ramsey\Uuid\Uuid;
+use Test\Ecotone\Amqp\AmqpMessagingTestCase;
+use Test\Ecotone\Amqp\Fixture\AmqpConsumer\AmqpConsumerAttributeExample;
+use Test\Ecotone\Amqp\Fixture\AmqpConsumer\AmqpConsumerWithFailStrategyAttributeExample;
+
+/**
+ * @internal
+ */
+/**
+ * licence Enterprise
+ * @internal
+ */
+#[CoversClass(AmqpConsumer::class)]
+final class AmqpConsumerAttributeTest extends AmqpMessagingTestCase
+{
+    public function test_throwing_exception_if_no_licence_for_amqp_consumer_attribute(): void
+    {
+        $this->expectException(LicensingException::class);
+
+        EcotoneLite::bootstrapFlowTesting(
+            [AmqpConsumerAttributeExample::class],
+            [
+                new AmqpConsumerAttributeExample(),
+                AmqpConnectionFactory::class => $this->getCachedConnectionFactory(),
+            ],
+            ServiceConfiguration::createWithDefaults()
+                ->withSkippedModulePackageNames(ModulePackageList::allPackagesExcept([ModulePackageList::AMQP_PACKAGE]))
+        );
+    }
+
+    public function test_having_consumer_without_publisher(): void
+    {
+        $endpointId = 'amqp_consumer_attribute';
+        $queueName = 'test_queue';
+        $ecotoneLiteConsumer = EcotoneLite::bootstrapFlowTesting(
+            [AmqpConsumerAttributeExample::class],
+            [
+                new AmqpConsumerAttributeExample(),
+                AmqpConnectionFactory::class => $this->getCachedConnectionFactory(),
+            ],
+            ServiceConfiguration::createWithDefaults()
+                ->withSkippedModulePackageNames(ModulePackageList::allPackagesExcept([ModulePackageList::AMQP_PACKAGE])),
+            licenceKey: LicenceTesting::VALID_LICENCE
+        );
+        $ecotoneLitePublisher = EcotoneLite::bootstrapFlowTesting(
+            [],
+            [
+                AmqpConnectionFactory::class => $this->getCachedConnectionFactory(),
+            ],
+            ServiceConfiguration::createWithDefaults()
+                ->withSkippedModulePackageNames(ModulePackageList::allPackagesExcept([ModulePackageList::AMQP_PACKAGE]))
+                ->withExtensionObjects([
+                    AmqpQueue::createWith($queueName),
+                    AmqpMessagePublisherConfiguration::create()
+                        ->withAutoDeclareQueueOnSend(true)
+                        ->withDefaultRoutingKey($queueName),
+                ]),
+            licenceKey: LicenceTesting::VALID_LICENCE
+        );
+
+        $payload = Uuid::uuid4()->toString();
+        $messagePublisher = $ecotoneLitePublisher->getGateway(MessagePublisher::class);
+        $messagePublisher->send($payload);
+
+        $ecotoneLiteConsumer->run($endpointId, ExecutionPollingMetadata::createWithDefaults()->withHandledMessageLimit(1)->withExecutionTimeLimitInMilliseconds(1));
+        $this->assertEquals([$payload], $ecotoneLiteConsumer->sendQueryWithRouting('consumer.getAttributeMessagePayloads'));
+
+        // Test that message is not consumed again
+        $ecotoneLiteConsumer->run($endpointId, ExecutionPollingMetadata::createWithDefaults()->withHandledMessageLimit(1)->withExecutionTimeLimitInMilliseconds(1));
+        $this->assertEquals([$payload], $ecotoneLiteConsumer->sendQueryWithRouting('consumer.getAttributeMessagePayloads'));
+    }
+
+    public function test_adding_product_to_shopping_cart_with_publisher_and_consumer(): void
+    {
+        $endpointId = 'amqp_consumer_attribute';
+        $queueName = 'test_queue';
+        $ecotoneLite = EcotoneLite::bootstrapFlowTesting(
+            [AmqpConsumerAttributeExample::class],
+            [
+                new AmqpConsumerAttributeExample(),
+                AmqpConnectionFactory::class => $this->getCachedConnectionFactory(),
+            ],
+            ServiceConfiguration::createWithDefaults()
+                ->withEnvironment('prod')
+                ->withSkippedModulePackageNames(ModulePackageList::allPackagesExcept([ModulePackageList::AMQP_PACKAGE]))
+                ->withExtensionObjects([
+                    AmqpQueue::createWith($queueName),
+                    AmqpMessagePublisherConfiguration::create()
+                        ->withAutoDeclareQueueOnSend(true)
+                        ->withDefaultRoutingKey($queueName),
+                ]),
+            licenceKey: LicenceTesting::VALID_LICENCE
+        );
+
+        $payload = Uuid::uuid4()->toString();
+        $messagePublisher = $ecotoneLite->getGateway(MessagePublisher::class);
+        $messagePublisher->send($payload);
+
+        $ecotoneLite->run($endpointId, ExecutionPollingMetadata::createWithDefaults()->withHandledMessageLimit(1)->withExecutionTimeLimitInMilliseconds(1));
+        $this->assertEquals([$payload], $ecotoneLite->sendQueryWithRouting('consumer.getAttributeMessagePayloads'));
+
+        // Test that message is not consumed again
+        $ecotoneLite->run($endpointId, ExecutionPollingMetadata::createWithDefaults()->withHandledMessageLimit(1)->withExecutionTimeLimitInMilliseconds(1));
+        $this->assertEquals([$payload], $ecotoneLite->sendQueryWithRouting('consumer.getAttributeMessagePayloads'));
+    }
+
+    public function test_defining_custom_failure_strategy(): void
+    {
+        $endpointId = 'amqp_consumer_attribute';
+        $queueName = 'test_queue';
+        $ecotoneLite = EcotoneLite::bootstrapFlowTesting(
+            [AmqpConsumerWithFailStrategyAttributeExample::class],
+            [
+                new AmqpConsumerWithFailStrategyAttributeExample(),
+                AmqpConnectionFactory::class => $this->getCachedConnectionFactory(),
+            ],
+            ServiceConfiguration::createWithDefaults()
+                ->withEnvironment('prod')
+                ->withSkippedModulePackageNames(ModulePackageList::allPackagesExcept([ModulePackageList::AMQP_PACKAGE]))
+                ->withExtensionObjects([
+                    AmqpQueue::createWith($queueName),
+                    AmqpMessagePublisherConfiguration::create()
+                        ->withAutoDeclareQueueOnSend(true)
+                        ->withHeaderMapper("*")
+                        ->withDefaultRoutingKey($queueName),
+                ]),
+            licenceKey: LicenceTesting::VALID_LICENCE
+        );
+
+        $payload = Uuid::uuid4()->toString();
+        $messagePublisher = $ecotoneLite->getGateway(MessagePublisher::class);
+        $messagePublisher->sendWithMetadata($payload, metadata: ['fail' => true]);
+
+        $ecotoneLite->run($endpointId, ExecutionPollingMetadata::createWithTestingSetup(failAtError: false));
+        $this->assertEquals([], $ecotoneLite->sendQueryWithRouting('consumer.getAttributeMessagePayloads'));
+
+        // Test that message is not consumed again
+        $ecotoneLite->run($endpointId, ExecutionPollingMetadata::createWithTestingSetup(failAtError: true));
+        $this->assertEquals([], $ecotoneLite->sendQueryWithRouting('consumer.getAttributeMessagePayloads'));
+    }
+
+    public function test_consuming_multiple_messages_from_queue(): void
+    {
+        $endpointId = 'amqp_consumer_attribute';
+        $queueName = 'test_queue';
+        $ecotoneLite = EcotoneLite::bootstrapFlowTesting(
+            [AmqpConsumerAttributeExample::class],
+            [
+                new AmqpConsumerAttributeExample(),
+                AmqpConnectionFactory::class => $this->getCachedConnectionFactory(),
+            ],
+            ServiceConfiguration::createWithDefaults()
+                ->withEnvironment('prod')
+                ->withSkippedModulePackageNames(ModulePackageList::allPackagesExcept([ModulePackageList::AMQP_PACKAGE]))
+                ->withExtensionObjects([
+                    AmqpQueue::createWith($queueName),
+                    AmqpMessagePublisherConfiguration::create()
+                        ->withAutoDeclareQueueOnSend(true)
+                        ->withDefaultRoutingKey($queueName),
+                ]),
+            licenceKey: LicenceTesting::VALID_LICENCE
+        );
+
+        $payload1 = 'message1';
+        $payload2 = 'message2';
+        $messagePublisher = $ecotoneLite->getGateway(MessagePublisher::class);
+        $messagePublisher->send($payload1);
+        $messagePublisher->send($payload2);
+
+        // Consume first message
+        $ecotoneLite->run($endpointId, ExecutionPollingMetadata::createWithDefaults()->withHandledMessageLimit(1)->withExecutionTimeLimitInMilliseconds(1));
+        $this->assertEquals([$payload1], $ecotoneLite->sendQueryWithRouting('consumer.getAttributeMessagePayloads'));
+
+        // Consume second message
+        $ecotoneLite->run($endpointId, ExecutionPollingMetadata::createWithDefaults()->withHandledMessageLimit(1)->withExecutionTimeLimitInMilliseconds(1));
+        $this->assertEquals([$payload1, $payload2], $ecotoneLite->sendQueryWithRouting('consumer.getAttributeMessagePayloads'));
+    }
+}

--- a/packages/Amqp/tests/Integration/AmqpConsumerAttributeTest.php
+++ b/packages/Amqp/tests/Integration/AmqpConsumerAttributeTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Test\Ecotone\Amqp\Integration;
 
 use Ecotone\Amqp\AmqpQueue;
-use Ecotone\Amqp\Attribute\AmqpConsumer;
+use Ecotone\Amqp\Attribute\RabbitConsumer;
 use Ecotone\Amqp\Publisher\AmqpMessagePublisherConfiguration;
 use Ecotone\Lite\EcotoneLite;
 use Ecotone\Messaging\Attribute\Converter;
@@ -33,7 +33,7 @@ use Test\Ecotone\Amqp\Fixture\AmqpConsumer\AmqpConsumerWithFailStrategyAttribute
  * licence Enterprise
  * @internal
  */
-#[CoversClass(AmqpConsumer::class)]
+#[CoversClass(RabbitConsumer::class)]
 final class AmqpConsumerAttributeTest extends AmqpMessagingTestCase
 {
     public function test_throwing_exception_if_no_licence_for_amqp_consumer_attribute(): void

--- a/packages/Ecotone/src/AnnotationFinder/AnnotatedMethod.php
+++ b/packages/Ecotone/src/AnnotationFinder/AnnotatedMethod.php
@@ -2,6 +2,8 @@
 
 namespace Ecotone\AnnotationFinder;
 
+use Ecotone\Messaging\Config\Container\AttributeDefinition;
+use Ecotone\Messaging\Config\Container\DefinitionHelper;
 use Ecotone\Messaging\Handler\TypeDescriptor;
 use InvalidArgumentException;
 
@@ -66,6 +68,27 @@ class AnnotatedMethod implements AnnotatedFinding
     public function getMethodAnnotations(): array
     {
         return $this->methodAnnotations;
+    }
+
+    /**
+     * @return AttributeDefinition[]
+     */
+    public function getAllAnnotationDefinitions(): array
+    {
+        $annotations = [];
+        foreach ($this->classAnnotations as $endpointAnnotation) {
+            if ($this->hasMethodAnnotation($endpointAnnotation->getClassName())) {
+                continue;
+            }
+
+            $annotations[] = AttributeDefinition::fromObject($endpointAnnotation);
+        }
+
+        foreach ($this->methodAnnotations as $methodAnnotation) {
+            $annotations[] = AttributeDefinition::fromObject($methodAnnotation);
+        }
+
+       return $annotations;
     }
 
     public function hasMethodAnnotation(string|TypeDescriptor $type): bool
@@ -138,6 +161,14 @@ class AnnotatedMethod implements AnnotatedFinding
         }
 
         return $this->getClassAnnotationsWithType($type);
+    }
+
+    /**
+     * @return AttributeDefinition[]
+     */
+    public function getAttributeDefinitions(): array
+    {
+        $object = [];
     }
 
     public function hasClassAnnotation(string|TypeDescriptor $type): bool

--- a/packages/Ecotone/src/Messaging/Attribute/ErrorChannel.php
+++ b/packages/Ecotone/src/Messaging/Attribute/ErrorChannel.php
@@ -10,7 +10,7 @@ use Ecotone\Messaging\Support\Assert;
 /**
  * licence Enterprise
  */
-#[Attribute(Attribute::TARGET_CLASS)]
+#[Attribute(Attribute::TARGET_CLASS | Attribute::TARGET_METHOD)]
 class ErrorChannel
 {
     /**

--- a/packages/Ecotone/src/Messaging/Config/Container/AttributeDefinition.php
+++ b/packages/Ecotone/src/Messaging/Config/Container/AttributeDefinition.php
@@ -17,8 +17,17 @@ class AttributeDefinition extends Definition
         );
     }
 
+    public static function fromObject(object $attribute): self
+    {
+        return DefinitionHelper::buildAttributeDefinitionFromInstance($attribute);
+    }
+
     public function instance(): object
     {
+        if ($this->hasFactory()) {
+            return DefinitionHelper::unserializeSerializedObject($this->arguments[0]);
+        }
+
         return new $this->className(...$this->arguments);
     }
 }

--- a/packages/Ecotone/src/Messaging/Config/Container/DefinitionHelper.php
+++ b/packages/Ecotone/src/Messaging/Config/Container/DefinitionHelper.php
@@ -23,6 +23,11 @@ class DefinitionHelper
         return new Definition(get_class($object), [serialize($object)], [self::class, 'unserializeSerializedObject']);
     }
 
+    public static function buildAttributeDefinitionFromInstance(object $object): AttributeDefinition
+    {
+        return new AttributeDefinition(get_class($object), [serialize($object)], [self::class, 'unserializeSerializedObject']);
+    }
+
     public static function unserializeSerializedObject(string $serializedObject): object
     {
         return unserialize($serializedObject);

--- a/packages/Ecotone/src/Messaging/Config/ModuleClassList.php
+++ b/packages/Ecotone/src/Messaging/Config/ModuleClassList.php
@@ -2,6 +2,7 @@
 
 namespace Ecotone\Messaging\Config;
 
+use Ecotone\Amqp\Configuration\AmqpConsumerModule;
 use Ecotone\Amqp\Configuration\AmqpMessageConsumerModule;
 use Ecotone\Amqp\Configuration\AmqpModule;
 use Ecotone\Amqp\Publisher\AmqpMessagePublisherModule;
@@ -119,6 +120,7 @@ class ModuleClassList
         AmqpMessagePublisherModule::class,
         AmqpModule::class,
         AmqpMessageConsumerModule::class,
+        AmqpConsumerModule::class,
     ];
 
     public const DBAL_MODULES = [

--- a/packages/Ecotone/src/Messaging/Config/ModuleClassList.php
+++ b/packages/Ecotone/src/Messaging/Config/ModuleClassList.php
@@ -2,7 +2,7 @@
 
 namespace Ecotone\Messaging\Config;
 
-use Ecotone\Amqp\Configuration\AmqpConsumerModule;
+use Ecotone\Amqp\Configuration\RabbitConsumerModule;
 use Ecotone\Amqp\Configuration\AmqpMessageConsumerModule;
 use Ecotone\Amqp\Configuration\AmqpModule;
 use Ecotone\Amqp\Publisher\AmqpMessagePublisherModule;
@@ -120,7 +120,7 @@ class ModuleClassList
         AmqpMessagePublisherModule::class,
         AmqpModule::class,
         AmqpMessageConsumerModule::class,
-        AmqpConsumerModule::class,
+        RabbitConsumerModule::class,
     ];
 
     public const DBAL_MODULES = [

--- a/packages/Ecotone/src/Messaging/Handler/Gateway/EnterpriseGatewayErrorChannelResolver.php
+++ b/packages/Ecotone/src/Messaging/Handler/Gateway/EnterpriseGatewayErrorChannelResolver.php
@@ -13,10 +13,16 @@ use Ecotone\Messaging\Handler\TypeDescriptor;
  */
 final class EnterpriseGatewayErrorChannelResolver implements GatewayErrorChannelResolver
 {
-    public function getErrorChannel(InterfaceToCall $interfaceToCall, ?string $errorChannelName): ?string
+    public function getErrorChannel(InterfaceToCall $interfaceToCall, array $endpointAnnotations, ?string $errorChannelName): ?string
     {
         if ($errorChannelName) {
             return $errorChannelName;
+        }
+
+        foreach ($endpointAnnotations as $endpointAnnotation) {
+            if ($endpointAnnotation->getClassName() === ErrorChannel::class) {
+                return $endpointAnnotation->instance()->errorChannelName;
+            }
         }
 
         /** @var ErrorChannel[] $errorChannel */
@@ -25,10 +31,16 @@ final class EnterpriseGatewayErrorChannelResolver implements GatewayErrorChannel
         return $errorChannel ? $errorChannel[0]->errorChannelName : null;
     }
 
-    public function getErrorChannelRoutingSlip(InterfaceToCall $interfaceToCall, string $requestChannelName): ?string
+    public function getErrorChannelRoutingSlip(InterfaceToCall $interfaceToCall, array $endpointAnnotations, string $requestChannelName): ?string
     {
         /** @var ErrorChannel[] $errorChannelAttributes */
         $errorChannelAttributes = $interfaceToCall->getAnnotationsByImportanceOrder(TypeDescriptor::create(ErrorChannel::class));
+
+        foreach ($endpointAnnotations as $endpointAnnotation) {
+            if ($endpointAnnotation->getClassName() === ErrorChannel::class) {
+                return $requestChannelName;
+            }
+        }
 
         if ($errorChannelAttributes) {
             return $requestChannelName;

--- a/packages/Ecotone/src/Messaging/Handler/Gateway/GatewayErrorChannelResolver.php
+++ b/packages/Ecotone/src/Messaging/Handler/Gateway/GatewayErrorChannelResolver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Ecotone\Messaging\Handler\Gateway;
 
+use Ecotone\Messaging\Config\Container\AttributeDefinition;
 use Ecotone\Messaging\Handler\InterfaceToCall;
 
 /**
@@ -15,17 +16,19 @@ interface GatewayErrorChannelResolver
      * Resolves the error channel name for a gateway method
      *
      * @param InterfaceToCall $interfaceToCall The interface method being called
+     * @param AttributeDefinition[] $endpointAnnotations The endpoint annotations
      * @param string|null $errorChannelName The error channel name set via withErrorChannel()
      * @return string|null The resolved error channel name or null if no error channel
      */
-    public function getErrorChannel(InterfaceToCall $interfaceToCall, ?string $errorChannelName): ?string;
+    public function getErrorChannel(InterfaceToCall $interfaceToCall, array $endpointAnnotations, ?string $errorChannelName): ?string;
 
     /**
      * Resolves the error channel routing slip for a gateway method
      *
      * @param InterfaceToCall $interfaceToCall The interface method being called
+     * @param AttributeDefinition[] $endpointAnnotations The endpoint annotations
      * @param string $requestChannelName The request channel name
      * @return string|null The routing slip channel name or null if no routing slip needed
      */
-    public function getErrorChannelRoutingSlip(InterfaceToCall $interfaceToCall, string $requestChannelName): ?string;
+    public function getErrorChannelRoutingSlip(InterfaceToCall $interfaceToCall, array $endpointAnnotations, string $requestChannelName): ?string;
 }

--- a/packages/Ecotone/src/Messaging/Handler/Gateway/GatewayProxyBuilder.php
+++ b/packages/Ecotone/src/Messaging/Handler/Gateway/GatewayProxyBuilder.php
@@ -306,7 +306,7 @@ class GatewayProxyBuilder implements InterceptedEndpoint, CompilableBuilder, Pro
             Assert::isTrue(is_a($requestChannelDefinition->getClassName(), SubscribableChannel::class, true), 'Gateway request channel should not be pollable if expected return type is not nullable');
         }
 
-        $errorChannelName = $errorChannelResolver->getErrorChannel($interfaceToCall, $this->errorChannelName);
+        $errorChannelName = $errorChannelResolver->getErrorChannel($interfaceToCall, $this->endpointAnnotations, $this->errorChannelName);
         if (! $interfaceToCall->canItReturnNull() && $errorChannelName && ! $interfaceToCall->hasReturnTypeVoid()) {
             throw InvalidArgumentException::create("Gateway {$interfaceToCall} with error channel must allow nullable return type");
         }
@@ -377,9 +377,9 @@ class GatewayProxyBuilder implements InterceptedEndpoint, CompilableBuilder, Pro
         $interfaceToCall = $builder->getInterfaceToCall($interfaceToCallReference);
 
         $aroundInterceptors = $this->aroundInterceptors;
-        $errorChannelName = $errorChannelResolver->getErrorChannel($interfaceToCall, $this->errorChannelName);
+        $errorChannelName = $errorChannelResolver->getErrorChannel($interfaceToCall, $this->endpointAnnotations, $this->errorChannelName);
         if ($errorChannelName) {
-            $errorChannelRoutingSlip = $errorChannelResolver->getErrorChannelRoutingSlip($interfaceToCall, $this->requestChannelName);
+            $errorChannelRoutingSlip = $errorChannelResolver->getErrorChannelRoutingSlip($interfaceToCall, $this->endpointAnnotations, $this->requestChannelName);
 
             $interceptorReference = $builder->register(
                 Uuid::uuid4()->toString(),

--- a/packages/Ecotone/src/Messaging/Handler/Gateway/StandardGatewayErrorChannelResolver.php
+++ b/packages/Ecotone/src/Messaging/Handler/Gateway/StandardGatewayErrorChannelResolver.php
@@ -14,7 +14,7 @@ use Ecotone\Messaging\Support\LicensingException;
  */
 final class StandardGatewayErrorChannelResolver implements GatewayErrorChannelResolver
 {
-    public function getErrorChannel(InterfaceToCall $interfaceToCall, ?string $errorChannelName): ?string
+    public function getErrorChannel(InterfaceToCall $interfaceToCall, array $endpointAnnotations, ?string $errorChannelName): ?string
     {
         $errorChannelAttributes = $interfaceToCall->getAnnotationsByImportanceOrder(TypeDescriptor::create(ErrorChannel::class));
         if ($errorChannelAttributes) {
@@ -24,7 +24,7 @@ final class StandardGatewayErrorChannelResolver implements GatewayErrorChannelRe
         return $errorChannelName;
     }
 
-    public function getErrorChannelRoutingSlip(InterfaceToCall $interfaceToCall, string $requestChannelName): ?string
+    public function getErrorChannelRoutingSlip(InterfaceToCall $interfaceToCall, array $endpointAnnotations, string $requestChannelName): ?string
     {
         return null;
     }

--- a/packages/Ecotone/src/Modelling/Attribute/InstantRetry.php
+++ b/packages/Ecotone/src/Modelling/Attribute/InstantRetry.php
@@ -9,7 +9,7 @@ use Attribute;
 /**
  * licence Enterprise
  */
-#[Attribute(Attribute::TARGET_CLASS)]
+#[Attribute(Attribute::TARGET_CLASS|Attribute::TARGET_METHOD)]
 class InstantRetry
 {
     /**

--- a/packages/Ecotone/src/Modelling/Config/InstantRetry/InstantRetryAttributeModule.php
+++ b/packages/Ecotone/src/Modelling/Config/InstantRetry/InstantRetryAttributeModule.php
@@ -3,9 +3,12 @@
 namespace Ecotone\Modelling\Config\InstantRetry;
 
 use Ecotone\AnnotationFinder\AnnotationFinder;
+use Ecotone\Messaging\Attribute\AsynchronousRunningEndpoint;
+use Ecotone\Messaging\Attribute\MessageConsumer;
 use Ecotone\Messaging\Attribute\ModuleAnnotation;
 use Ecotone\Messaging\Config\Annotation\AnnotationModule;
 use Ecotone\Messaging\Config\Configuration;
+use Ecotone\Messaging\Config\ConfigurationException;
 use Ecotone\Messaging\Config\Container\Definition;
 use Ecotone\Messaging\Config\Container\Reference;
 use Ecotone\Messaging\Config\ModulePackageList;
@@ -15,6 +18,7 @@ use Ecotone\Messaging\Handler\InterfaceToCallRegistry;
 use Ecotone\Messaging\Handler\Processor\MethodInvoker\AroundInterceptorBuilder;
 use Ecotone\Messaging\Handler\TypeDescriptor;
 use Ecotone\Messaging\Precedence;
+use Ecotone\Messaging\Support\Assert;
 use Ecotone\Messaging\Support\LicensingException;
 use Ecotone\Modelling\Attribute\InstantRetry;
 use Ecotone\Modelling\CommandBus;
@@ -27,11 +31,19 @@ use Ramsey\Uuid\Uuid;
  */
 final class InstantRetryAttributeModule implements AnnotationModule
 {
+    /**
+     * @var array<string, InstantRetry> $commandBusesWithInstantRetry key is interface name, value is InstantRetry attribute
+     */
     private array $commandBusesWithInstantRetry;
+    /**
+     * @var array<string, InstantRetry> $asynchronousEndpointsWithInstantRetry key is endpoint id
+     */
+    private array $asynchronousEndpointsWithInstantRetry;
 
-    private function __construct(array $commandBusesWithInstantRetry)
+    private function __construct(array $commandBusesWithInstantRetry, array $asynchronousEndpointsWithInstantRetry)
     {
         $this->commandBusesWithInstantRetry = $commandBusesWithInstantRetry;
+        $this->asynchronousEndpointsWithInstantRetry = $asynchronousEndpointsWithInstantRetry;
     }
 
     /**
@@ -44,7 +56,7 @@ final class InstantRetryAttributeModule implements AnnotationModule
 
         foreach ($annotatedInterfaces as $annotatedInterface) {
             if (! is_subclass_of($annotatedInterface, CommandBus::class)) {
-                throw new InvalidArgumentException(sprintf(
+                throw new ConfigurationException(sprintf(
                     "InstantRetry attribute can only be used on interfaces extending CommandBus. '%s' does not extend CommandBus.",
                     $annotatedInterface
                 ));
@@ -54,7 +66,22 @@ final class InstantRetryAttributeModule implements AnnotationModule
             $commandBusesWithInstantRetry[$annotatedInterface] = $instantRetryAttribute;
         }
 
-        return new self($commandBusesWithInstantRetry);
+        $asynchronousEndpointsWithInstantRetry = [];
+        $annotatedMethods = $annotationRegistrationService->findAnnotatedMethods(InstantRetry::class);
+        foreach ($annotatedMethods as $annotatedMethod) {
+            if (!$annotatedMethod->hasMethodAnnotation(MessageConsumer::class)) {
+                throw new ConfigurationException(sprintf(
+                    "InstantRetry attribute can only be used on methods annotated with MessageConsumer. '%s' is not annotated with MessageConsumer (e.g. RabbitConsumer, KafkaConsumer).",
+                    $annotatedMethod->getClassName() . '::' . $annotatedMethod->getMethodName()
+                ));
+            }
+
+            /** @var MessageConsumer $messageConsumer */
+            $messageConsumer = $annotatedMethod->getMethodAnnotationsWithType(MessageConsumer::class)[0];
+            $asynchronousEndpointsWithInstantRetry[$messageConsumer->getEndpointId()] = $annotatedMethod->getAnnotationForMethod();
+        }
+
+        return new self($commandBusesWithInstantRetry, $asynchronousEndpointsWithInstantRetry);
     }
 
     /**
@@ -62,7 +89,7 @@ final class InstantRetryAttributeModule implements AnnotationModule
      */
     public function prepare(Configuration $messagingConfiguration, array $extensionObjects, ModuleReferenceSearchService $moduleReferenceSearchService, InterfaceToCallRegistry $interfaceToCallRegistry): void
     {
-        if (empty($this->commandBusesWithInstantRetry)) {
+        if (empty($this->commandBusesWithInstantRetry) && empty($this->asynchronousEndpointsWithInstantRetry)) {
             return;
         }
 
@@ -79,6 +106,19 @@ final class InstantRetryAttributeModule implements AnnotationModule
                 $instantRetryAttribute->exceptions,
                 TypeDescriptor::create($commandBusInterface)->toString(),
                 Precedence::CUSTOM_INSTANT_RETRY_PRECEDENCE,
+                null,
+            );
+        }
+
+        foreach ($this->asynchronousEndpointsWithInstantRetry as $asynchronousEndpoint => $instantRetryAttribute) {
+            $this->registerInterceptor(
+                $messagingConfiguration,
+                $interfaceToCallRegistry,
+                $instantRetryAttribute->retryTimes,
+                $instantRetryAttribute->exceptions,
+                AsynchronousRunningEndpoint::class,
+                Precedence::CUSTOM_INSTANT_RETRY_PRECEDENCE,
+                $asynchronousEndpoint,
             );
         }
     }
@@ -111,9 +151,10 @@ final class InstantRetryAttributeModule implements AnnotationModule
         array $exceptions,
         string $pointcut,
         int $precedence,
+        ?string $relatedEndpointId,
     ): void {
         $instantRetryId = Uuid::uuid4()->toString();
-        $messagingConfiguration->registerServiceDefinition($instantRetryId, Definition::createFor(InstantRetryInterceptor::class, [$retryAttempt, $exceptions, Reference::to(RetryStatusTracker::class)]));
+        $messagingConfiguration->registerServiceDefinition($instantRetryId, Definition::createFor(InstantRetryInterceptor::class, [$retryAttempt, $exceptions, Reference::to(RetryStatusTracker::class), $relatedEndpointId]));
 
         $messagingConfiguration
             ->registerAroundMethodInterceptor(

--- a/packages/Ecotone/src/Modelling/Config/InstantRetry/InstantRetryInterceptor.php
+++ b/packages/Ecotone/src/Modelling/Config/InstantRetry/InstantRetryInterceptor.php
@@ -3,10 +3,12 @@
 namespace Ecotone\Modelling\Config\InstantRetry;
 
 use Ecotone\Messaging\Attribute\Parameter\Reference;
+use Ecotone\Messaging\Endpoint\PollingMetadata;
 use Ecotone\Messaging\Handler\Logger\LoggingGateway;
 use Ecotone\Messaging\Handler\Processor\MethodInvoker\MethodInvocation;
 use Ecotone\Messaging\Handler\TypeDescriptor;
 use Ecotone\Messaging\Message;
+use Ecotone\Messaging\MessageHeaders;
 use Exception;
 
 /**
@@ -15,14 +17,21 @@ use Exception;
 class InstantRetryInterceptor
 {
     public function __construct(
-        private int $maxRetryAttempts,
-        private array $exceptions,
+        private int                $maxRetryAttempts,
+        private array              $exceptions,
         private RetryStatusTracker $retryStatusTracker,
+        private ?string            $relatedEndpointId = null,
     ) {
     }
 
-    public function retry(MethodInvocation $methodInvocation, Message $message, #[Reference] LoggingGateway $logger)
+    public function retry(MethodInvocation $methodInvocation, Message $message, #[Reference] LoggingGateway $logger, ?PollingMetadata $pollingMetadata)
     {
+        if (! is_null($this->relatedEndpointId)) {
+            if (!$pollingMetadata || $pollingMetadata->getEndpointId() !== $this->relatedEndpointId) {
+                return $methodInvocation->proceed();
+            }
+        }
+
         if ($this->retryStatusTracker->isCurrentlyWrappedByRetry()) {
             return $methodInvocation->proceed();
         }

--- a/packages/Ecotone/tests/Modelling/Unit/Config/InstantRetry/InstantRetryAttributeModuleTest.php
+++ b/packages/Ecotone/tests/Modelling/Unit/Config/InstantRetry/InstantRetryAttributeModuleTest.php
@@ -6,6 +6,7 @@ namespace Modelling\Unit\Config\InstantRetry;
 
 use Ecotone\Lite\EcotoneLite;
 use Ecotone\Messaging\Channel\SimpleMessageChannelBuilder;
+use Ecotone\Messaging\Config\ConfigurationException;
 use Ecotone\Messaging\Config\ModulePackageList;
 use Ecotone\Messaging\Config\ServiceConfiguration;
 use Ecotone\Messaging\Support\LicensingException;
@@ -199,7 +200,7 @@ final class InstantRetryAttributeModuleTest extends TestCase
 
     public function test_instant_retry_attribute_fails_on_non_command_bus_interfaces()
     {
-        $this->expectException(InvalidArgumentException::class);
+        $this->expectException(ConfigurationException::class);
         $this->expectExceptionMessage('InstantRetry attribute can only be used on interfaces extending CommandBus');
 
         EcotoneLite::bootstrapFlowTesting(

--- a/packages/Kafka/src/Attribute/KafkaConsumer.php
+++ b/packages/Kafka/src/Attribute/KafkaConsumer.php
@@ -8,6 +8,7 @@ use Attribute;
 use Ecotone\Messaging\Attribute\MessageConsumer;
 use Ecotone\Messaging\Config\Container\DefinedObject;
 use Ecotone\Messaging\Config\Container\Definition;
+use Ecotone\Messaging\Endpoint\FinalFailureStrategy;
 use Ecotone\Messaging\Support\Assert;
 
 /**
@@ -19,7 +20,8 @@ final class KafkaConsumer extends MessageConsumer implements DefinedObject
     public function __construct(
         string $endpointId,
         private array|string $topics,
-        private ?string $groupId = null
+        private ?string $groupId = null,
+        private FinalFailureStrategy $finalFailureStrategy = FinalFailureStrategy::STOP
     ) {
         Assert::notNullAndEmpty($topics, "Topics can't be empty");
 
@@ -43,6 +45,11 @@ final class KafkaConsumer extends MessageConsumer implements DefinedObject
         return $this->groupId;
     }
 
+    public function getFinalFailureStrategy(): FinalFailureStrategy
+    {
+        return $this->finalFailureStrategy;
+    }
+
     public function getDefinition(): Definition
     {
         return new Definition(
@@ -51,6 +58,7 @@ final class KafkaConsumer extends MessageConsumer implements DefinedObject
                 $this->getEndpointId(),
                 $this->topics,
                 $this->groupId,
+                $this->finalFailureStrategy,
             ]
         );
     }

--- a/packages/Kafka/tests/Fixture/KafkaConsumer/KafkaConsumerWithFailStrategyExample.php
+++ b/packages/Kafka/tests/Fixture/KafkaConsumer/KafkaConsumerWithFailStrategyExample.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Ecotone\Kafka\Fixture\KafkaConsumer;
+
+use Ecotone\Kafka\Attribute\KafkaConsumer;
+use Ecotone\Messaging\Attribute\Parameter\Header;
+use Ecotone\Messaging\Attribute\Parameter\Payload;
+use Ecotone\Messaging\Endpoint\FinalFailureStrategy;
+use Ecotone\Modelling\Attribute\QueryHandler;
+
+/**
+ * licence Enterprise
+ */
+final class KafkaConsumerWithFailStrategyExample
+{
+    /** @var string[] */
+    private array $messagePayloads = [];
+
+    #[KafkaConsumer('kafka_consumer_attribute', 'testTopicFailure', finalFailureStrategy: FinalFailureStrategy::IGNORE)]
+    public function handle(#[Payload] string $payload, #[Header('fail')] bool $fail = false): void
+    {
+        $this->messagePayloads[] = $payload;
+
+        if ($fail) {
+            throw new \RuntimeException('Failed');
+        }
+    }
+
+    /**
+     * @return string[]
+     */
+    #[QueryHandler('consumer.getAttributeMessagePayloads')]
+    public function getMessagePayloads(): array
+    {
+        return $this->messagePayloads;
+    }
+}

--- a/packages/Kafka/tests/Fixture/KafkaConsumer/KafkaConsumerWithInstantRetryAndErrorChannelExample.php
+++ b/packages/Kafka/tests/Fixture/KafkaConsumer/KafkaConsumerWithInstantRetryAndErrorChannelExample.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Ecotone\Kafka\Fixture\KafkaConsumer;
+
+use Ecotone\Kafka\Attribute\KafkaConsumer;
+use Ecotone\Messaging\Attribute\ErrorChannel;
+use Ecotone\Messaging\Attribute\Parameter\Header;
+use Ecotone\Messaging\Attribute\Parameter\Payload;
+use Ecotone\Messaging\Endpoint\FinalFailureStrategy;
+use Ecotone\Modelling\Attribute\InstantRetry;
+use Ecotone\Modelling\Attribute\QueryHandler;
+
+/**
+ * licence Enterprise
+ */
+final class KafkaConsumerWithInstantRetryAndErrorChannelExample
+{
+    /** @var string[] */
+    private array $messagePayloads = [];
+
+    #[InstantRetry(retryTimes: 1)]
+    #[ErrorChannel('customErrorChannel')]
+    #[KafkaConsumer('kafka_consumer_attribute', 'testTopicError', finalFailureStrategy: FinalFailureStrategy::RESEND)]
+    public function handle(#[Payload] string $payload, #[Header('fail')] bool $fail = false): void
+    {
+        $this->messagePayloads[] = $payload;
+
+        if ($fail) {
+            throw new \RuntimeException('Failed');
+        }
+    }
+
+    /**
+     * @return string[]
+     */
+    #[QueryHandler('consumer.getAttributeMessagePayloads')]
+    public function getMessagePayloads(): array
+    {
+        return $this->messagePayloads;
+    }
+}

--- a/packages/Kafka/tests/Fixture/KafkaConsumer/KafkaConsumerWithInstantRetryExample.php
+++ b/packages/Kafka/tests/Fixture/KafkaConsumer/KafkaConsumerWithInstantRetryExample.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Ecotone\Kafka\Fixture\KafkaConsumer;
+
+use Ecotone\Kafka\Attribute\KafkaConsumer;
+use Ecotone\Messaging\Attribute\Parameter\Header;
+use Ecotone\Messaging\Attribute\Parameter\Payload;
+use Ecotone\Messaging\Endpoint\FinalFailureStrategy;
+use Ecotone\Modelling\Attribute\InstantRetry;
+use Ecotone\Modelling\Attribute\QueryHandler;
+
+/**
+ * licence Enterprise
+ */
+final class KafkaConsumerWithInstantRetryExample
+{
+    /** @var string[] */
+    private array $messagePayloads = [];
+
+    #[InstantRetry(retryTimes: 1)]
+    #[KafkaConsumer('kafka_consumer_attribute', 'testTopicRetry', finalFailureStrategy: FinalFailureStrategy::IGNORE)]
+    public function handle(#[Payload] string $payload, #[Header('fail')] bool $fail = false): void
+    {
+        $this->messagePayloads[] = $payload;
+
+        if ($fail) {
+            throw new \RuntimeException('Failed');
+        }
+    }
+
+    /**
+     * @return string[]
+     */
+    #[QueryHandler('consumer.getAttributeMessagePayloads')]
+    public function getMessagePayloads(): array
+    {
+        return $this->messagePayloads;
+    }
+}

--- a/packages/Kafka/tests/Integration/KafkaChannelAdapterTest.php
+++ b/packages/Kafka/tests/Integration/KafkaChannelAdapterTest.php
@@ -15,6 +15,7 @@ use Ecotone\Messaging\Config\ModulePackageList;
 use Ecotone\Messaging\Config\ServiceConfiguration;
 use Ecotone\Messaging\Endpoint\ExecutionPollingMetadata;
 use Ecotone\Messaging\Handler\Logger\EchoLogger;
+use Ecotone\Messaging\Channel\SimpleMessageChannelBuilder;
 use Ecotone\Messaging\MessageHeaders;
 use Ecotone\Messaging\MessagePublisher;
 use Ecotone\Modelling\AggregateMessage;
@@ -23,6 +24,9 @@ use PHPUnit\Framework\TestCase;
 use Ramsey\Uuid\Uuid;
 use Test\Ecotone\Kafka\ConnectionTestCase;
 use Test\Ecotone\Kafka\Fixture\ChannelAdapter\ExampleKafkaConsumer;
+use Test\Ecotone\Kafka\Fixture\KafkaConsumer\KafkaConsumerWithFailStrategyExample;
+use Test\Ecotone\Kafka\Fixture\KafkaConsumer\KafkaConsumerWithInstantRetryAndErrorChannelExample;
+use Test\Ecotone\Kafka\Fixture\KafkaConsumer\KafkaConsumerWithInstantRetryExample;
 
 /**
  * licence Enterprise
@@ -145,5 +149,115 @@ final class KafkaChannelAdapterTest extends TestCase
                 ]),
             licenceKey: LicenceTesting::VALID_LICENCE,
         );
+    }
+
+    public function test_defining_custom_failure_strategy(): void
+    {
+        $endpointId = 'kafka_consumer_attribute';
+        $topicName = 'test_topic_failure_' . Uuid::uuid4()->toString();
+        $ecotoneLite = EcotoneLite::bootstrapFlowTesting(
+            [KafkaConsumerWithFailStrategyExample::class],
+            [
+                KafkaBrokerConfiguration::class => ConnectionTestCase::getConnection(),
+                new KafkaConsumerWithFailStrategyExample(),
+            ],
+            ServiceConfiguration::createWithDefaults()
+                ->withEnvironment('prod')
+                ->withSkippedModulePackageNames(ModulePackageList::allPackagesExcept([ModulePackageList::KAFKA_PACKAGE]))
+                ->withExtensionObjects([
+                    KafkaPublisherConfiguration::createWithDefaults($topicName)
+                        ->withHeaderMapper("*"),
+                    TopicConfiguration::createWithReferenceName('testTopicFailure', $topicName),
+                ]),
+            licenceKey: LicenceTesting::VALID_LICENCE
+        );
+
+        $payload = Uuid::uuid4()->toString();
+        $messagePublisher = $ecotoneLite->getGateway(MessagePublisher::class);
+        $messagePublisher->sendWithMetadata($payload, metadata: ['fail' => true]);
+
+        $ecotoneLite->run($endpointId, ExecutionPollingMetadata::createWithTestingSetup(failAtError: false));
+        $this->assertEquals([$payload], $ecotoneLite->sendQueryWithRouting('consumer.getAttributeMessagePayloads'));
+
+        // Test that message is not consumed again
+        $ecotoneLite->run($endpointId, ExecutionPollingMetadata::createWithTestingSetup(failAtError: true));
+        $this->assertEquals([$payload], $ecotoneLite->sendQueryWithRouting('consumer.getAttributeMessagePayloads'));
+    }
+
+    public function test_defining_instant_retries(): void
+    {
+        $endpointId = 'kafka_consumer_attribute';
+        $topicName = 'test_topic_retry_' . Uuid::uuid4()->toString();
+        $ecotoneLite = EcotoneLite::bootstrapFlowTesting(
+            [KafkaConsumerWithInstantRetryExample::class],
+            [
+                KafkaBrokerConfiguration::class => ConnectionTestCase::getConnection(),
+                new KafkaConsumerWithInstantRetryExample(),
+            ],
+            ServiceConfiguration::createWithDefaults()
+                ->withEnvironment('prod')
+                ->withSkippedModulePackageNames(ModulePackageList::allPackagesExcept([ModulePackageList::KAFKA_PACKAGE]))
+                ->withExtensionObjects([
+                    KafkaPublisherConfiguration::createWithDefaults($topicName)
+                        ->withHeaderMapper("*"),
+                    TopicConfiguration::createWithReferenceName('testTopicRetry', $topicName),
+                ]),
+            licenceKey: LicenceTesting::VALID_LICENCE
+        );
+
+        $payload = Uuid::uuid4()->toString();
+        $messagePublisher = $ecotoneLite->getGateway(MessagePublisher::class);
+        $messagePublisher->sendWithMetadata($payload, metadata: ['fail' => true]);
+
+        $ecotoneLite->run($endpointId, ExecutionPollingMetadata::createWithTestingSetup(failAtError: false));
+        $messages = $ecotoneLite->sendQueryWithRouting('consumer.getAttributeMessagePayloads');
+        $this->assertCount(2, $messages);
+        $this->assertEquals($payload, $messages[0]);
+        $this->assertEquals($payload, $messages[1]);
+
+        // Test that message is not consumed again
+        $ecotoneLite->run($endpointId, ExecutionPollingMetadata::createWithTestingSetup(failAtError: true));
+        $messages = $ecotoneLite->sendQueryWithRouting('consumer.getAttributeMessagePayloads');
+        $this->assertCount(2, $messages);
+    }
+
+    public function test_defining_error_channel(): void
+    {
+        $endpointId = 'kafka_consumer_attribute';
+        $topicName = 'test_topic_error_' . Uuid::uuid4()->toString();
+        $ecotoneLite = EcotoneLite::bootstrapFlowTesting(
+            [KafkaConsumerWithInstantRetryAndErrorChannelExample::class],
+            [
+                KafkaBrokerConfiguration::class => ConnectionTestCase::getConnection(),
+                new KafkaConsumerWithInstantRetryAndErrorChannelExample(),
+            ],
+            ServiceConfiguration::createWithDefaults()
+                ->withEnvironment('prod')
+                ->withSkippedModulePackageNames(ModulePackageList::allPackagesExcept([ModulePackageList::KAFKA_PACKAGE]))
+                ->withExtensionObjects([
+                    KafkaPublisherConfiguration::createWithDefaults($topicName)
+                        ->withHeaderMapper("*"),
+                    TopicConfiguration::createWithReferenceName('testTopicError', $topicName),
+                    SimpleMessageChannelBuilder::createQueueChannel('customErrorChannel'),
+                ]),
+            licenceKey: LicenceTesting::VALID_LICENCE
+        );
+
+        $payload = Uuid::uuid4()->toString();
+        $messagePublisher = $ecotoneLite->getGateway(MessagePublisher::class);
+        $messagePublisher->sendWithMetadata($payload, metadata: ['fail' => true]);
+
+        $ecotoneLite->run($endpointId, ExecutionPollingMetadata::createWithTestingSetup(failAtError: false));
+        $messages = $ecotoneLite->sendQueryWithRouting('consumer.getAttributeMessagePayloads');
+        $this->assertCount(2, $messages);
+        $this->assertEquals($payload, $messages[0]);
+        $this->assertEquals($payload, $messages[1]);
+
+        // Test that message is not consumed again
+        $ecotoneLite->run($endpointId, ExecutionPollingMetadata::createWithTestingSetup(failAtError: true));
+        $messages = $ecotoneLite->sendQueryWithRouting('consumer.getAttributeMessagePayloads');
+        $this->assertCount(2, $messages);
+
+        $this->assertNotNull($ecotoneLite->getMessageChannel('customErrorChannel')->receive());
     }
 }


### PR DESCRIPTION
## Why is this change proposed?

There are situations where instead of Message Channel we want to fetch Messages directly from Queue/Topic. 
To do this we can now use `RabbitConsumer` and `KafkaConsumer` and simply annotation methods.
Together with that we can make use of attribute based configuration for making the whole flow more resilient. 

### Rabbit Consumer
<img width="702" height="959" alt="image" src="https://github.com/user-attachments/assets/e8bd3d41-593e-4f75-a58b-1931038c8e2e" />
<img width="734" height="1078" alt="image" src="https://github.com/user-attachments/assets/c42cdb1d-938d-4ee6-9227-12add9900b0e" />

### Kafka Consumer
<img width="739" height="1078" alt="image" src="https://github.com/user-attachments/assets/e7336404-731e-43e7-b52e-45d467f97e54" />
<img width="739" height="1078" alt="image" src="https://github.com/user-attachments/assets/b09b0565-f4f5-4028-aedd-03455ca73a89" />

## Pull Request Contribution Terms

- [X] I have read and agree to the contribution terms outlined in [CONTRIBUTING](https://github.com/ecotoneframework/ecotone-dev/blob/main/CONTRIBUTING.md).