### PR TITLE
[Hotfix] Container loading for Distributed Bus

### DIFF
--- a/packages/Ecotone/src/Lite/LazyInMemoryContainer.php
+++ b/packages/Ecotone/src/Lite/LazyInMemoryContainer.php
@@ -3,6 +3,7 @@
 namespace Ecotone\Lite;
 
 use Ecotone\Messaging\Config\Container\Compiler\ContainerImplementation;
+use Ecotone\Messaging\Config\Container\DefinedObject;
 use Ecotone\Messaging\Config\Container\Definition;
 use Ecotone\Messaging\Config\Container\Reference;
 use Ecotone\Messaging\Config\DefinedObjectWrapper;
@@ -49,7 +50,9 @@ class LazyInMemoryContainer implements ContainerInterface
             return $object;
         } elseif ($argument instanceof Reference) {
             return $this->resolveReference($argument);
-        } else {
+        } elseif ($argument instanceof DefinedObject) {
+            return $this->resolveArgument($argument->getDefinition());
+        }else {
             return $argument;
         }
     }

--- a/packages/Ecotone/src/Messaging/Channel/PollableChannel/Serialization/OutboundMessageConverter.php
+++ b/packages/Ecotone/src/Messaging/Channel/PollableChannel/Serialization/OutboundMessageConverter.php
@@ -13,6 +13,7 @@ use Ecotone\Messaging\MessageConverter\HeaderMapper;
 use Ecotone\Messaging\MessageHeaders;
 use Ecotone\Messaging\Scheduling\DatePoint;
 use Ecotone\Messaging\Scheduling\Duration;
+use Ecotone\Messaging\Scheduling\TimeSpan;
 
 /**
  * licence Apache-2.0
@@ -105,6 +106,10 @@ class OutboundMessageConverter
 
         if ($deliveryDelay instanceof Duration) {
             $deliveryDelay = $deliveryDelay->inMilliseconds();
+        }
+
+        if ($deliveryDelay instanceof TimeSpan) {
+            $deliveryDelay = $deliveryDelay->toMilliseconds();
         }
 
         if ($deliveryDelay && $deliveryDelay < 0) {

--- a/packages/Ecotone/src/Messaging/Handler/Processor/MethodInvoker/Converter/FetchAggregateConverter.php
+++ b/packages/Ecotone/src/Messaging/Handler/Processor/MethodInvoker/Converter/FetchAggregateConverter.php
@@ -69,7 +69,8 @@ class FetchAggregateConverter implements ParameterConverter
         );
 
         if (! $resolvedAggregate && ! $this->doesAllowsNull) {
-            throw new AggregateNotFoundException("Aggregate {$this->aggregateClassName} was not found for identifiers {$identifiers}.");
+            $identifiersString = is_array($identifiers) ? json_encode($identifiers) : (string) $identifiers;
+            throw new AggregateNotFoundException("Aggregate {$this->aggregateClassName} was not found for identifiers {$identifiersString}.");
         }
 
         return $resolvedAggregate?->getAggregateInstance();

--- a/packages/Ecotone/src/Modelling/Api/Distribution/DistributedServiceMap.php
+++ b/packages/Ecotone/src/Modelling/Api/Distribution/DistributedServiceMap.php
@@ -23,7 +23,7 @@ final class DistributedServiceMap implements DefinedObject
      * @param array<string, array<string>> $subscriptionRoutingKeys
      * @param array<object> $distributedBusAnnotations
      */
-    private function __construct(
+    public function __construct(
         private string $referenceName,
         private array $serviceMapping = [],
         private ?array $subscriptionRoutingKeys = null,
@@ -117,6 +117,7 @@ final class DistributedServiceMap implements DefinedObject
         return Definition::createFor(
             self::class,
             [
+                $this->referenceName,
                 $this->serviceMapping,
                 $this->subscriptionRoutingKeys,
                 $this->distributedBusAnnotations,

--- a/packages/Ecotone/tests/Messaging/Fixture/Endpoint/ConsumerContinuouslyWorkingService.php
+++ b/packages/Ecotone/tests/Messaging/Fixture/Endpoint/ConsumerContinuouslyWorkingService.php
@@ -10,7 +10,7 @@ use Ecotone\Messaging\Transaction\Transactional;
 /**
  * licence Apache-2.0
  */
-class ConsumerContinuouslyWorkingService implements DefinedObject
+class ConsumerContinuouslyWorkingService
 {
     private $receivedPayload;
 
@@ -54,10 +54,5 @@ class ConsumerContinuouslyWorkingService implements DefinedObject
     public function getReceivedPayload()
     {
         return $this->receivedPayload;
-    }
-
-    public function getDefinition(): Definition
-    {
-        return new Definition(self::class, [$this->returnData], 'createWithReturn');
     }
 }

--- a/packages/Ecotone/tests/Messaging/Fixture/Handler/Processor/Interceptor/BaseInterceptorExample.php
+++ b/packages/Ecotone/tests/Messaging/Fixture/Handler/Processor/Interceptor/BaseInterceptorExample.php
@@ -35,7 +35,7 @@ abstract class BaseInterceptorExample implements DefinedObject
      * StubCallSavingService constructor.
      * @param $valueToReturn
      */
-    private function __construct($valueToReturn)
+    public function __construct($valueToReturn)
     {
         $this->valueToReturn = $valueToReturn;
     }
@@ -81,6 +81,6 @@ abstract class BaseInterceptorExample implements DefinedObject
 
     public function getDefinition(): Definition
     {
-        return new Definition(self::class, [$this->valueToReturn]);
+        return new Definition(static::class, [$this->valueToReturn]);
     }
 }

--- a/packages/Ecotone/tests/Messaging/Fixture/Service/CalculatingService.php
+++ b/packages/Ecotone/tests/Messaging/Fixture/Service/CalculatingService.php
@@ -15,7 +15,7 @@ use Ecotone\Messaging\Config\Container\Definition;
 /**
  * licence Apache-2.0
  */
-class CalculatingService implements DefinedObject
+class CalculatingService
 {
     /**
      * @var int
@@ -32,6 +32,15 @@ class CalculatingService implements DefinedObject
     {
         $calculatingService = new self();
         $calculatingService->secondValueForMathOperations = $secondValueForMathOperations;
+
+        return $calculatingService;
+    }
+
+    public static function reconstruct(int $secondValueForMathOperations, mixed $lastResult): self
+    {
+        $calculatingService = new self();
+        $calculatingService->secondValueForMathOperations = $secondValueForMathOperations;
+        $calculatingService->lastResult = $lastResult;
 
         return $calculatingService;
     }
@@ -63,10 +72,5 @@ class CalculatingService implements DefinedObject
     public function getLastResult()
     {
         return $this->lastResult;
-    }
-
-    public function getDefinition(): Definition
-    {
-        return new Definition(self::class, [$this->secondValueForMathOperations], 'create');
     }
 }

--- a/packages/Ecotone/tests/Messaging/Unit/Config/MessagingSystemConfigurationTest.php
+++ b/packages/Ecotone/tests/Messaging/Unit/Config/MessagingSystemConfigurationTest.php
@@ -16,6 +16,7 @@ use Ecotone\Messaging\Config\ConfigurationException;
 use Ecotone\Messaging\Config\ConsoleCommandConfiguration;
 use Ecotone\Messaging\Config\ConsoleCommandParameter;
 use Ecotone\Messaging\Config\Container\ContainerBuilder;
+use Ecotone\Messaging\Config\Container\Definition;
 use Ecotone\Messaging\Config\Container\GatewayProxyReference;
 use Ecotone\Messaging\Config\Container\Reference;
 use Ecotone\Messaging\Config\InMemoryModuleMessaging;
@@ -280,25 +281,28 @@ class MessagingSystemConfigurationTest extends MessagingTestCase
 
     public function test_registering_before_call_intercepted_asynchronous_endpoint()
     {
+        $reference = 'calculatingService';
         $calculatingService = CalculatingService::create(1);
         $configuredMessagingSystem = MessagingSystemConfiguration::prepareWithDefaultsForTesting()
             ->registerConsumerFactory(new EventDrivenConsumerBuilder())
             ->registerConsumerFactory(new PollingConsumerBuilder())
             ->registerMessageHandler(
-                ServiceActivatorBuilder::createWithDirectReference($calculatingService, 'result')
+                ServiceActivatorBuilder::create($reference, InterfaceToCall::create(CalculatingService::class, 'result'))
                     ->withEndpointId('endpointId')
                     ->withInputChannelName('inputChannel')
             )
             ->registerAsynchronousEndpoint('asyncChannel', 'endpointId')
             ->registerBeforeMethodInterceptor(MethodInterceptorBuilder::create(
-                $calculatingService,
+                Reference::to($reference),
                 InterfaceToCall::create(CalculatingService::class, 'sum'),
                 1,
                 CalculatingService::class
             ))
             ->registerPollingMetadata(PollingMetadata::create('asyncChannel')->setExecutionAmountLimit(1))
             ->registerMessageChannel(SimpleMessageChannelBuilder::createQueueChannel('asyncChannel'))
-            ->buildMessagingSystemFromConfiguration(InMemoryReferenceSearchService::createEmpty());
+            ->buildMessagingSystemFromConfiguration(InMemoryReferenceSearchService::createWith([
+                $reference => $calculatingService
+            ]));
 
         $message = MessageBuilder::withPayload(2)
             ->build();
@@ -341,6 +345,7 @@ class MessagingSystemConfigurationTest extends MessagingTestCase
 
     public function test_registering_before_call_intercepted_asynchronous_endpoint_with_two_channels()
     {
+        $reference = 'calculatingService';
         $calculatingService = CalculatingService::create(1);
         $asyncChannelNameOne = 'asyncChannelOne';
         $asyncChannelNameTwo = 'asyncChannelTwo';
@@ -348,13 +353,13 @@ class MessagingSystemConfigurationTest extends MessagingTestCase
             ->registerConsumerFactory(new EventDrivenConsumerBuilder())
             ->registerConsumerFactory(new PollingConsumerBuilder())
             ->registerMessageHandler(
-                ServiceActivatorBuilder::createWithDirectReference($calculatingService, 'result')
+                ServiceActivatorBuilder::create($reference, InterfaceToCall::create(CalculatingService::class, 'result'))
                     ->withEndpointId('endpointId')
                     ->withInputChannelName('inputChannel')
             )
             ->registerAsynchronousEndpoint([$asyncChannelNameOne, $asyncChannelNameTwo], 'endpointId')
             ->registerBeforeMethodInterceptor(MethodInterceptorBuilder::create(
-                $calculatingService,
+                Reference::to($reference),
                 InterfaceToCall::create(CalculatingService::class, 'sum'),
                 1,
                 CalculatingService::class
@@ -363,7 +368,9 @@ class MessagingSystemConfigurationTest extends MessagingTestCase
             ->registerPollingMetadata(PollingMetadata::create($asyncChannelNameTwo)->withTestingSetup())
             ->registerMessageChannel(SimpleMessageChannelBuilder::createQueueChannel($asyncChannelNameOne))
             ->registerMessageChannel(SimpleMessageChannelBuilder::createQueueChannel($asyncChannelNameTwo))
-            ->buildMessagingSystemFromConfiguration(InMemoryReferenceSearchService::createEmpty());
+            ->buildMessagingSystemFromConfiguration(InMemoryReferenceSearchService::createWith([
+                $reference => $calculatingService
+            ]));
 
         /** @var MessageChannel $channel */
         $channel = $configuredMessagingSystem->getMessageChannelByName('inputChannel');
@@ -387,6 +394,8 @@ class MessagingSystemConfigurationTest extends MessagingTestCase
 
     public function test_registering_presend_interceptor_wish_async_channel()
     {
+        $reference = 'calculatingService';
+        $calculatingService = CalculatingService::create(1);
         $configuredMessagingSystem = MessagingSystemConfiguration::prepareWithDefaultsForTesting()
             ->registerConsumerFactory(new EventDrivenConsumerBuilder())
             ->registerConsumerFactory(new PollingConsumerBuilder())
@@ -399,13 +408,15 @@ class MessagingSystemConfigurationTest extends MessagingTestCase
             ->registerMessageChannel(SimpleMessageChannelBuilder::createQueueChannel('asyncChannel'))
             ->registerBeforeSendInterceptor(
                 MethodInterceptorBuilder::create(
-                    CalculatingService::create(1),
+                    Reference::to($reference),
                     InterfaceToCall::create(CalculatingService::class, 'sum'),
                     1,
                     CalculatingService::class
                 )
             )
-            ->buildMessagingSystemFromConfiguration(InMemoryReferenceSearchService::createEmpty());
+            ->buildMessagingSystemFromConfiguration(InMemoryReferenceSearchService::createWith([
+                $reference => $calculatingService
+            ]));
 
         $replyChannel = QueueChannel::create();
         $requestMessage = MessageBuilder::withPayload(2)
@@ -422,6 +433,8 @@ class MessagingSystemConfigurationTest extends MessagingTestCase
 
     public function test_registering_presend_interceptor_wish_two_async_channels()
     {
+        $reference = 'calculatingService';
+        $interceptorService = CalculatingService::create(1);
         $asyncChannelOne = 'asyncChannelOne';
         $asyncChannelTwo = 'asyncChannelTwo';
         $calculatingService = CalculatingService::create(0);
@@ -440,13 +453,15 @@ class MessagingSystemConfigurationTest extends MessagingTestCase
             ->registerMessageChannel(SimpleMessageChannelBuilder::createQueueChannel($asyncChannelTwo))
             ->registerBeforeSendInterceptor(
                 MethodInterceptorBuilder::create(
-                    CalculatingService::create(1),
+                    Reference::to($reference),
                     InterfaceToCall::create(CalculatingService::class, 'sum'),
                     1,
                     CalculatingService::class
                 )
             )
-            ->buildMessagingSystemFromConfiguration(InMemoryReferenceSearchService::createEmpty());
+            ->buildMessagingSystemFromConfiguration(InMemoryReferenceSearchService::createWith([
+                $reference => $interceptorService
+            ]));
 
         /** @var PollableChannel $channel */
         $channel = $configuredMessagingSystem->getMessageChannelByName('inputChannel');
@@ -458,6 +473,8 @@ class MessagingSystemConfigurationTest extends MessagingTestCase
 
     public function test_registering_presend_interceptor_polling_channel()
     {
+        $reference = 'calculatingService';
+        $calculatingService = CalculatingService::create(1);
         $configuredMessagingSystem = MessagingSystemConfiguration::prepareWithDefaultsForTesting()
             ->registerConsumerFactory(new EventDrivenConsumerBuilder())
             ->registerConsumerFactory(new PollingConsumerBuilder())
@@ -469,13 +486,15 @@ class MessagingSystemConfigurationTest extends MessagingTestCase
             ->registerMessageChannel(SimpleMessageChannelBuilder::createQueueChannel('inputChannel'))
             ->registerBeforeSendInterceptor(
                 MethodInterceptorBuilder::create(
-                    CalculatingService::create(1),
+                    Reference::to($reference),
                     InterfaceToCall::create(CalculatingService::class, 'sum'),
                     1,
                     CalculatingService::class
                 )
             )
-            ->buildMessagingSystemFromConfiguration(InMemoryReferenceSearchService::createEmpty());
+            ->buildMessagingSystemFromConfiguration(InMemoryReferenceSearchService::createWith([
+                $reference => $calculatingService
+            ]));
 
         $replyChannel = QueueChannel::create();
         $requestMessage = MessageBuilder::withPayload(2)
@@ -492,6 +511,10 @@ class MessagingSystemConfigurationTest extends MessagingTestCase
 
     public function test_registering_multiple_before_send_interceptors()
     {
+        $reference1 = 'calculatingService1';
+        $reference2 = 'calculatingService2';
+        $calculatingService1 = CalculatingService::create(1);
+        $calculatingService2 = CalculatingService::create(1);
         $configuredMessagingSystem = MessagingSystemConfiguration::prepareWithDefaultsForTesting()
             ->registerConsumerFactory(new EventDrivenConsumerBuilder())
             ->registerConsumerFactory(new PollingConsumerBuilder())
@@ -503,7 +526,7 @@ class MessagingSystemConfigurationTest extends MessagingTestCase
             ->registerMessageChannel(SimpleMessageChannelBuilder::createQueueChannel('inputChannel1'))
             ->registerBeforeSendInterceptor(
                 MethodInterceptorBuilder::create(
-                    CalculatingService::create(1),
+                    Reference::to($reference1),
                     InterfaceToCall::create(CalculatingService::class, 'sum'),
                     1,
                     CalculatingService::class
@@ -511,13 +534,16 @@ class MessagingSystemConfigurationTest extends MessagingTestCase
             )
             ->registerBeforeSendInterceptor(
                 MethodInterceptorBuilder::create(
-                    CalculatingService::create(1),
+                    Reference::to($reference2),
                     InterfaceToCall::create(CalculatingService::class, 'sum'),
                     1,
                     CalculatingService::class
                 )
             )
-            ->buildMessagingSystemFromConfiguration(InMemoryReferenceSearchService::createEmpty());
+            ->buildMessagingSystemFromConfiguration(InMemoryReferenceSearchService::createWith([
+                $reference1 => $calculatingService1,
+                $reference2 => $calculatingService2
+            ]));
 
         $replyChannel = QueueChannel::create();
         $requestMessage = MessageBuilder::withPayload(2)
@@ -534,6 +560,8 @@ class MessagingSystemConfigurationTest extends MessagingTestCase
 
     public function test_not_duplicating_before_send_interceptors()
     {
+        $reference = 'calculatingService';
+        $calculatingService = CalculatingService::create(1);
         $configuredMessagingSystem = MessagingSystemConfiguration::prepareWithDefaultsForTesting()
             ->registerConsumerFactory(new EventDrivenConsumerBuilder())
             ->registerConsumerFactory(new PollingConsumerBuilder())
@@ -550,7 +578,7 @@ class MessagingSystemConfigurationTest extends MessagingTestCase
             ->registerMessageChannel(SimpleMessageChannelBuilder::createQueueChannel('inputChannel1'))
             ->registerBeforeSendInterceptor(
                 MethodInterceptorBuilder::create(
-                    CalculatingService::create(1),
+                    Reference::to($reference),
                     InterfaceToCall::create(CalculatingService::class, 'sum'),
                     1,
                     CalculatingService::class
@@ -558,13 +586,15 @@ class MessagingSystemConfigurationTest extends MessagingTestCase
             )
             ->registerBeforeSendInterceptor(
                 MethodInterceptorBuilder::create(
-                    CalculatingService::create(1),
+                    Reference::to($reference),
                     InterfaceToCall::create(CalculatingService::class, 'sum'),
                     1,
                     CalculatingService::class
                 )
             )
-            ->buildMessagingSystemFromConfiguration(InMemoryReferenceSearchService::createEmpty());
+            ->buildMessagingSystemFromConfiguration(InMemoryReferenceSearchService::createWith([
+                $reference => $calculatingService
+            ]));
 
         $replyChannel = QueueChannel::create();
         $requestMessage = MessageBuilder::withPayload(2)
@@ -1166,7 +1196,14 @@ class MessagingSystemConfigurationTest extends MessagingTestCase
         $requestChannelName = 'requestChannelName';
         $endpointName = 'pollableName';
 
+        $beforeInterceptorRef = 'beforeInterceptor';
+        $afterInterceptorRef = 'afterInterceptor';
+        $lastServiceRef = 'lastService';
+
+        $beforeInterceptor = CalculatingService::create(2);
+        $afterInterceptor = CalculatingService::create(2);
         $lastServiceFromChain = CalculatingService::create(0);
+
         $messagingSystem = $messagingSystemConfiguration
             ->registerConsumer(
                 InboundChannelAdapterBuilder::createWithDirectObject(
@@ -1183,7 +1220,7 @@ class MessagingSystemConfigurationTest extends MessagingTestCase
             )
             ->registerBeforeMethodInterceptor(
                 MethodInterceptorBuilder::create(
-                    CalculatingService::create(2),
+                    Reference::to($beforeInterceptorRef),
                     InterfaceToCall::create(CalculatingService::class, 'multiply'),
                     1,
                     ConsumerContinuouslyWorkingService::class
@@ -1201,7 +1238,7 @@ class MessagingSystemConfigurationTest extends MessagingTestCase
             )
             ->registerAfterMethodInterceptor(
                 MethodInterceptorBuilder::create(
-                    CalculatingService::create(2),
+                    Reference::to($afterInterceptorRef),
                     InterfaceToCall::create(CalculatingService::class, 'multiply'),
                     1,
                     ConsumerContinuouslyWorkingService::class
@@ -1209,13 +1246,17 @@ class MessagingSystemConfigurationTest extends MessagingTestCase
             )
             ->registerAfterMethodInterceptor(
                 MethodInterceptorBuilder::create(
-                    $lastServiceFromChain,
+                    Reference::to($lastServiceRef),
                     InterfaceToCall::create(CalculatingService::class, 'result'),
                     1,
                     ConsumerContinuouslyWorkingService::class
                 )
             )
-            ->buildMessagingSystemFromConfiguration(InMemoryReferenceSearchService::createEmpty());
+            ->buildMessagingSystemFromConfiguration(InMemoryReferenceSearchService::createWith([
+                $beforeInterceptorRef => $beforeInterceptor,
+                $afterInterceptorRef => $afterInterceptor,
+                $lastServiceRef => $lastServiceFromChain
+            ]));
 
         $messagingSystem->run($endpointName);
 
@@ -1231,9 +1272,9 @@ class MessagingSystemConfigurationTest extends MessagingTestCase
 
         $messagingSystem = $messagingSystemConfiguration
             ->registerConsumer(
-                InboundChannelAdapterBuilder::createWithDirectObject(
+                InboundChannelAdapterBuilder::create(
                     $requestChannelName,
-                    ConsumerContinuouslyWorkingService::createWithReturn(5),
+                    ConsumerContinuouslyWorkingService::class,
                     InterfaceToCall::create(ConsumerContinuouslyWorkingService::class, 'executeReturn')
                 )->withEndpointId($endpointName)
             )
@@ -1245,30 +1286,32 @@ class MessagingSystemConfigurationTest extends MessagingTestCase
             )
             ->registerBeforeMethodInterceptor(
                 MethodInterceptorBuilder::create(
-                    $interceptingHandler,
+                    Reference::to(NoReturnMessageHandler::class),
                     InterfaceToCall::create(NoReturnMessageHandler::class, 'handle'),
                     1,
                     ConsumerContinuouslyWorkingService::class
                 )
             )
             ->registerAroundMethodInterceptor(
-                AroundInterceptorBuilder::createWithDirectObjectAndResolveConverters(
-                    InterfaceToCallRegistry::createEmpty(),
-                    $interceptingHandler,
-                    'handle',
+                AroundInterceptorBuilder::create(
+                    NoReturnMessageHandler::class,
+                    InterfaceToCall::create(NoReturnMessageHandler::class, 'handle'),
                     1,
                     ConsumerContinuouslyWorkingService::class
                 )
             )
             ->registerAfterMethodInterceptor(
                 MethodInterceptorBuilder::create(
-                    $interceptingHandler,
+                    Reference::to(NoReturnMessageHandler::class),
                     InterfaceToCall::create(NoReturnMessageHandler::class, 'handle'),
                     1,
                     ConsumerContinuouslyWorkingService::class
                 )
             )
-            ->buildMessagingSystemFromConfiguration(InMemoryReferenceSearchService::createEmpty());
+            ->buildMessagingSystemFromConfiguration(InMemoryReferenceSearchService::createWith([
+                ConsumerContinuouslyWorkingService::class => ConsumerContinuouslyWorkingService::createWithReturn(5),
+                NoReturnMessageHandler::class => $interceptingHandler
+            ]));
 
         $messagingSystem->run($endpointName);
 
@@ -1282,6 +1325,12 @@ class MessagingSystemConfigurationTest extends MessagingTestCase
     {
         $endpointName = 'endpointName';
         $inputChannelName = 'inputChannel';
+        $beforeInterceptorRef = 'beforeInterceptor';
+        $afterInterceptorRef = 'afterInterceptor';
+
+        $beforeInterceptor = CalculatingService::create(2);
+        $afterInterceptor = CalculatingService::create(3);
+
         $messagingSystemConfiguration =
             MessagingSystemConfiguration::prepareWithDefaultsForTesting()
                 ->registerMessageHandler(
@@ -1291,7 +1340,7 @@ class MessagingSystemConfigurationTest extends MessagingTestCase
                 )
                 ->registerBeforeMethodInterceptor(
                     MethodInterceptorBuilder::create(
-                        CalculatingService::create(2),
+                        Reference::to($beforeInterceptorRef),
                         InterfaceToCall::create(CalculatingService::class, 'sum'),
                         Precedence::DEFAULT_PRECEDENCE,
                         CalculatingService::class
@@ -1308,14 +1357,17 @@ class MessagingSystemConfigurationTest extends MessagingTestCase
                 )
                 ->registerAfterMethodInterceptor(
                     MethodInterceptorBuilder::create(
-                        CalculatingService::create(3),
+                        Reference::to($afterInterceptorRef),
                         InterfaceToCall::create(CalculatingService::class, 'multiply'),
                         Precedence::DEFAULT_PRECEDENCE,
                         CalculatingService::class
                     )
                 )
                 ->registerConsumerFactory(new EventDrivenConsumerBuilder())
-                ->buildMessagingSystemFromConfiguration(InMemoryReferenceSearchService::createEmpty());
+                ->buildMessagingSystemFromConfiguration(InMemoryReferenceSearchService::createWith([
+                    $beforeInterceptorRef => $beforeInterceptor,
+                    $afterInterceptorRef => $afterInterceptor
+                ]));
 
         $messageChannel = $messagingSystemConfiguration->getMessageChannelByName($inputChannelName);
         $outputChannel = QueueChannel::create();
@@ -1629,6 +1681,16 @@ class MessagingSystemConfigurationTest extends MessagingTestCase
     public function test_registering_interceptors_with_precedence_for_message_handler()
     {
         $inputChannelName = 'inputChannel';
+        $beforeInterceptor1Ref = 'beforeInterceptor1';
+        $beforeInterceptor2Ref = 'beforeInterceptor2';
+        $afterInterceptor1Ref = 'afterInterceptor1';
+        $afterInterceptor2Ref = 'afterInterceptor2';
+
+        $beforeInterceptor1 = CalculatingService::create(3);
+        $beforeInterceptor2 = CalculatingService::create(2);
+        $afterInterceptor1 = CalculatingService::create(2);
+        $afterInterceptor2 = CalculatingService::create(2);
+
         $messagingSystemConfiguration =
             MessagingSystemConfiguration::prepareWithDefaultsForTesting()
                 ->registerMessageHandler(
@@ -1637,7 +1699,7 @@ class MessagingSystemConfigurationTest extends MessagingTestCase
                 )
                 ->registerBeforeMethodInterceptor(
                     MethodInterceptorBuilder::create(
-                        CalculatingService::create(3),
+                        Reference::to($beforeInterceptor1Ref),
                         InterfaceToCall::create(CalculatingService::class, 'multiply'),
                         3,
                         CalculatingService::class
@@ -1645,7 +1707,7 @@ class MessagingSystemConfigurationTest extends MessagingTestCase
                 )
                 ->registerBeforeMethodInterceptor(
                     MethodInterceptorBuilder::create(
-                        CalculatingService::create(2),
+                        Reference::to($beforeInterceptor2Ref),
                         InterfaceToCall::create(CalculatingService::class, 'sum'),
                         1,
                         CalculatingService::class
@@ -1653,7 +1715,7 @@ class MessagingSystemConfigurationTest extends MessagingTestCase
                 )
                 ->registerAfterMethodInterceptor(
                     MethodInterceptorBuilder::create(
-                        CalculatingService::create(2),
+                        Reference::to($afterInterceptor1Ref),
                         InterfaceToCall::create(CalculatingService::class, 'multiply'),
                         3,
                         CalculatingService::class
@@ -1661,14 +1723,19 @@ class MessagingSystemConfigurationTest extends MessagingTestCase
                 )
                 ->registerAfterMethodInterceptor(
                     MethodInterceptorBuilder::create(
-                        CalculatingService::create(2),
+                        Reference::to($afterInterceptor2Ref),
                         InterfaceToCall::create(CalculatingService::class, 'sum'),
                         1,
                         CalculatingService::class
                     )
                 )
                 ->registerConsumerFactory(new EventDrivenConsumerBuilder())
-                ->buildMessagingSystemFromConfiguration(InMemoryReferenceSearchService::createEmpty());
+                ->buildMessagingSystemFromConfiguration(InMemoryReferenceSearchService::createWith([
+                    $beforeInterceptor1Ref => $beforeInterceptor1,
+                    $beforeInterceptor2Ref => $beforeInterceptor2,
+                    $afterInterceptor1Ref => $afterInterceptor1,
+                    $afterInterceptor2Ref => $afterInterceptor2
+                ]));
 
         $messageChannel = $messagingSystemConfiguration->getMessageChannelByName($inputChannelName);
         $outputChannel = QueueChannel::create();
@@ -1688,6 +1755,8 @@ class MessagingSystemConfigurationTest extends MessagingTestCase
     public function test_registering_single_after_interceptor_for_gateway()
     {
         $requestChannelName = 'inputChannel';
+        $interceptorRef = 'interceptor';
+        $interceptor = CalculatingService::create(3);
 
         $messagingSystemConfiguration =
             MessagingSystemConfiguration::prepareWithDefaultsForTesting()
@@ -1700,14 +1769,16 @@ class MessagingSystemConfigurationTest extends MessagingTestCase
                 )
                 ->registerAfterMethodInterceptor(
                     MethodInterceptorBuilder::create(
-                        CalculatingService::create(3),
+                        Reference::to($interceptorRef),
                         InterfaceToCall::create(CalculatingService::class, 'sum'),
                         0,
                         ServiceInterfaceCalculatingService::class
                     )
                 )
                 ->registerConsumerFactory(new EventDrivenConsumerBuilder())
-                ->buildMessagingSystemFromConfiguration(InMemoryReferenceSearchService::createEmpty());
+                ->buildMessagingSystemFromConfiguration(InMemoryReferenceSearchService::createWith([
+                    $interceptorRef => $interceptor
+                ]));
 
         /** @var ServiceInterfaceCalculatingService $gateway */
         $gateway = $messagingSystemConfiguration->getGatewayByName('ref-name');
@@ -1733,16 +1804,17 @@ class MessagingSystemConfigurationTest extends MessagingTestCase
                         ->withInputChannelName($requestChannelName)
                 )
                 ->registerAroundMethodInterceptor(
-                    AroundInterceptorBuilder::createWithDirectObjectAndResolveConverters(
-                        InterfaceToCallRegistry::createEmpty(),
-                        $aroundInterceptor,
-                        'handle',
+                    AroundInterceptorBuilder::create(
+                        NoReturnMessageHandler::class,
+                        InterfaceToCall::create(NoReturnMessageHandler::class, 'handle'),
                         1,
                         ServiceInterfaceCalculatingService::class
                     )
                 )
                 ->registerConsumerFactory(new EventDrivenConsumerBuilder())
-                ->buildMessagingSystemFromConfiguration(InMemoryReferenceSearchService::createEmpty());
+                ->buildMessagingSystemFromConfiguration(InMemoryReferenceSearchService::createWith([
+                    NoReturnMessageHandler::class => $aroundInterceptor
+                ]));
 
         /** @var ServiceInterfaceCalculatingService $gateway */
         $gateway = $messagingSystemConfiguration->getGatewayByName('ref-name');
@@ -1759,6 +1831,8 @@ class MessagingSystemConfigurationTest extends MessagingTestCase
     {
         $requestChannelName = 'inputChannel';
         $aroundInterceptor = NoReturnMessageHandler::create();
+        $beforeInterceptorRef = 'beforeInterceptor';
+        $beforeInterceptor = CalculatingService::create(3);
 
         $messagingSystemConfiguration =
             MessagingSystemConfiguration::prepareWithDefaultsForTesting()
@@ -1771,23 +1845,25 @@ class MessagingSystemConfigurationTest extends MessagingTestCase
                 )
                 ->registerBeforeMethodInterceptor(
                     MethodInterceptorBuilder::create(
-                        CalculatingService::create(3),
+                        Reference::to($beforeInterceptorRef),
                         InterfaceToCall::create(CalculatingService::class, 'sum'),
                         1,
                         ServiceInterfaceCalculatingService::class
                     )
                 )
                 ->registerAroundMethodInterceptor(
-                    AroundInterceptorBuilder::createWithDirectObjectAndResolveConverters(
-                        InterfaceToCallRegistry::createEmpty(),
-                        $aroundInterceptor,
-                        'handle',
+                    AroundInterceptorBuilder::create(
+                        NoReturnMessageHandler::class,
+                        InterfaceToCall::create(NoReturnMessageHandler::class, 'handle'),
                         1,
                         ServiceInterfaceCalculatingService::class
                     )
                 )
                 ->registerConsumerFactory(new EventDrivenConsumerBuilder())
-                ->buildMessagingSystemFromConfiguration(InMemoryReferenceSearchService::createEmpty());
+                ->buildMessagingSystemFromConfiguration(InMemoryReferenceSearchService::createWith([
+                    $beforeInterceptorRef => $beforeInterceptor,
+                    NoReturnMessageHandler::class => $aroundInterceptor
+                ]));
 
         /** @var ServiceInterfaceCalculatingService $gateway */
         $gateway = $messagingSystemConfiguration->getGatewayByName('ref-name');
@@ -1805,6 +1881,16 @@ class MessagingSystemConfigurationTest extends MessagingTestCase
         $requestChannelName = 'inputChannel';
         $aroundInterceptor = NoReturnMessageHandler::create();
 
+        $beforeInterceptor1Ref = 'beforeInterceptor1';
+        $beforeInterceptor2Ref = 'beforeInterceptor2';
+        $afterInterceptor1Ref = 'afterInterceptor1';
+        $afterInterceptor2Ref = 'afterInterceptor2';
+
+        $beforeInterceptor1 = CalculatingService::create(3);
+        $beforeInterceptor2 = CalculatingService::create(3);
+        $afterInterceptor1 = CalculatingService::create(0);
+        $afterInterceptor2 = CalculatingService::create(2);
+
         $messagingSystemConfiguration =
             MessagingSystemConfiguration::prepareWithDefaultsForTesting()
                 ->registerGatewayBuilder(
@@ -1816,7 +1902,7 @@ class MessagingSystemConfigurationTest extends MessagingTestCase
                 )
                 ->registerBeforeMethodInterceptor(
                     MethodInterceptorBuilder::create(
-                        CalculatingService::create(3),
+                        Reference::to($beforeInterceptor1Ref),
                         InterfaceToCall::create(CalculatingService::class, 'multiply'),
                         0,
                         ServiceInterfaceCalculatingService::class
@@ -1824,24 +1910,23 @@ class MessagingSystemConfigurationTest extends MessagingTestCase
                 )
                 ->registerBeforeMethodInterceptor(
                     MethodInterceptorBuilder::create(
-                        CalculatingService::create(3),
+                        Reference::to($beforeInterceptor2Ref),
                         InterfaceToCall::create(CalculatingService::class, 'sum'),
                         1,
                         ServiceInterfaceCalculatingService::class
                     )
                 )
                 ->registerAroundMethodInterceptor(
-                    AroundInterceptorBuilder::createWithDirectObjectAndResolveConverters(
-                        InterfaceToCallRegistry::createEmpty(),
-                        $aroundInterceptor,
-                        'handle',
+                    AroundInterceptorBuilder::create(
+                        NoReturnMessageHandler::class,
+                        InterfaceToCall::create(NoReturnMessageHandler::class, 'handle'),
                         1,
                         ServiceInterfaceCalculatingService::class
                     )
                 )
                 ->registerAfterMethodInterceptor(
                     MethodInterceptorBuilder::create(
-                        CalculatingService::create(0),
+                        Reference::to($afterInterceptor1Ref),
                         InterfaceToCall::create(CalculatingService::class, 'result'),
                         1,
                         ServiceInterfaceCalculatingService::class
@@ -1849,14 +1934,20 @@ class MessagingSystemConfigurationTest extends MessagingTestCase
                 )
                 ->registerAfterMethodInterceptor(
                     MethodInterceptorBuilder::create(
-                        CalculatingService::create(2),
+                        Reference::to($afterInterceptor2Ref),
                         InterfaceToCall::create(CalculatingService::class, 'multiply'),
                         0,
                         ServiceInterfaceCalculatingService::class
                     )
                 )
                 ->registerConsumerFactory(new EventDrivenConsumerBuilder())
-                ->buildMessagingSystemFromConfiguration(InMemoryReferenceSearchService::createEmpty());
+                ->buildMessagingSystemFromConfiguration(InMemoryReferenceSearchService::createWith([
+                    $beforeInterceptor1Ref => $beforeInterceptor1,
+                    $beforeInterceptor2Ref => $beforeInterceptor2,
+                    $afterInterceptor1Ref => $afterInterceptor1,
+                    $afterInterceptor2Ref => $afterInterceptor2,
+                    NoReturnMessageHandler::class => $aroundInterceptor
+                ]));
 
         /** @var ServiceInterfaceCalculatingService $gateway */
         $gateway = $messagingSystemConfiguration->getGatewayByName('ref-name');
@@ -1873,6 +1964,17 @@ class MessagingSystemConfigurationTest extends MessagingTestCase
     {
         $requestChannelName = 'inputChannel';
         $aroundInterceptor = NoReturnMessageHandler::create();
+
+        $interceptor0Ref = 'interceptor0Service';
+        $interceptor1Ref = 'interceptor1Service';
+        $interceptor2Ref = 'interceptor2Service';
+        $interceptor3Ref = 'interceptor3Service';
+
+        $interceptor0 = CalculatingService::create(3);
+        $interceptor1 = CalculatingService::create(3);
+        $interceptor2 = CalculatingService::create(0);
+        $interceptor3 = CalculatingService::create(2);
+
         $messagingSystemConfiguration =
             MessagingSystemConfiguration::prepareWithDefaultsForTesting()
                 ->registerGatewayBuilder(
@@ -1885,7 +1987,7 @@ class MessagingSystemConfigurationTest extends MessagingTestCase
                 )
                 ->registerBeforeMethodInterceptor(
                     MethodInterceptorBuilder::create(
-                        CalculatingService::create(3),
+                        Reference::to($interceptor0Ref),
                         InterfaceToCall::create(CalculatingService::class, 'multiply'),
                         0,
                         '',
@@ -1894,7 +1996,7 @@ class MessagingSystemConfigurationTest extends MessagingTestCase
                 )
                 ->registerBeforeMethodInterceptor(
                     MethodInterceptorBuilder::create(
-                        CalculatingService::create(3),
+                        Reference::to($interceptor1Ref),
                         InterfaceToCall::create(CalculatingService::class, 'sum'),
                         1,
                         '',
@@ -1902,17 +2004,16 @@ class MessagingSystemConfigurationTest extends MessagingTestCase
                     )
                 )
                 ->registerAroundMethodInterceptor(
-                    AroundInterceptorBuilder::createWithDirectObjectAndResolveConverters(
-                        InterfaceToCallRegistry::createEmpty(),
-                        $aroundInterceptor,
-                        'handle',
+                    AroundInterceptorBuilder::create(
+                        NoReturnMessageHandler::class,
+                        InterfaceToCall::create(NoReturnMessageHandler::class, 'handle'),
                         1,
                         ''
                     )
                 )
                 ->registerAfterMethodInterceptor(
                     MethodInterceptorBuilder::create(
-                        CalculatingService::create(0),
+                        Reference::to($interceptor2Ref),
                         InterfaceToCall::create(CalculatingService::class, 'result'),
                         1,
                         '',
@@ -1921,7 +2022,7 @@ class MessagingSystemConfigurationTest extends MessagingTestCase
                 )
                 ->registerAfterMethodInterceptor(
                     MethodInterceptorBuilder::create(
-                        CalculatingService::create(2),
+                        Reference::to($interceptor3Ref),
                         InterfaceToCall::create(CalculatingService::class, 'multiply'),
                         0,
                         '',
@@ -1929,7 +2030,13 @@ class MessagingSystemConfigurationTest extends MessagingTestCase
                     )
                 )
                 ->registerConsumerFactory(new EventDrivenConsumerBuilder())
-                ->buildMessagingSystemFromConfiguration(InMemoryReferenceSearchService::createEmpty());
+                ->buildMessagingSystemFromConfiguration(InMemoryReferenceSearchService::createWith([
+                    $interceptor0Ref => $interceptor0,
+                    $interceptor1Ref => $interceptor1,
+                    $interceptor2Ref => $interceptor2,
+                    $interceptor3Ref => $interceptor3,
+                    NoReturnMessageHandler::class => $aroundInterceptor
+                ]));
 
         /** @var ServiceInterfaceCalculatingService $gateway */
         $gateway = $messagingSystemConfiguration->getGatewayByName('ref-name');

--- a/packages/Ecotone/tests/Messaging/Unit/Handler/Gateway/GatewayProxyBuilderTest.php
+++ b/packages/Ecotone/tests/Messaging/Unit/Handler/Gateway/GatewayProxyBuilderTest.php
@@ -7,6 +7,7 @@ use Ecotone\Messaging\Channel\QueueChannel;
 use Ecotone\Messaging\Channel\SimpleMessageChannelBuilder;
 use Ecotone\Messaging\Config\Annotation\ModuleConfiguration\MethodInterceptor\BeforeSendGateway;
 use Ecotone\Messaging\Config\Container\AttributeDefinition;
+use Ecotone\Messaging\Config\Container\Reference;
 use Ecotone\Messaging\Conversion\MediaType;
 use Ecotone\Messaging\Handler\Gateway\GatewayProxyBuilder;
 use Ecotone\Messaging\Handler\Gateway\ParameterToMessageConverter\GatewayHeaderBuilder;
@@ -832,7 +833,21 @@ class GatewayProxyBuilderTest extends MessagingTestCase
 
     public function test_calling_interface_with_before_and_after_interceptors()
     {
+        $beforeInterceptor1Ref = 'beforeInterceptor1';
+        $beforeInterceptor2Ref = 'beforeInterceptor2';
+        $afterInterceptor1Ref = 'afterInterceptor1';
+        $afterInterceptor2Ref = 'afterInterceptor2';
+
+        $beforeInterceptor1 = CalculatingService::create(3);
+        $beforeInterceptor2 = CalculatingService::create(3);
+        $afterInterceptor1 = CalculatingService::create(0);
+        $afterInterceptor2 = CalculatingService::create(2);
+
         $messaging = ComponentTestBuilder::create()
+            ->withReference($beforeInterceptor1Ref, $beforeInterceptor1)
+            ->withReference($beforeInterceptor2Ref, $beforeInterceptor2)
+            ->withReference($afterInterceptor1Ref, $afterInterceptor1)
+            ->withReference($afterInterceptor2Ref, $afterInterceptor2)
             ->withGateway(
                 GatewayProxyBuilder::create(
                     ServiceInterfaceCalculatingService::class,
@@ -843,7 +858,7 @@ class GatewayProxyBuilderTest extends MessagingTestCase
             )
             ->withBeforeInterceptor(
                 MethodInterceptorBuilder::create(
-                    CalculatingService::create(3),
+                    Reference::to($beforeInterceptor1Ref),
                     InterfaceToCall::create(CalculatingService::class, 'multiply'),
                     0,
                     ServiceInterfaceCalculatingService::class
@@ -851,7 +866,7 @@ class GatewayProxyBuilderTest extends MessagingTestCase
             )
             ->withBeforeInterceptor(
                 MethodInterceptorBuilder::create(
-                    CalculatingService::create(3),
+                    Reference::to($beforeInterceptor2Ref),
                     InterfaceToCall::create(CalculatingService::class, 'sum'),
                     1,
                     ServiceInterfaceCalculatingService::class
@@ -859,7 +874,7 @@ class GatewayProxyBuilderTest extends MessagingTestCase
             )
             ->withAfterInterceptor(
                 MethodInterceptorBuilder::create(
-                    CalculatingService::create(0),
+                    Reference::to($afterInterceptor1Ref),
                     InterfaceToCall::create(CalculatingService::class, 'result'),
                     1,
                     ServiceInterfaceCalculatingService::class
@@ -867,7 +882,7 @@ class GatewayProxyBuilderTest extends MessagingTestCase
             )
             ->withAfterInterceptor(
                 MethodInterceptorBuilder::create(
-                    CalculatingService::create(2),
+                    Reference::to($afterInterceptor2Ref),
                     InterfaceToCall::create(CalculatingService::class, 'multiply'),
                     0,
                     ServiceInterfaceCalculatingService::class


### PR DESCRIPTION
## Why is this change proposed?

With one of recent refactors Distributed Bus DI setup was misconfigured. It was not caught due to In Memory container being used in tests. This is now fixed together with proper In Memory configuration change, to catch such situations in future.

## Pull Request Contribution Terms

- [X] I have read and agree to the contribution terms outlined in [CONTRIBUTING](https://github.com/ecotoneframework/ecotone-dev/blob/main/CONTRIBUTING.md).