### PR TITLE
Scheduler with expression language

### DIFF
--- a/packages/Ecotone/src/Messaging/Attribute/Poller.php
+++ b/packages/Ecotone/src/Messaging/Attribute/Poller.php
@@ -33,8 +33,16 @@ class Poller
      * How long should poller handle messages before stopping
      */
     private int $executionTimeLimitInMilliseconds;
+    /**
+     * Expression to evaluate for fixed rate in milliseconds at runtime
+     */
+    private ?string $fixedRateExpression;
+    /**
+     * Expression to evaluate for cron schedule at runtime
+     */
+    private ?string $cronExpression;
 
-    public function __construct(string $cron = '', string $errorChannelName = '', int $fixedRateInMilliseconds = PollingMetadata::DEFAULT_FIXED_RATE, int $initialDelayInMilliseconds = PollingMetadata::DEFAULT_INITIAL_DELAY, int $memoryLimitInMegabytes = PollingMetadata::DEFAULT_MEMORY_LIMIT_MEGABYTES, int $handledMessageLimit = PollingMetadata::DEFAULT_HANDLED_MESSAGE_LIMIT, int $executionTimeLimitInMilliseconds  = PollingMetadata::DEFAULT_EXECUTION_TIME_LIMIT_IN_MILLISECONDS)
+    public function __construct(string $cron = '', string $errorChannelName = '', int $fixedRateInMilliseconds = PollingMetadata::DEFAULT_FIXED_RATE, int $initialDelayInMilliseconds = PollingMetadata::DEFAULT_INITIAL_DELAY, int $memoryLimitInMegabytes = PollingMetadata::DEFAULT_MEMORY_LIMIT_MEGABYTES, int $handledMessageLimit = PollingMetadata::DEFAULT_HANDLED_MESSAGE_LIMIT, int $executionTimeLimitInMilliseconds  = PollingMetadata::DEFAULT_EXECUTION_TIME_LIMIT_IN_MILLISECONDS, ?string $fixedRateExpression = null, ?string $cronExpression = null)
     {
         $this->cron                             = $cron;
         $this->errorChannelName                 = $errorChannelName;
@@ -43,6 +51,8 @@ class Poller
         $this->memoryLimitInMegabytes           = $memoryLimitInMegabytes;
         $this->handledMessageLimit              = $handledMessageLimit;
         $this->executionTimeLimitInMilliseconds = $executionTimeLimitInMilliseconds;
+        $this->fixedRateExpression              = $fixedRateExpression;
+        $this->cronExpression                   = $cronExpression;
     }
 
     public function getCron(): string
@@ -78,5 +88,25 @@ class Poller
     public function getExecutionTimeLimitInMilliseconds(): int
     {
         return $this->executionTimeLimitInMilliseconds;
+    }
+
+    public function getFixedRateExpression(): ?string
+    {
+        return $this->fixedRateExpression;
+    }
+
+    public function getCronExpression(): ?string
+    {
+        return $this->cronExpression;
+    }
+
+    public function hasFixedRateExpression(): bool
+    {
+        return $this->fixedRateExpression !== null;
+    }
+
+    public function hasCronExpression(): bool
+    {
+        return $this->cronExpression !== null;
     }
 }

--- a/packages/Ecotone/src/Messaging/Config/Annotation/ModuleConfiguration/PollerModule.php
+++ b/packages/Ecotone/src/Messaging/Config/Annotation/ModuleConfiguration/PollerModule.php
@@ -52,7 +52,9 @@ class PollerModule extends NoExternalConfigurationModule implements AnnotationMo
                     ->setErrorChannelName($poller->getErrorChannelName())
                     ->setMemoryLimitInMegaBytes($poller->getMemoryLimitInMegabytes())
                     ->setHandledMessageLimit($poller->getHandledMessageLimit())
-                    ->setExecutionTimeLimitInMilliseconds($poller->getExecutionTimeLimitInMilliseconds());
+                    ->setExecutionTimeLimitInMilliseconds($poller->getExecutionTimeLimitInMilliseconds())
+                    ->setFixedRateExpression($poller->getFixedRateExpression())
+                    ->setCronExpression($poller->getCronExpression());
 
                 $multiplePollingMetadata[] = $pollingMetadata;
             }

--- a/packages/Ecotone/src/Messaging/Endpoint/InterceptedChannelAdapterBuilder.php
+++ b/packages/Ecotone/src/Messaging/Endpoint/InterceptedChannelAdapterBuilder.php
@@ -15,6 +15,7 @@ use Ecotone\Messaging\Endpoint\PollingConsumer\InterceptedConsumerRunner;
 use Ecotone\Messaging\Endpoint\PollingConsumer\PollingConsumerErrorChannelInterceptor;
 use Ecotone\Messaging\Gateway\MessagingEntrypoint;
 use Ecotone\Messaging\Handler\ChannelResolver;
+use Ecotone\Messaging\Handler\ExpressionEvaluationService;
 use Ecotone\Messaging\Handler\Gateway\ErrorChannelService;
 use Ecotone\Messaging\Handler\Gateway\GatewayProxyBuilder;
 use Ecotone\Messaging\Handler\InterfaceToCall;
@@ -67,6 +68,7 @@ abstract class InterceptedChannelAdapterBuilder implements ChannelAdapterConsume
             new Reference(EcotoneClockInterface::class),
             new Reference(LoggingGateway::class),
             new Reference(MessagingEntrypoint::class),
+            new Reference(ExpressionEvaluationService::REFERENCE),
         ]);
         $builder->registerPollingEndpoint($this->endpointId, $consumerRunner);
     }

--- a/packages/Ecotone/src/Messaging/Endpoint/PollingConsumer/InterceptedConsumerRunner.php
+++ b/packages/Ecotone/src/Messaging/Endpoint/PollingConsumer/InterceptedConsumerRunner.php
@@ -7,6 +7,7 @@ use Ecotone\Messaging\Endpoint\EndpointRunner;
 use Ecotone\Messaging\Endpoint\ExecutionPollingMetadata;
 use Ecotone\Messaging\Endpoint\PollingMetadata;
 use Ecotone\Messaging\Gateway\MessagingEntrypoint;
+use Ecotone\Messaging\Handler\ExpressionEvaluationService;
 use Ecotone\Messaging\Handler\Logger\LoggingGateway;
 use Ecotone\Messaging\Handler\NonProxyGateway;
 use Ecotone\Messaging\MessagePoller;
@@ -21,12 +22,13 @@ use Ecotone\Messaging\Scheduling\SyncTaskScheduler;
 class InterceptedConsumerRunner implements EndpointRunner
 {
     public function __construct(
-        private NonProxyGateway       $gateway,
-        private MessagePoller         $messagePoller,
-        private PollingMetadata       $defaultPollingMetadata,
-        private EcotoneClockInterface $clock,
-        private LoggingGateway        $logger,
-        private MessagingEntrypoint   $messagingEntrypoint,
+        private NonProxyGateway            $gateway,
+        private MessagePoller              $messagePoller,
+        private PollingMetadata            $defaultPollingMetadata,
+        private EcotoneClockInterface      $clock,
+        private LoggingGateway             $logger,
+        private MessagingEntrypoint        $messagingEntrypoint,
+        private ExpressionEvaluationService $expressionEvaluationService,
     ) {
     }
 
@@ -42,11 +44,11 @@ class InterceptedConsumerRunner implements EndpointRunner
         $interceptors = InterceptedConsumer::createInterceptorsForPollingMetadata($pollingMetadata, $this->logger, $this->clock);
         $interceptedGateway = new InterceptedGateway($this->gateway, $interceptors);
 
+        $trigger = $this->createTrigger($pollingMetadata);
+
         $interceptedConsumer = new ScheduledTaskConsumer(
             SyncTaskScheduler::createWithEmptyTriggerContext($this->clock, $pollingMetadata),
-            $pollingMetadata->getCron()
-                ? CronTrigger::createWith($pollingMetadata->getCron())
-                : PeriodicTrigger::create($pollingMetadata->getFixedRateInMilliseconds(), $pollingMetadata->getInitialDelayInMilliseconds()),
+            $trigger,
             new PollToGatewayTaskExecutor($this->messagePoller, $interceptedGateway, $this->messagingEntrypoint),
         );
 
@@ -55,5 +57,32 @@ class InterceptedConsumerRunner implements EndpointRunner
         } else {
             return $interceptedConsumer;
         }
+    }
+
+    private function createTrigger(PollingMetadata $pollingMetadata)
+    {
+        // Evaluate cron expression if provided
+        if ($pollingMetadata->hasCronExpression()) {
+            $cronValue = $this->expressionEvaluationService->evaluate(
+                $pollingMetadata->getCronExpression(),
+                []
+            );
+            return CronTrigger::createWith((string) $cronValue);
+        }
+
+        // Evaluate fixed rate expression if provided
+        if ($pollingMetadata->hasFixedRateExpression()) {
+            $fixedRateValue = $this->expressionEvaluationService->evaluate(
+                $pollingMetadata->getFixedRateExpression(),
+                []
+            );
+
+            return PeriodicTrigger::create((int) $fixedRateValue, $pollingMetadata->getInitialDelayInMilliseconds());
+        }
+
+        // Fall back to static values
+        return $pollingMetadata->getCron()
+            ? CronTrigger::createWith($pollingMetadata->getCron())
+            : PeriodicTrigger::create($pollingMetadata->getFixedRateInMilliseconds(), $pollingMetadata->getInitialDelayInMilliseconds());
     }
 }

--- a/packages/Ecotone/src/Messaging/Endpoint/PollingConsumer/InterceptedPollingConsumerBuilder.php
+++ b/packages/Ecotone/src/Messaging/Endpoint/PollingConsumer/InterceptedPollingConsumerBuilder.php
@@ -18,6 +18,7 @@ use Ecotone\Messaging\Endpoint\InboundChannelAdapterEntrypoint;
 use Ecotone\Messaging\Endpoint\MessageHandlerConsumerBuilder;
 use Ecotone\Messaging\Gateway\MessagingEntrypoint;
 use Ecotone\Messaging\Handler\ChannelResolver;
+use Ecotone\Messaging\Handler\ExpressionEvaluationService;
 use Ecotone\Messaging\Handler\Gateway\ErrorChannelService;
 use Ecotone\Messaging\Handler\Gateway\GatewayProxyBuilder;
 use Ecotone\Messaging\Handler\Logger\LoggingGateway;
@@ -109,6 +110,7 @@ abstract class InterceptedPollingConsumerBuilder implements MessageHandlerConsum
             new Reference(EcotoneClockInterface::class),
             new Reference(LoggingGateway::class),
             new Reference(MessagingEntrypoint::class),
+            new Reference(ExpressionEvaluationService::REFERENCE),
         ]);
         $builder->registerPollingEndpoint($endpointId, $consumerRunner, $this->withContinuesPolling());
     }

--- a/packages/Ecotone/src/Messaging/Endpoint/PollingMetadata.php
+++ b/packages/Ecotone/src/Messaging/Endpoint/PollingMetadata.php
@@ -50,6 +50,8 @@ final class PollingMetadata implements DefinedObject
         private string $taskExecutorName = '',
         private bool $stopOnError = self::DEFAULT_STOP_ON_ERROR,
         private bool $finishWhenNoMessages = self::DEFAULT_FINISH_WHEN_NO_MESSAGES,
+        private ?string $fixedRateExpression = null,
+        private ?string $cronExpression = null,
     ) {
         $this->withSignalInterceptors = $withSignalInterceptors ?? extension_loaded('pcntl');
     }
@@ -430,6 +432,42 @@ final class PollingMetadata implements DefinedObject
         return $this->finishWhenNoMessages;
     }
 
+    public function getFixedRateExpression(): ?string
+    {
+        return $this->fixedRateExpression;
+    }
+
+    public function getCronExpression(): ?string
+    {
+        return $this->cronExpression;
+    }
+
+    public function hasFixedRateExpression(): bool
+    {
+        return $this->fixedRateExpression !== null;
+    }
+
+    public function hasCronExpression(): bool
+    {
+        return $this->cronExpression !== null;
+    }
+
+    public function setFixedRateExpression(?string $fixedRateExpression): PollingMetadata
+    {
+        $copy = $this->createCopy();
+        $copy->fixedRateExpression = $fixedRateExpression;
+
+        return $copy;
+    }
+
+    public function setCronExpression(?string $cronExpression): PollingMetadata
+    {
+        $copy = $this->createCopy();
+        $copy->cronExpression = $cronExpression;
+
+        return $copy;
+    }
+
     /**
      * @return PollingMetadata
      */
@@ -458,6 +496,8 @@ final class PollingMetadata implements DefinedObject
             $this->taskExecutorName,
             $this->stopOnError,
             $this->finishWhenNoMessages,
+            $this->fixedRateExpression,
+            $this->cronExpression,
         ]);
     }
 }

--- a/packages/Ecotone/tests/Messaging/Fixture/Poller/ExpressionPollerExample.php
+++ b/packages/Ecotone/tests/Messaging/Fixture/Poller/ExpressionPollerExample.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Ecotone\Messaging\Fixture\Poller;
+
+use Ecotone\Messaging\Attribute\Poller;
+use Ecotone\Messaging\Attribute\Scheduled;
+use Ecotone\Messaging\NullableMessageChannel;
+
+/**
+ * licence Apache-2.0
+ */
+final class ExpressionPollerExample
+{
+    private array $processedMessages = [];
+
+    #[Scheduled(NullableMessageChannel::CHANNEL_NAME, 'expression_poller_endpoint')]
+    #[Poller(fixedRateExpression: "reference('timerService').getFixedRate()")]
+    public function pollWithFixedRateExpression(): void
+    {
+        $this->processedMessages[] = 'fixed_rate_message';
+    }
+
+    #[Scheduled(NullableMessageChannel::CHANNEL_NAME, 'cron_expression_poller_endpoint')]
+    #[Poller(cronExpression: "reference('timerService').getCronSchedule()")]
+    public function pollWithCronExpression(): void
+    {
+        $this->processedMessages[] = 'cron_message';
+    }
+
+    public function getProcessedMessages(): array
+    {
+        return $this->processedMessages;
+    }
+
+    public function reset(): void
+    {
+        $this->processedMessages = [];
+    }
+}

--- a/packages/Ecotone/tests/Messaging/Fixture/Poller/TimerService.php
+++ b/packages/Ecotone/tests/Messaging/Fixture/Poller/TimerService.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Ecotone\Messaging\Fixture\Poller;
+
+/**
+ * licence Apache-2.0
+ */
+final class TimerService
+{
+    public function getFixedRate(): int
+    {
+        return 500; // 500 ms
+    }
+
+    public function getCronSchedule(): string
+    {
+        return '* * * * *'; // Every minute
+    }
+}

--- a/packages/Ecotone/tests/Messaging/Unit/Endpoint/PollingConsumer/PollerExpressionTest.php
+++ b/packages/Ecotone/tests/Messaging/Unit/Endpoint/PollingConsumer/PollerExpressionTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Ecotone\Messaging\Unit\Endpoint\PollingConsumer;
+
+use Ecotone\Lite\EcotoneLite;
+use Ecotone\Messaging\Config\Container\PollingMetadataReference;
+use Ecotone\Messaging\Config\ServiceConfiguration;
+use Ecotone\Messaging\Endpoint\ExecutionPollingMetadata;
+use PHPUnit\Framework\TestCase;
+use Test\Ecotone\Messaging\Fixture\Poller\ExpressionPollerExample;
+use Test\Ecotone\Messaging\Fixture\Poller\TimerService;
+
+/**
+ * licence Apache-2.0
+ * @internal
+ */
+final class PollerExpressionTest extends TestCase
+{
+    public function test_poller_with_fixed_rate_expression()
+    {
+        $timerService = new TimerService();
+        $pollerExample = new ExpressionPollerExample();
+
+        $ecotoneLite = EcotoneLite::bootstrapFlowTesting(
+            [ExpressionPollerExample::class],
+            [
+                'timerService' => $timerService,
+                $pollerExample,
+            ],
+            ServiceConfiguration::createWithDefaults()
+        );
+
+        // Run the consumer - this will evaluate the expression and create the trigger
+        // The expression "reference('timerService').getFixedRate()" should return 2000
+        $ecotoneLite->run('expression_poller_endpoint', ExecutionPollingMetadata::createWithDefaults()->withHandledMessageLimit(1));
+
+        // Verify that the poller ran and processed a message
+        $this->assertEquals(['fixed_rate_message'], $pollerExample->getProcessedMessages());
+    }
+
+    public function test_poller_with_cron_expression()
+    {
+        $timerService = new TimerService();
+        $pollerExample = new ExpressionPollerExample();
+
+        $ecotoneLite = EcotoneLite::bootstrapFlowTesting(
+            [ExpressionPollerExample::class],
+            [
+                'timerService' => $timerService,
+                $pollerExample,
+            ],
+            ServiceConfiguration::createWithDefaults()
+        );
+
+        $ecotoneLite->run('expression_poller_endpoint', ExecutionPollingMetadata::createWithTestingSetup(1, 100));
+
+        $this->assertEquals(['fixed_rate_message'], $pollerExample->getProcessedMessages());
+    }
+}


### PR DESCRIPTION
## Why is this change proposed?

This provides ability to set up scheduler using expression language:
<img width="745" height="427" alt="image" src="https://github.com/user-attachments/assets/6e045314-01ea-40e9-8e35-951f6109297c" />


## Pull Request Contribution Terms

- [X] I have read and agree to the contribution terms outlined in [CONTRIBUTING](https://github.com/ecotoneframework/ecotone-dev/blob/main/CONTRIBUTING.md).