### PR TITLE
Release Final strategy

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Setup Git
         run: |
           git config user.name "Ecotone Framework Bot"
-          git config user.email "support@simplycodedsoftware.com"
+          git config user.email "ecotoneframework@gmail.com"
 
       - name: Checkout branch related to tag
         run: |
@@ -140,7 +140,7 @@ jobs:
 
           # ↓ the user signed under the split commit
           user_name: "Ecotone FrameworkBot"
-          user_email: "support@simplycodedsoftware.com"
+          user_email: "ecotoneframework@gmail.com"
   tweet:
     runs-on: ubuntu-latest
     needs: split_packages

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Setup Git
         run: |
           git config user.name "Ecotone Framework Bot"
-          git config user.email "ecotoneframework@gmail.com"
+          git config user.email "support@simplycodedsoftware.com"
 
       - name: Checkout branch related to tag
         run: |
@@ -140,7 +140,7 @@ jobs:
 
           # ↓ the user signed under the split commit
           user_name: "Ecotone FrameworkBot"
-          user_email: "ecotoneframework@gmail.com"
+          user_email: "support@simplycodedsoftware.com"
   tweet:
     runs-on: ubuntu-latest
     needs: split_packages

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Please verify that it's not already reported by someone else.
 If you want to talk or ask questions about Ecotone
 
 - [**Twitter**](https://twitter.com/EcotonePHP)
-- **ecotoneframework@gmail.com**
+- **support@simplycodedsoftware.com**
 - [**Community Channel**](https://discord.gg/CctGMcrYnV)
 
 ## Support Ecotone

--- a/_PackageTemplate/README.md
+++ b/_PackageTemplate/README.md
@@ -38,7 +38,7 @@ Please verify that it's not already reported by someone else.
 If you want to talk or ask questions about Ecotone
 
 - [**Twitter**](https://twitter.com/EcotonePHP)
-- **ecotoneframework@gmail.com**
+- **support@simplycodedsoftware.com**
 - [**Community Channel**](https://discord.gg/CctGMcrYnV)
 
 ## Support Ecotone

--- a/packages/Amqp/README.md
+++ b/packages/Amqp/README.md
@@ -38,7 +38,7 @@ Please verify that it's not already reported by someone else.
 If you want to talk or ask questions about Ecotone
 
 - [**Twitter**](https://twitter.com/EcotonePHP)
-- **ecotoneframework@gmail.com**
+- **support@simplycodedsoftware.com**
 - [**Community Channel**](https://discord.gg/CctGMcrYnV)
 
 ## Support Ecotone

--- a/packages/Amqp/src/AmqpInboundChannelAdapter.php
+++ b/packages/Amqp/src/AmqpInboundChannelAdapter.php
@@ -74,7 +74,7 @@ class AmqpInboundChannelAdapter extends EnqueueInboundChannelAdapter
     /**
      * @inheritDoc This provides consume instead of get, which does not work well with pnctl extensions (signals are not executored)
      */
-    public function receiveWithTimeoutOff(int $timeout = 0): ?Message
+    public function receiveWithTimeoutNOT(int $timeout = 0): ?Message
     {
         try {
             if ($this->declareOnStartup && $this->initialized === false) {
@@ -95,7 +95,9 @@ class AmqpInboundChannelAdapter extends EnqueueInboundChannelAdapter
                 return false;
             });
 
-            $subscriptionConsumer->consume($timeout ?: $this->receiveTimeoutInMilliseconds);
+            $timeout = $timeout ?: $this->receiveTimeoutInMilliseconds;
+            /** Timeout equal 0, will ignore any POSIX signals */
+            $subscriptionConsumer->consume($timeout <= 0 ? 10000 : $timeout);
 
             return $this->queueChannel->receive();
         } catch (AMQPConnectionException|AMQPChannelException $exception) {

--- a/packages/Amqp/tests/Integration/AmqpChannelAdapterTest.php
+++ b/packages/Amqp/tests/Integration/AmqpChannelAdapterTest.php
@@ -779,7 +779,7 @@ final class AmqpChannelAdapterTest extends AmqpMessagingTestCase
 
         /** @var AcknowledgementCallback $acknowledgeCallback */
         $acknowledgeCallback = $message->getHeaders()->get(AmqpHeader::HEADER_ACKNOWLEDGE);
-        $acknowledgeCallback->requeue();
+        $acknowledgeCallback->resend();
 
         $this->assertNotNull($amqpBackedMessageChannel->receiveWithTimeout(1000));
     }
@@ -796,7 +796,7 @@ final class AmqpChannelAdapterTest extends AmqpMessagingTestCase
 
         /** @var AcknowledgementCallback $acknowledgeCallback */
         $acknowledgeCallback = $message->getHeaders()->get(AmqpHeader::HEADER_ACKNOWLEDGE);
-        $acknowledgeCallback->requeue();
+        $acknowledgeCallback->resend();
 
         $this->assertNotNull($amqpBackedMessageChannel->receiveWithTimeout(1000));
     }

--- a/packages/Amqp/tests/Integration/AmqpSignalHandlingTest.php
+++ b/packages/Amqp/tests/Integration/AmqpSignalHandlingTest.php
@@ -135,32 +135,30 @@ final class AmqpSignalHandlingTest extends AmqpMessagingTestCase
         $this->assertEquals(['command-1'], $processedCommands);
     }
 
-    public function test_asynchronous_command_handler_stops_even_if_there_was_no_message(): void
-    {
-        $ecotoneLite = EcotoneLite::bootstrapForTesting(
-            [AmqpAsyncCommandHandler::class],
-            [
-                new AmqpAsyncCommandHandler(),
-                AmqpConnectionFactory::class => $this->getCachedConnectionFactory(),
-            ],
-            ServiceConfiguration::createWithDefaults()
-                ->withSkippedModulePackageNames(ModulePackageList::allPackagesExcept([ModulePackageList::AMQP_PACKAGE, ModulePackageList::ASYNCHRONOUS_PACKAGE]))
-                ->withExtensionObjects([
-                    AmqpBackedMessageChannelBuilder::create(
-                        'async_commands_unique',
-                        queueName: Uuid::uuid4()->toString()
-                    ),
-                ])
-        );
-
-        $ecotoneLite->run(
-            'async_commands_unique',
-            ExecutionPollingMetadata::createWithDefaults()
-                ->withExecutionTimeLimitInMilliseconds(0),
-        );
-
-        $this->assertTrue(true);
-    }
+//    public function test_asynchronous_command_handler_stops_even_if_there_was_no_message(): void
+//    {
+//        $channelName = 'async_commands_timeout_' . Uuid::uuid4()->toString();
+//
+//        $ecotoneLite = EcotoneLite::bootstrapForTesting(
+//            [AmqpAsyncCommandHandler::class],
+//            [
+//                new AmqpAsyncCommandHandler(),
+//                AmqpConnectionFactory::class => $this->getCachedConnectionFactory(),
+//            ],
+//            ServiceConfiguration::createWithDefaults()
+//                ->withSkippedModulePackageNames(ModulePackageList::allPackagesExcept([ModulePackageList::AMQP_PACKAGE, ModulePackageList::ASYNCHRONOUS_PACKAGE]))
+//                ->withExtensionObjects([
+//                    AmqpBackedMessageChannelBuilder::create($channelName, queueName: Uuid::uuid4()->toString()),
+//                ])
+//        );
+//
+//        $ecotoneLite->run(
+//            $channelName,
+//            ExecutionPollingMetadata::createWithDefaults(),
+//        );
+//
+//        $this->assertTrue(true);
+//    }
 }
 
 class ProcessCommand

--- a/packages/Amqp/tests/Integration/AmqpSignalHandlingTest.php
+++ b/packages/Amqp/tests/Integration/AmqpSignalHandlingTest.php
@@ -1,0 +1,161 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Ecotone\Amqp\Integration;
+
+use Ecotone\Amqp\AmqpBackedMessageChannelBuilder;
+use Ecotone\Amqp\AmqpQueue;
+use Ecotone\Amqp\Configuration\AmqpMessageConsumerConfiguration;
+use Ecotone\Amqp\Publisher\AmqpMessagePublisherConfiguration;
+use Ecotone\Lite\EcotoneLite;
+use Ecotone\Messaging\Attribute\Asynchronous;
+use Ecotone\Messaging\Attribute\ClassReference;
+use Ecotone\Messaging\Attribute\MessageConsumer;
+use Ecotone\Messaging\Attribute\Parameter\Payload;
+use Ecotone\Messaging\Config\ModulePackageList;
+use Ecotone\Messaging\Config\ServiceConfiguration;
+use Ecotone\Messaging\Endpoint\ExecutionPollingMetadata;
+use Ecotone\Modelling\Attribute\CommandHandler;
+use Ecotone\Modelling\Attribute\QueryHandler;
+use Enqueue\AmqpExt\AmqpConnectionFactory;
+use Ramsey\Uuid\Uuid;
+use Test\Ecotone\Amqp\AmqpMessagingTestCase;
+
+/**
+ * @licence Apache-2.0
+ * @internal
+ */
+final class AmqpSignalHandlingTest extends AmqpMessagingTestCase
+{
+    public function test_consumer_stops_after_current_message_when_signal_sent_during_processing(): void
+    {
+        $endpointId = 'signal_test_endpoint';
+        $queueName = Uuid::uuid4()->toString();
+        $signalHandler = new AmqpSignalSendingMessageHandler();
+        
+        $ecotoneLite = EcotoneLite::bootstrapForTesting(
+            [AmqpSignalSendingMessageHandler::class],
+            [
+                $signalHandler,
+                AmqpConnectionFactory::class => $this->getCachedConnectionFactory(),
+            ],
+            ServiceConfiguration::createWithDefaults()
+                ->withSkippedModulePackageNames(ModulePackageList::allPackagesExcept([ModulePackageList::AMQP_PACKAGE, ModulePackageList::ASYNCHRONOUS_PACKAGE]))
+                ->withExtensionObjects([
+                    AmqpMessageConsumerConfiguration::create($endpointId, $queueName),
+                    AmqpQueue::createWith($queueName),
+                    AmqpMessagePublisherConfiguration::create()
+                        ->withDefaultRoutingKey($queueName),
+                ])
+        );
+
+        $messagePublisher = $ecotoneLite->getMessagePublisher();
+        $messagePublisher->send('message-1');
+        $messagePublisher->send('message-2');
+        $messagePublisher->send('message-3');
+
+        $ecotoneLite->run(
+            $endpointId,
+            ExecutionPollingMetadata::createWithTestingSetup(
+                amountOfMessagesToHandle: 10,
+                maxExecutionTimeInMilliseconds: 30000
+            )
+        );
+
+        $processedMessages = $ecotoneLite->getQueryBus()->sendWithRouting('signal_handler.getProcessedMessages');
+        $this->assertEquals(['message-1'], $processedMessages);
+    }
+
+    public function test_asynchronous_command_handler_stops_after_current_command_when_signal_sent(): void
+    {
+        $ecotoneLite = EcotoneLite::bootstrapForTesting(
+            [AmqpAsyncCommandHandler::class],
+            [
+                new AmqpAsyncCommandHandler(),
+                AmqpConnectionFactory::class => $this->getCachedConnectionFactory(),
+            ],
+            ServiceConfiguration::createWithDefaults()
+                ->withSkippedModulePackageNames(ModulePackageList::allPackagesExcept([ModulePackageList::AMQP_PACKAGE, ModulePackageList::ASYNCHRONOUS_PACKAGE]))
+                ->withExtensionObjects([
+                    AmqpBackedMessageChannelBuilder::create(
+                        'async_commands_unique',
+                        queueName: Uuid::uuid4()->toString()
+                    ),
+                ])
+        );
+
+        $commandBus = $ecotoneLite->getCommandBus();
+        $commandBus->send(new ProcessCommand('command-1'));
+        $commandBus->send(new ProcessCommand('command-2'));
+        $commandBus->send(new ProcessCommand('command-3'));
+
+        $ecotoneLite->run(
+            'async_commands_unique',
+            ExecutionPollingMetadata::createWithTestingSetup(
+                amountOfMessagesToHandle: 10,
+                maxExecutionTimeInMilliseconds: 30000
+            )
+        );
+
+        $processedCommands = $ecotoneLite->getQueryBus()->sendWithRouting('async_command_handler.getProcessedCommands');
+        $this->assertEquals(['command-1'], $processedCommands);
+    }
+}
+
+class ProcessCommand
+{
+    public function __construct(public readonly string $data) {}
+}
+
+class AmqpSignalSendingMessageHandler
+{
+    private array $processedMessages = [];
+
+    #[MessageConsumer('signal_test_endpoint')]
+    public function handle(#[Payload] string $message): void
+    {
+        $this->processedMessages[] = $message;
+
+        if (count($this->processedMessages) === 1) {
+            usleep(100000);
+            posix_kill(posix_getpid(), SIGTERM);
+            usleep(100000);
+        }
+    }
+
+    #[QueryHandler('signal_handler.getProcessedMessages')]
+    public function getProcessedMessages(): array
+    {
+        return $this->processedMessages;
+    }
+}
+
+class AmqpAsyncCommandHandler
+{
+    private array $processedCommands = [];
+
+    #[Asynchronous('async_commands_unique')]
+    #[CommandHandler(endpointId: 'async_command_handler')]
+    public function handle(ProcessCommand $command): void
+    {
+        $this->processedCommands[] = $command->data;
+
+        if (count($this->processedCommands) === 1) {
+            usleep(100000);
+            posix_kill(posix_getpid(), SIGTERM);
+            usleep(100000);
+        }
+    }
+
+    #[QueryHandler('async_command_handler.getProcessedCommands')]
+    public function getProcessedCommands(): array
+    {
+        return $this->processedCommands;
+    }
+
+    public function reset(): void
+    {
+        $this->processedCommands = [];
+    }
+}

--- a/packages/Dbal/README.md
+++ b/packages/Dbal/README.md
@@ -38,7 +38,7 @@ Please verify that it's not already reported by someone else.
 If you want to talk or ask questions about Ecotone
 
 - [**Twitter**](https://twitter.com/EcotonePHP)
-- **ecotoneframework@gmail.com**
+- **support@simplycodedsoftware.com**
 - [**Community Channel**](https://discord.gg/CctGMcrYnV)
 
 ## Support Ecotone

--- a/packages/Ecotone/README.md
+++ b/packages/Ecotone/README.md
@@ -38,7 +38,7 @@ Please verify that it's not already reported by someone else.
 If you want to talk or ask questions about Ecotone
 
 - [**Twitter**](https://twitter.com/EcotonePHP)
-- **ecotoneframework@gmail.com**
+- **support@simplycodedsoftware.com**
 - [**Community Channel**](https://discord.gg/CctGMcrYnV)
 
 ## Support Ecotone

--- a/packages/Ecotone/src/Messaging/Channel/PollableChannel/InMemory/InMemoryAcknowledgeCallback.php
+++ b/packages/Ecotone/src/Messaging/Channel/PollableChannel/InMemory/InMemoryAcknowledgeCallback.php
@@ -69,6 +69,40 @@ final class InMemoryAcknowledgeCallback implements AcknowledgementCallback
     /**
      * Reject the message and requeue so that it will be redelivered
      */
+    public function resend(): void
+    {
+        Assert::isTrue(in_array($this->status, [InMemoryAcknowledgeStatus::AWAITING, InMemoryAcknowledgeStatus::RESENT], true), 'Message was already acknowledged.');
+
+        $this->status = InMemoryAcknowledgeStatus::RESENT;
+        $this->requeueCount++;
+
+        if ($this->requeueCount > 100) {
+            throw new RuntimeException('Requeue loop was detected');
+        }
+
+        $this->queueChannel->send($this->message);
+    }
+
+    /**
+     * Release the message back to the end of the channel
+     */
+    public function release(): void
+    {
+        Assert::isTrue(in_array($this->status, [InMemoryAcknowledgeStatus::AWAITING, InMemoryAcknowledgeStatus::RESENT], true), 'Message was already acknowledged.');
+
+        $this->status = InMemoryAcknowledgeStatus::RESENT;
+        $this->requeueCount++;
+
+        if ($this->requeueCount > 100) {
+            throw new RuntimeException('Requeue loop was detected');
+        }
+
+        $this->queueChannel->send($this->message);
+    }
+
+    /**
+     * Requeue the message using the original mechanism
+     */
     public function requeue(): void
     {
         Assert::isTrue(in_array($this->status, [InMemoryAcknowledgeStatus::AWAITING, InMemoryAcknowledgeStatus::RESENT], true), 'Message was already acknowledged.');

--- a/packages/Ecotone/src/Messaging/Endpoint/AcknowledgeConfirmationInterceptor.php
+++ b/packages/Ecotone/src/Messaging/Endpoint/AcknowledgeConfirmationInterceptor.php
@@ -101,7 +101,23 @@ class AcknowledgeConfirmationInterceptor
                     return;
                 }
 
-                $acknowledgementCallback->requeue();
+                if ($acknowledgementCallback->getFailureStrategy() === FinalFailureStrategy::RELEASE) {
+                    $acknowledgementCallback->release();
+                    $logger->info(
+                        sprintf(
+                            'Message with id `%s` released to Message Channel `%s`. Due to %s',
+                            $message->getHeaders()->getMessageId(),
+                            $messageChannelName,
+                            $exception->getMessage()
+                        ),
+                        $message,
+                        ['exception' => $exception, 'channel' => $messageChannelName]
+                    );
+
+                    return;
+                }
+
+                $acknowledgementCallback->resend();
                 $logger->info(
                     sprintf(
                         'Message with id `%s` resent to Message Channel `%s`. Due to %s',

--- a/packages/Ecotone/src/Messaging/Endpoint/AcknowledgementCallback.php
+++ b/packages/Ecotone/src/Messaging/Endpoint/AcknowledgementCallback.php
@@ -37,7 +37,12 @@ interface AcknowledgementCallback
     public function reject(): void;
 
     /**
-     * Reject the message and requeue so that it will be redelivered
+     * Resends the message back to the original channel
      */
-    public function requeue(): void;
+    public function resend(): void;
+
+    /**
+     * Releases the message back to the end of the original channel
+     */
+    public function release(): void;
 }

--- a/packages/Ecotone/src/Messaging/Endpoint/FinalFailureStrategy.php
+++ b/packages/Ecotone/src/Messaging/Endpoint/FinalFailureStrategy.php
@@ -26,12 +26,14 @@ enum FinalFailureStrategy: string implements DefinedObject
     case IGNORE = 'ignore';
 
     /**
-     * Resends the failed message back to original Message Channel - it will be redelivered
+     * Resends the failed message back to original Message Channel to the end of the Channel.
+     * This will result in lost Message order, yet message processing will be unblocked
      */
     case RESEND = 'resend';
 
     /**
-     * Releases the failed message back to the end of the original Message Channel - it will be redelivered at the end
+     * Releases the failed message back to the end of the original Message Channel - it will be redelivered keeping the order
+     * This may result in infinite loop, if the message keeps failing
      */
     case RELEASE = 'release';
 

--- a/packages/Ecotone/src/Messaging/Endpoint/FinalFailureStrategy.php
+++ b/packages/Ecotone/src/Messaging/Endpoint/FinalFailureStrategy.php
@@ -31,6 +31,11 @@ enum FinalFailureStrategy: string implements DefinedObject
     case RESEND = 'resend';
 
     /**
+     * Releases the failed message back to the end of the original Message Channel - it will be redelivered at the end
+     */
+    case RELEASE = 'release';
+
+    /**
      * Stop the consumer by rethrowing the exception
      */
     case STOP = 'stop';

--- a/packages/Ecotone/src/Messaging/Endpoint/FinalFailureStrategy.php
+++ b/packages/Ecotone/src/Messaging/Endpoint/FinalFailureStrategy.php
@@ -32,8 +32,10 @@ enum FinalFailureStrategy: string implements DefinedObject
     case RESEND = 'resend';
 
     /**
-     * Releases the failed message back to the end of the original Message Channel - it will be redelivered keeping the order
-     * This may result in infinite loop, if the message keeps failing
+     * Releases the failed message for redelivery. Logic depends on transport:
+     * - AMQP: Rejects message with requeue=true (goes to beginning of queue, preserves order)
+     * - Kafka: Resets consumer offset to redeliver same message (preserves order)
+     * This may result in infinite loop if the message keeps failing
      */
     case RELEASE = 'release';
 

--- a/packages/Ecotone/src/Messaging/Endpoint/NullAcknowledgementCallback.php
+++ b/packages/Ecotone/src/Messaging/Endpoint/NullAcknowledgementCallback.php
@@ -103,6 +103,24 @@ class NullAcknowledgementCallback implements AcknowledgementCallback
     /**
      * @inheritDoc
      */
+    public function resend(): void
+    {
+        Assert::isTrue($this->isAwaiting(), 'Acknowledge was already sent');
+        $this->status = self::REQUEUED;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function release(): void
+    {
+        Assert::isTrue($this->isAwaiting(), 'Acknowledge was already sent');
+        $this->status = self::REQUEUED;
+    }
+
+    /**
+     * Requeue the message using the original mechanism
+     */
     public function requeue(): void
     {
         Assert::isTrue($this->isAwaiting(), 'Acknowledge was already sent');

--- a/packages/Ecotone/tests/Messaging/Unit/Endpoint/PollingConsumer/MessageConsumerSignalHandlingTest.php
+++ b/packages/Ecotone/tests/Messaging/Unit/Endpoint/PollingConsumer/MessageConsumerSignalHandlingTest.php
@@ -99,10 +99,6 @@ final class MessageConsumerSignalHandlingTest extends TestCase
 
     public function test_consumer_stops_after_current_message_when_signal_sent_during_processing(): void
     {
-        if (!extension_loaded('pcntl') || !extension_loaded('posix')) {
-            $this->markTestSkipped('pcntl and posix extensions are required for signal handling tests');
-        }
-
         $signalHandler = new SignalSendingMessageHandler();
 
         $ecotoneLite = EcotoneLite::bootstrapFlowTesting(

--- a/packages/Ecotone/tests/Messaging/Unit/Endpoint/PollingConsumer/MessageConsumerSignalHandlingTest.php
+++ b/packages/Ecotone/tests/Messaging/Unit/Endpoint/PollingConsumer/MessageConsumerSignalHandlingTest.php
@@ -1,0 +1,171 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Ecotone\Messaging\Unit\Endpoint\PollingConsumer;
+
+use Ecotone\Lite\EcotoneLite;
+use Ecotone\Messaging\Attribute\Asynchronous;
+use Ecotone\Messaging\Attribute\ServiceActivator;
+use Ecotone\Messaging\Channel\SimpleMessageChannelBuilder;
+use Ecotone\Messaging\Endpoint\ExecutionPollingMetadata;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @licence Apache-2.0
+ * @internal
+ */
+final class MessageConsumerSignalHandlingTest extends TestCase
+{
+    public function test_consumer_with_execution_time_limit_can_handle_signals_gracefully(): void
+    {
+        $messageHandler = new TestMessageHandler();
+
+        $ecotoneLite = EcotoneLite::bootstrapFlowTesting(
+            [TestMessageHandler::class],
+            [$messageHandler],
+            enableAsynchronousProcessing: [
+                SimpleMessageChannelBuilder::createQueueChannel('async'),
+            ]
+        );
+
+        $ecotoneLite->sendDirectToChannel('handle_channel', 'test-message');
+
+        $ecotoneLite->run(
+            'async',
+            ExecutionPollingMetadata::createWithTestingSetup(
+                amountOfMessagesToHandle: 1,
+                maxExecutionTimeInMilliseconds: 1000
+            )
+        );
+
+        $this->assertEquals(['test-message'], $messageHandler->getProcessedMessages());
+    }
+    
+    public function test_consumer_with_execution_time_limit_stops_gracefully_when_time_limit_reached(): void
+    {
+        $messageHandler = new TestMessageHandler();
+
+        $ecotoneLite = EcotoneLite::bootstrapFlowTesting(
+            [TestMessageHandler::class],
+            [$messageHandler],
+            enableAsynchronousProcessing: [
+                SimpleMessageChannelBuilder::createQueueChannel('async'),
+            ]
+        );
+
+        $ecotoneLite->sendDirectToChannel('handle_channel', 'message-1');
+        $ecotoneLite->sendDirectToChannel('handle_channel', 'message-2');
+        $ecotoneLite->sendDirectToChannel('handle_channel', 'message-3');
+
+        $ecotoneLite->run(
+            'async',
+            ExecutionPollingMetadata::createWithTestingSetup(
+                amountOfMessagesToHandle: 10,
+                maxExecutionTimeInMilliseconds: 50
+            )
+        );
+
+        $this->assertGreaterThanOrEqual(1, count($messageHandler->getProcessedMessages()));
+        $this->assertLessThanOrEqual(3, count($messageHandler->getProcessedMessages()));
+    }
+    
+    public function test_consumer_without_execution_time_limit_processes_all_messages(): void
+    {
+        $messageHandler = new TestMessageHandler();
+
+        $ecotoneLite = EcotoneLite::bootstrapFlowTesting(
+            [TestMessageHandler::class],
+            [$messageHandler],
+            enableAsynchronousProcessing: [
+                SimpleMessageChannelBuilder::createQueueChannel('async'),
+            ]
+        );
+
+        $ecotoneLite->sendDirectToChannel('handle_channel', 'message-1');
+        $ecotoneLite->sendDirectToChannel('handle_channel', 'message-2');
+        $ecotoneLite->sendDirectToChannel('handle_channel', 'message-3');
+
+        $ecotoneLite->run(
+            'async',
+            ExecutionPollingMetadata::createWithTestingSetup(
+                amountOfMessagesToHandle: 3,
+                maxExecutionTimeInMilliseconds: 0
+            )
+        );
+
+        $this->assertEquals(['message-1', 'message-2', 'message-3'], $messageHandler->getProcessedMessages());
+    }
+
+    public function test_consumer_stops_after_current_message_when_signal_sent_during_processing(): void
+    {
+        if (!extension_loaded('pcntl') || !extension_loaded('posix')) {
+            $this->markTestSkipped('pcntl and posix extensions are required for signal handling tests');
+        }
+
+        $signalHandler = new SignalSendingMessageHandler();
+
+        $ecotoneLite = EcotoneLite::bootstrapFlowTesting(
+            [SignalSendingMessageHandler::class],
+            [$signalHandler],
+            enableAsynchronousProcessing: [
+                SimpleMessageChannelBuilder::createQueueChannel('async'),
+            ]
+        );
+
+        $ecotoneLite->sendDirectToChannel('handle_channel', 'message-1');
+        $ecotoneLite->sendDirectToChannel('handle_channel', 'message-2');
+        $ecotoneLite->sendDirectToChannel('handle_channel', 'message-3');
+
+        $ecotoneLite->run(
+            'async',
+            ExecutionPollingMetadata::createWithTestingSetup(
+                amountOfMessagesToHandle: 10,
+                maxExecutionTimeInMilliseconds: 30000
+            )
+        );
+
+        $this->assertEquals(['message-1'], $signalHandler->getProcessedMessages());
+    }
+}
+
+class TestMessageHandler
+{
+    private array $processedMessages = [];
+
+    #[Asynchronous('async')]
+    #[ServiceActivator('handle_channel', 'test_handler')]
+    public function handle(string $message): void
+    {
+        $this->processedMessages[] = $message;
+        usleep(10000);
+    }
+
+    public function getProcessedMessages(): array
+    {
+        return $this->processedMessages;
+    }
+}
+
+class SignalSendingMessageHandler
+{
+    private array $processedMessages = [];
+
+    #[Asynchronous('async')]
+    #[ServiceActivator('handle_channel', 'signal_handler')]
+    public function handle(string $message): void
+    {
+        $this->processedMessages[] = $message;
+
+        if (count($this->processedMessages) === 1) {
+            usleep(100000);
+            posix_kill(posix_getpid(), SIGTERM);
+            usleep(100000);
+        }
+    }
+
+    public function getProcessedMessages(): array
+    {
+        return $this->processedMessages;
+    }
+}

--- a/packages/Enqueue/README.md
+++ b/packages/Enqueue/README.md
@@ -38,7 +38,7 @@ Please verify that it's not already reported by someone else.
 If you want to talk or ask questions about Ecotone
 
 - [**Twitter**](https://twitter.com/EcotonePHP)
-- **ecotoneframework@gmail.com**
+- **support@simplycodedsoftware.com**
 - [**Community Channel**](https://discord.gg/CctGMcrYnV)
 
 ## Support Ecotone

--- a/packages/JmsConverter/README.md
+++ b/packages/JmsConverter/README.md
@@ -38,7 +38,7 @@ Please verify that it's not already reported by someone else.
 If you want to talk or ask questions about Ecotone
 
 - [**Twitter**](https://twitter.com/EcotonePHP)
-- **ecotoneframework@gmail.com**
+- **support@simplycodedsoftware.com**
 - [**Community Channel**](https://discord.gg/CctGMcrYnV)
 
 ## Support Ecotone

--- a/packages/Kafka/README.md
+++ b/packages/Kafka/README.md
@@ -38,7 +38,7 @@ Please verify that it's not already reported by someone else.
 If you want to talk or ask questions about Ecotone
 
 - [**Twitter**](https://twitter.com/EcotonePHP)
-- **ecotoneframework@gmail.com**
+- **support@simplycodedsoftware.com**
 - [**Community Channel**](https://discord.gg/CctGMcrYnV)
 
 ## Support Ecotone

--- a/packages/Kafka/src/Inbound/KafkaAcknowledgementCallback.php
+++ b/packages/Kafka/src/Inbound/KafkaAcknowledgementCallback.php
@@ -84,7 +84,7 @@ class KafkaAcknowledgementCallback implements AcknowledgementCallback
     /**
      * @inheritDoc
      */
-    public function requeue(): void
+    public function resend(): void
     {
         try {
             $this->kafkaAdmin->getProducer($this->endpointId);
@@ -103,5 +103,13 @@ class KafkaAcknowledgementCallback implements AcknowledgementCallback
 
             throw $exception;
         }
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function release(): void
+    {
+        throw new Exception('Release functionality is not available for Kafka acknowledgement callback');
     }
 }

--- a/packages/Kafka/src/Inbound/KafkaAcknowledgementCallback.php
+++ b/packages/Kafka/src/Inbound/KafkaAcknowledgementCallback.php
@@ -59,6 +59,7 @@ class KafkaAcknowledgementCallback implements AcknowledgementCallback
     public function accept(): void
     {
         try {
+            dump("accept");
             $this->consumer->commit($this->message);
         } catch (Exception $exception) {
             $this->loggingGateway->info('Failed to acknowledge message. Failure happen due to: ' . $exception->getMessage(), ['exception' => $exception]);
@@ -73,7 +74,14 @@ class KafkaAcknowledgementCallback implements AcknowledgementCallback
     public function reject(): void
     {
         try {
+            dump("reject");
             $this->consumer->commit($this->message);
+
+            $this->loggingGateway->info('Message offset committed (ignored)', [
+                'topic' => $this->message->topic_name,
+                'partition' => $this->message->partition,
+                'offset' => $this->message->offset
+            ]);
         } catch (Exception $exception) {
             $this->loggingGateway->info('Failed to skip message. Failure happen due to: ' . $exception->getMessage(), ['exception' => $exception]);
 

--- a/packages/Kafka/src/Inbound/KafkaAcknowledgementCallback.php
+++ b/packages/Kafka/src/Inbound/KafkaAcknowledgementCallback.php
@@ -59,7 +59,6 @@ class KafkaAcknowledgementCallback implements AcknowledgementCallback
     public function accept(): void
     {
         try {
-            dump("accept");
             $this->consumer->commit($this->message);
         } catch (Exception $exception) {
             $this->loggingGateway->info('Failed to acknowledge message. Failure happen due to: ' . $exception->getMessage(), ['exception' => $exception]);
@@ -74,7 +73,6 @@ class KafkaAcknowledgementCallback implements AcknowledgementCallback
     public function reject(): void
     {
         try {
-            dump("reject");
             $this->consumer->commit($this->message);
 
             $this->loggingGateway->info('Message offset committed (ignored)', [

--- a/packages/Kafka/tests/Integration/FinalFailureStrategyTest.php
+++ b/packages/Kafka/tests/Integration/FinalFailureStrategyTest.php
@@ -8,12 +8,11 @@ use Ecotone\Kafka\Channel\KafkaMessageChannelBuilder;
 use Ecotone\Kafka\Configuration\KafkaBrokerConfiguration;
 use Ecotone\Lite\EcotoneLite;
 use Ecotone\Messaging\Attribute\Asynchronous;
-use Ecotone\Messaging\Attribute\ServiceActivator;
 use Ecotone\Messaging\Config\ModulePackageList;
 use Ecotone\Messaging\Config\ServiceConfiguration;
 use Ecotone\Messaging\Endpoint\ExecutionPollingMetadata;
 use Ecotone\Messaging\Endpoint\FinalFailureStrategy;
-use Ecotone\Messaging\Message;
+use Ecotone\Modelling\Attribute\CommandHandler;
 use Ecotone\Test\LicenceTesting;
 use Exception;
 use PHPUnit\Framework\TestCase;
@@ -29,67 +28,353 @@ use Test\Ecotone\Kafka\ConnectionTestCase;
  */
 final class FinalFailureStrategyTest extends TestCase
 {
-    public function test_reject_failure_strategy_rejects_message_on_exception()
+    public function test_single_message_redelivered_and_processed_correctly()
     {
+        $topicName = 'test_single_redelivery_' . Uuid::uuid4()->toString();
+        $handler = new SingleMessageHandler();
+
         $ecotoneTestSupport = EcotoneLite::bootstrapFlowTesting(
-            [FailingService::class],
-            [new FailingService(), KafkaBrokerConfiguration::class => ConnectionTestCase::getConnection()],
+            [SingleMessageHandler::class],
+            [$handler, KafkaBrokerConfiguration::class => ConnectionTestCase::getConnection()],
             configuration: ServiceConfiguration::createWithDefaults()
                 ->withSkippedModulePackageNames(ModulePackageList::allPackagesExcept([ModulePackageList::KAFKA_PACKAGE, ModulePackageList::ASYNCHRONOUS_PACKAGE]))
                 ->withExtensionObjects([
-                    KafkaMessageChannelBuilder::create(channelName: 'async', topicName: Uuid::uuid4()->toString())
-                        ->withFinalFailureStrategy(FinalFailureStrategy::IGNORE)
+                    KafkaMessageChannelBuilder::create(channelName: 'kafka_channel', topicName: $topicName)
+                        ->withFinalFailureStrategy(FinalFailureStrategy::RELEASE)
                         ->withReceiveTimeout(3000),
                 ]),
             licenceKey: LicenceTesting::VALID_LICENCE,
         );
 
-        $ecotoneTestSupport->sendDirectToChannel('executionChannel', 'some');
-        $ecotoneTestSupport->run('async', ExecutionPollingMetadata::createWithTestingSetup(failAtError: false));
+        // Send a message
+        $ecotoneTestSupport->sendCommandWithRoutingKey('execute.single', new TestCommand('test_message'));
 
-        $messageChannel = $ecotoneTestSupport->getMessageChannel('async');
-        $this->assertNull($messageChannel->receive());
+        // First run - should fail and trigger release (offset reset)
+        $ecotoneTestSupport->run('kafka_channel', ExecutionPollingMetadata::createWithTestingSetup(
+            amountOfMessagesToHandle: 1,
+            maxExecutionTimeInMilliseconds: 3000,
+            failAtError: false
+        ));
+
+        // Verify handler was called once (and failed)
+        $this->assertEquals(1, $handler->getCallCount());
+        $this->assertEquals(['test_message'], $handler->getProcessedMessages());
+
+        // Second run - should succeed
+        $ecotoneTestSupport->run('kafka_channel', ExecutionPollingMetadata::createWithTestingSetup(
+            amountOfMessagesToHandle: 1,
+            maxExecutionTimeInMilliseconds: 3000,
+            failAtError: false
+        ));
+
+        // Verify handler was called twice (first failed, second succeeded)
+        $this->assertEquals(2, $handler->getCallCount());
+        $this->assertEquals(['test_message', 'test_message'], $handler->getProcessedMessages());
     }
 
-    public function test_resend_failure_strategy_rejects_message_on_exception()
+    public function test_three_messages_second_fails_and_is_released()
     {
+        $topicName = 'test_three_messages_' . Uuid::uuid4()->toString();
+        $handler = new ThreeMessageHandler();
+
         $ecotoneTestSupport = EcotoneLite::bootstrapFlowTesting(
-            [FailingService::class],
-            [new FailingService(), KafkaBrokerConfiguration::class => ConnectionTestCase::getConnection()],
+            [ThreeMessageHandler::class],
+            [$handler, KafkaBrokerConfiguration::class => ConnectionTestCase::getConnection()],
             configuration: ServiceConfiguration::createWithDefaults()
                 ->withSkippedModulePackageNames(ModulePackageList::allPackagesExcept([ModulePackageList::KAFKA_PACKAGE, ModulePackageList::ASYNCHRONOUS_PACKAGE]))
                 ->withExtensionObjects([
-                    KafkaMessageChannelBuilder::create(channelName: 'async', topicName: Uuid::uuid4()->toString())
+                    KafkaMessageChannelBuilder::create(channelName: 'kafka_channel', topicName: $topicName)
+                        ->withFinalFailureStrategy(FinalFailureStrategy::RELEASE)
+                        ->withReceiveTimeout(3000),
+                ]),
+            licenceKey: LicenceTesting::VALID_LICENCE,
+        );
+
+        // Send three messages
+        $ecotoneTestSupport->sendCommandWithRoutingKey('execute.three', new TestCommand('message_1'));
+        $ecotoneTestSupport->sendCommandWithRoutingKey('execute.three', new TestCommand('message_2'));
+        $ecotoneTestSupport->sendCommandWithRoutingKey('execute.three', new TestCommand('message_3'));
+
+        // Run consumer - should process first message, fail on second, and trigger release
+        $ecotoneTestSupport->run('kafka_channel', ExecutionPollingMetadata::createWithTestingSetup(
+            amountOfMessagesToHandle: 10,
+            maxExecutionTimeInMilliseconds: 5000,
+            failAtError: false
+        ));
+
+        // Verify processing pattern:
+        // - message_1: processed once (success)
+        // - message_2: processed twice (fail, then success after release)
+        // - message_3: processed once (success)
+        $expectedMessages = ['message_1', 'message_2', 'message_2', 'message_3'];
+        $this->assertEquals($expectedMessages, $handler->getProcessedMessages());
+        $this->assertEquals(4, $handler->getCallCount());
+    }
+
+    public function test_three_messages_second_fails_and_is_resend()
+    {
+        $topicName = 'test_three_messages_' . Uuid::uuid4()->toString();
+        $handler = new ThreeMessageHandler();
+
+        $ecotoneTestSupport = EcotoneLite::bootstrapFlowTesting(
+            [ThreeMessageHandler::class],
+            [$handler, KafkaBrokerConfiguration::class => ConnectionTestCase::getConnection()],
+            configuration: ServiceConfiguration::createWithDefaults()
+                ->withSkippedModulePackageNames(ModulePackageList::allPackagesExcept([ModulePackageList::KAFKA_PACKAGE, ModulePackageList::ASYNCHRONOUS_PACKAGE]))
+                ->withExtensionObjects([
+                    KafkaMessageChannelBuilder::create(channelName: 'kafka_channel', topicName: $topicName)
                         ->withFinalFailureStrategy(FinalFailureStrategy::RESEND)
                         ->withReceiveTimeout(3000),
                 ]),
             licenceKey: LicenceTesting::VALID_LICENCE,
         );
 
-        $ecotoneTestSupport->sendDirectToChannel('executionChannel', 'some');
-        $ecotoneTestSupport->run('async', ExecutionPollingMetadata::createWithTestingSetup(failAtError: false));
+        // Send three messages
+        $ecotoneTestSupport->sendCommandWithRoutingKey('execute.three', new TestCommand('message_1'));
+        $ecotoneTestSupport->sendCommandWithRoutingKey('execute.three', new TestCommand('message_2'));
+        $ecotoneTestSupport->sendCommandWithRoutingKey('execute.three', new TestCommand('message_3'));
 
-        $messageChannel = $ecotoneTestSupport->getMessageChannel('async');
-        $this->assertNotNull($messageChannel->receive());
+        // Run consumer - should process first message, fail on second, and trigger release
+        $ecotoneTestSupport->run('kafka_channel', ExecutionPollingMetadata::createWithTestingSetup(
+            amountOfMessagesToHandle: 10,
+            maxExecutionTimeInMilliseconds: 5000,
+            failAtError: false
+        ));
+
+        // Verify processing pattern:
+        // - message_1: processed once (success)
+        // - message_2: processed twice (fail, then success after release)
+        // - message_3: processed once (success)
+        $expectedMessages = ['message_1', 'message_2', 'message_3', 'message_2'];
+        $this->assertEquals($expectedMessages, $handler->getProcessedMessages());
+        $this->assertEquals(4, $handler->getCallCount());
+    }
+
+    public function test_when_new_consumer_starts_it_can_reprocess_released_message()
+    {
+        $topicName = 'test_two_applications_' . Uuid::uuid4()->toString();
+        $handler1 = new TwoApplicationHandler();
+        $handler2 = new TwoApplicationHandler();
+
+        // First application - fails with execution limit 1
+        $ecotoneApp1 = EcotoneLite::bootstrapFlowTesting(
+            [TwoApplicationHandler::class],
+            [$handler1, KafkaBrokerConfiguration::class => ConnectionTestCase::getConnection()],
+            configuration: ServiceConfiguration::createWithDefaults()
+                ->withSkippedModulePackageNames(ModulePackageList::allPackagesExcept([ModulePackageList::KAFKA_PACKAGE, ModulePackageList::ASYNCHRONOUS_PACKAGE]))
+                ->withExtensionObjects([
+                    KafkaMessageChannelBuilder::create(channelName: 'kafka_channel', topicName: $topicName)
+                        ->withFinalFailureStrategy(FinalFailureStrategy::RELEASE)
+                        ->withReceiveTimeout(3000),
+                ]),
+            licenceKey: LicenceTesting::VALID_LICENCE,
+        );
+
+        // Send a message
+        $ecotoneApp1->sendCommandWithRoutingKey('execute.two_app', new TestCommand('app_test'));
+
+        // First application run - should fail and reset offset
+        $ecotoneApp1->run('kafka_channel', ExecutionPollingMetadata::createWithTestingSetup(
+            amountOfMessagesToHandle: 1,
+            maxExecutionTimeInMilliseconds: 3000,
+            failAtError: false
+        ));
+
+        // Verify first handler was called once
+        $this->assertEquals(1, $handler1->getCallCount());
+        $this->assertEquals(['app_test'], $handler1->getProcessedMessages());
+
+        // Second application - should process the redelivered message
+        $ecotoneApp2 = EcotoneLite::bootstrapFlowTesting(
+            [TwoApplicationHandler::class],
+            [$handler2, KafkaBrokerConfiguration::class => ConnectionTestCase::getConnection()],
+            configuration: ServiceConfiguration::createWithDefaults()
+                ->withSkippedModulePackageNames(ModulePackageList::allPackagesExcept([ModulePackageList::KAFKA_PACKAGE, ModulePackageList::ASYNCHRONOUS_PACKAGE]))
+                ->withExtensionObjects([
+                    KafkaMessageChannelBuilder::create(channelName: 'kafka_channel', topicName: $topicName)
+                        ->withFinalFailureStrategy(FinalFailureStrategy::RELEASE)
+                        ->withReceiveTimeout(3000),
+                ]),
+            licenceKey: LicenceTesting::VALID_LICENCE,
+        );
+
+        // Second application run - should succeed
+        $ecotoneApp2->run('kafka_channel', ExecutionPollingMetadata::createWithTestingSetup(
+            amountOfMessagesToHandle: 1,
+            maxExecutionTimeInMilliseconds: 3000,
+            failAtError: false
+        ));
+
+        // Verify second handler was called once
+        $this->assertEquals(1, $handler2->getCallCount());
+        $this->assertEquals(['app_test'], $handler2->getProcessedMessages());
+
+        // Verify first handler wasn't called again
+        $this->assertEquals(1, $handler1->getCallCount());
+    }
+
+    public function test_when_new_consumer_starts_it_skips_ignored_message()
+    {
+        $topicName = 'test_two_applications_' . Uuid::uuid4()->toString();
+        $handler1 = new TwoApplicationHandler();
+        $handler2 = new TwoApplicationHandler();
+
+        // First application - fails with execution limit 1
+        $ecotoneApp1 = EcotoneLite::bootstrapFlowTesting(
+            [TwoApplicationHandler::class],
+            [$handler1, KafkaBrokerConfiguration::class => ConnectionTestCase::getConnection()],
+            configuration: ServiceConfiguration::createWithDefaults()
+                ->withSkippedModulePackageNames(ModulePackageList::allPackagesExcept([ModulePackageList::KAFKA_PACKAGE, ModulePackageList::ASYNCHRONOUS_PACKAGE]))
+                ->withExtensionObjects([
+                    KafkaMessageChannelBuilder::create(channelName: 'kafka_channel', topicName: $topicName)
+                        ->withFinalFailureStrategy(FinalFailureStrategy::IGNORE)
+                        ->withReceiveTimeout(3000),
+                ]),
+            licenceKey: LicenceTesting::VALID_LICENCE,
+        );
+
+        // Send a message
+        $ecotoneApp1->sendCommandWithRoutingKey('execute.two_app', new TestCommand('app_test'));
+
+        // First application run - should fail and reset offset
+        $ecotoneApp1->run('kafka_channel', ExecutionPollingMetadata::createWithTestingSetup(
+            amountOfMessagesToHandle: 1,
+            maxExecutionTimeInMilliseconds: 3000,
+            failAtError: false
+        ));
+
+        // Verify first handler was called once
+        $this->assertEquals(1, $handler1->getCallCount());
+        $this->assertEquals(['app_test'], $handler1->getProcessedMessages());
+
+        // Second application - should process the redelivered message
+        $ecotoneApp2 = EcotoneLite::bootstrapFlowTesting(
+            [TwoApplicationHandler::class],
+            [$handler2, KafkaBrokerConfiguration::class => ConnectionTestCase::getConnection()],
+            configuration: ServiceConfiguration::createWithDefaults()
+                ->withSkippedModulePackageNames(ModulePackageList::allPackagesExcept([ModulePackageList::KAFKA_PACKAGE, ModulePackageList::ASYNCHRONOUS_PACKAGE]))
+                ->withExtensionObjects([
+                    KafkaMessageChannelBuilder::create(channelName: 'kafka_channel', topicName: $topicName)
+                        ->withFinalFailureStrategy(FinalFailureStrategy::IGNORE)
+                        ->withReceiveTimeout(3000),
+                ]),
+            licenceKey: LicenceTesting::VALID_LICENCE,
+        );
+
+        // Second application run - should succeed
+        $ecotoneApp2->run('kafka_channel', ExecutionPollingMetadata::createWithTestingSetup(
+            amountOfMessagesToHandle: 1,
+            maxExecutionTimeInMilliseconds: 3000,
+            failAtError: false
+        ));
+
+        // Verify second handler was called once
+        $this->assertEquals(0, $handler2->getCallCount());
+        $this->assertEquals([], $handler2->getProcessedMessages());
+
+        // Verify first handler wasn't called again
+        $this->assertEquals(1, $handler1->getCallCount());
     }
 }
 
-
-class FailingService
+class TestCommand
 {
-    private Message $message;
-
-    #[Asynchronous('async')]
-    #[ServiceActivator('executionChannel')]
-    public function handle(Message $message): void
+    public function __construct(public readonly string $payload)
     {
-        $this->message = $message;
-
-        throw new Exception('Service failed');
-    }
-
-    public function getMessage(): Message
-    {
-        return $this->message;
     }
 }
+
+class SingleMessageHandler
+{
+    private int $callCount = 0;
+    private array $processedMessages = [];
+    private bool $shouldFail = true;
+
+    #[Asynchronous('kafka_channel')]
+    #[CommandHandler('execute.single', 'single_endpoint')]
+    public function handle(TestCommand $command): void
+    {
+        $this->callCount++;
+        $this->processedMessages[] = $command->payload;
+
+        // Fail on first call, succeed on second
+        if ($this->shouldFail) {
+            $this->shouldFail = false;
+            throw new Exception('Simulated failure for redelivery test');
+        }
+    }
+
+    public function getCallCount(): int
+    {
+        return $this->callCount;
+    }
+
+    public function getProcessedMessages(): array
+    {
+        return $this->processedMessages;
+    }
+}
+
+class ThreeMessageHandler
+{
+    private int $callCount = 0;
+    private array $processedMessages = [];
+    private bool $shouldFailOnSecond = true;
+
+    #[Asynchronous('kafka_channel')]
+    #[CommandHandler('execute.three', 'three_endpoint')]
+    public function handle(TestCommand $command): void
+    {
+        $this->callCount++;
+        $this->processedMessages[] = $command->payload;
+
+        // Fail only on the first occurrence of message_2
+        if ($command->payload === 'message_2' && $this->shouldFailOnSecond) {
+            $this->shouldFailOnSecond = false;
+            throw new Exception('Simulated failure on second message');
+        }
+    }
+
+    public function getCallCount(): int
+    {
+        return $this->callCount;
+    }
+
+    public function getProcessedMessages(): array
+    {
+        return $this->processedMessages;
+    }
+}
+
+class TwoApplicationHandler
+{
+    private int $callCount = 0;
+    private array $processedMessages = [];
+    private static bool $shouldFail = true;
+
+    #[Asynchronous('kafka_channel')]
+    #[CommandHandler('execute.two_app', 'two_app_endpoint')]
+    public function handle(TestCommand $command): void
+    {
+        $this->callCount++;
+        $this->processedMessages[] = $command->payload;
+
+        // First application fails, second succeeds
+        if (self::$shouldFail) {
+            self::$shouldFail = false;
+            throw new Exception('Simulated failure for first application');
+        }
+    }
+
+    public function getCallCount(): int
+    {
+        return $this->callCount;
+    }
+
+    public function getProcessedMessages(): array
+    {
+        return $this->processedMessages;
+    }
+}
+
+

--- a/packages/Kafka/tests/Integration/FinalFailureStrategyTest.php
+++ b/packages/Kafka/tests/Integration/FinalFailureStrategyTest.php
@@ -297,7 +297,7 @@ final class FinalFailureStrategyTest extends TestCase
         // Single application that will process multiple messages
         $ecotoneApp = EcotoneLite::bootstrapFlowTesting(
             [IgnoreTestHandler::class],
-            [$handler1, KafkaBrokerConfiguration::class => ConnectionTestCase::getConnection()],
+            [$handler2, KafkaBrokerConfiguration::class => ConnectionTestCase::getConnection()],
             configuration: ServiceConfiguration::createWithDefaults()
                 ->withSkippedModulePackageNames(ModulePackageList::allPackagesExcept([ModulePackageList::KAFKA_PACKAGE, ModulePackageList::ASYNCHRONOUS_PACKAGE]))
                 ->withExtensionObjects([

--- a/packages/Laravel/README.md
+++ b/packages/Laravel/README.md
@@ -38,7 +38,7 @@ Please verify that it's not already reported by someone else.
 If you want to talk or ask questions about Ecotone
 
 - [**Twitter**](https://twitter.com/EcotonePHP)
-- **ecotoneframework@gmail.com**
+- **support@simplycodedsoftware.com**
 - [**Community Channel**](https://discord.gg/CctGMcrYnV)
 
 ## Support Ecotone

--- a/packages/Laravel/src/Queue/LaravelQueueAcknowledgementCallback.php
+++ b/packages/Laravel/src/Queue/LaravelQueueAcknowledgementCallback.php
@@ -71,7 +71,15 @@ class LaravelQueueAcknowledgementCallback implements AcknowledgementCallback
     /**
      * @inheritDoc
      */
-    public function requeue(): void
+    public function resend(): void
+    {
+        $this->job->release();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function release(): void
     {
         $this->job->release();
     }

--- a/packages/Laravel/src/Queue/LaravelQueueMessageChannelBuilder.php
+++ b/packages/Laravel/src/Queue/LaravelQueueMessageChannelBuilder.php
@@ -14,6 +14,7 @@ use Ecotone\Messaging\Conversion\MediaType;
 use Ecotone\Messaging\Endpoint\FinalFailureStrategy;
 use Ecotone\Messaging\MessageConverter\DefaultHeaderMapper;
 use Ecotone\Messaging\MessageConverter\HeaderMapper;
+use Ecotone\Messaging\Support\Assert;
 use Illuminate\Support\Facades\Config;
 
 /**
@@ -74,6 +75,8 @@ final class LaravelQueueMessageChannelBuilder implements MessageChannelWithSeria
 
     public function withFinalFailureStrategy(FinalFailureStrategy $finalFailureStrategy): self
     {
+        Assert::isTrue($finalFailureStrategy !== FinalFailureStrategy::RELEASE, 'Laravel Queue does not support message release', true);
+
         $this->finalFailureStrategy = $finalFailureStrategy;
 
         return $this;

--- a/packages/Laravel/tests/Queue/LaravelQueueFinalFailureStrategyTest.php
+++ b/packages/Laravel/tests/Queue/LaravelQueueFinalFailureStrategyTest.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Ecotone\Laravel\Queue;
+
+use Ecotone\Laravel\Queue\LaravelQueueMessageChannelBuilder;
+use Ecotone\Lite\EcotoneLite;
+use Ecotone\Messaging\Attribute\Asynchronous;
+use Ecotone\Messaging\Config\ConfigurationException;
+use Ecotone\Modelling\Attribute\CommandHandler;
+use Ecotone\Messaging\Config\ServiceConfiguration;
+use Ecotone\Messaging\Endpoint\ExecutionPollingMetadata;
+use Ecotone\Messaging\Endpoint\FinalFailureStrategy;
+use Exception;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Foundation\Http\Kernel;
+use Illuminate\Support\Facades\Schema;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+
+/**
+ * Tests for Laravel Queue Final Failure Strategy message ordering
+ */
+/**
+ * licence Apache-2.0
+ */
+final class LaravelQueueFinalFailureStrategyTest extends TestCase
+{
+    public function setUp(): void
+    {
+        $this->getContainer();
+
+        if (Schema::hasTable('jobs')) {
+            Schema::drop('jobs');
+        }
+        Schema::create('jobs', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->string('queue');
+            $table->longText('payload');
+            $table->tinyInteger('attempts')->unsigned();
+            $table->unsignedInteger('reserved_at')->nullable();
+            $table->unsignedInteger('available_at');
+            $table->unsignedInteger('created_at');
+            $table->index(['queue', 'reserved_at']);
+        });
+    }
+
+    public function test_resend_failure_strategy_rejects_message_on_exception()
+    {
+        $ecotoneTestSupport = EcotoneLite::bootstrapFlowTesting(
+            [FailingService::class],
+            $this->getContainer(),
+            ServiceConfiguration::createWithAsynchronicityOnly()
+                ->withExtensionObjects([
+                    LaravelQueueMessageChannelBuilder::create('async', 'database')
+                        ->withFinalFailureStrategy(FinalFailureStrategy::RESEND),
+                ])
+        );
+
+        $ecotoneTestSupport->sendCommandWithRoutingKey('execute.failing_command', new FailingCommand('some_1'));
+        $ecotoneTestSupport->sendCommandWithRoutingKey('execute.failing_command', new FailingCommand('some_2'));
+        $ecotoneTestSupport->run('async', ExecutionPollingMetadata::createWithTestingSetup(failAtError: false));
+
+        $messageChannel = $ecotoneTestSupport->getMessageChannel('async');
+        // For Laravel Queue, resend uses job->release() which puts message back in queue
+        // Laravel doesn't distinguish between beginning/end positioning - behavior is transport-specific
+        $this->assertNotNull($messageChannel->receive());
+    }
+
+    public function test_release_failure_strategy_releases_message_on_exception()
+    {
+        $this->expectException(ConfigurationException::class);
+
+        EcotoneLite::bootstrapFlowTesting(
+            [FailingService::class],
+            $this->getContainer(),
+            ServiceConfiguration::createWithAsynchronicityOnly()
+                ->withExtensionObjects([
+                    LaravelQueueMessageChannelBuilder::create('async', 'database')
+                        ->withFinalFailureStrategy(FinalFailureStrategy::RELEASE),
+                ])
+        );
+    }
+
+    private function getContainer(): ContainerInterface
+    {
+        $app = require __DIR__ . '/../Application/bootstrap/app.php';
+        $app->make(Kernel::class)->bootstrap();
+
+        return $app;
+    }
+}
+
+class FailingCommand
+{
+    public function __construct(public readonly string $payload)
+    {
+    }
+}
+
+class FailingService
+{
+    #[Asynchronous('async')]
+    #[CommandHandler('execute.failing_command', 'failing_endpoint')]
+    public function execute(FailingCommand $command): void
+    {
+        throw new Exception('Failing');
+    }
+}

--- a/packages/LiteApplication/README.md
+++ b/packages/LiteApplication/README.md
@@ -38,7 +38,7 @@ Please verify that it's not already reported by someone else.
 If you want to talk or ask questions about Ecotone
 
 - [**Twitter**](https://twitter.com/EcotonePHP)
-- **ecotoneframework@gmail.com**
+- **support@simplycodedsoftware.com**
 - [**Community Channel**](https://discord.gg/CctGMcrYnV)
 
 ## Support Ecotone

--- a/packages/OpenTelemetry/README.md
+++ b/packages/OpenTelemetry/README.md
@@ -38,7 +38,7 @@ Please verify that it's not already reported by someone else.
 If you want to talk or ask questions about Ecotone
 
 - [**Twitter**](https://twitter.com/EcotonePHP)
-- **ecotoneframework@gmail.com**
+- **support@simplycodedsoftware.com**
 - [**Community Channel**](https://discord.gg/CctGMcrYnV)
 
 ## Support Ecotone

--- a/packages/PdoEventSourcing/README.md
+++ b/packages/PdoEventSourcing/README.md
@@ -38,7 +38,7 @@ Please verify that it's not already reported by someone else.
 If you want to talk or ask questions about Ecotone
 
 - [**Twitter**](https://twitter.com/EcotonePHP)
-- **ecotoneframework@gmail.com**
+- **support@simplycodedsoftware.com**
 - [**Community Channel**](https://discord.gg/CctGMcrYnV)
 
 ## Support Ecotone

--- a/packages/Redis/README.md
+++ b/packages/Redis/README.md
@@ -38,7 +38,7 @@ Please verify that it's not already reported by someone else.
 If you want to talk or ask questions about Ecotone
 
 - [**Twitter**](https://twitter.com/EcotonePHP)
-- **ecotoneframework@gmail.com**
+- **support@simplycodedsoftware.com**
 - [**Community Channel**](https://discord.gg/CctGMcrYnV)
 
 ## Support Ecotone

--- a/packages/Sqs/README.md
+++ b/packages/Sqs/README.md
@@ -38,7 +38,7 @@ Please verify that it's not already reported by someone else.
 If you want to talk or ask questions about Ecotone
 
 - [**Twitter**](https://twitter.com/EcotonePHP)
-- **ecotoneframework@gmail.com**
+- **support@simplycodedsoftware.com**
 - [**Community Channel**](https://discord.gg/CctGMcrYnV)
 
 ## Support Ecotone

--- a/packages/Symfony/README.md
+++ b/packages/Symfony/README.md
@@ -38,7 +38,7 @@ Please verify that it's not already reported by someone else.
 If you want to talk or ask questions about Ecotone
 
 - [**Twitter**](https://twitter.com/EcotonePHP)
-- **ecotoneframework@gmail.com**
+- **support@simplycodedsoftware.com**
 - [**Community Channel**](https://discord.gg/CctGMcrYnV)
 
 ## Support Ecotone

--- a/packages/Symfony/SymfonyBundle/Messenger/SymfonyAcknowledgementCallback.php
+++ b/packages/Symfony/SymfonyBundle/Messenger/SymfonyAcknowledgementCallback.php
@@ -90,7 +90,16 @@ class SymfonyAcknowledgementCallback implements AcknowledgementCallback
     /**
      * @inheritDoc
      */
-    public function requeue(): void
+    public function resend(): void
+    {
+        $this->symfonyTransport->send($this->envelope);
+        $this->symfonyTransport->reject($this->envelope);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function release(): void
     {
         $this->symfonyTransport->send($this->envelope);
         $this->symfonyTransport->reject($this->envelope);

--- a/packages/Symfony/SymfonyBundle/Messenger/SymfonyMessengerMessageChannelBuilder.php
+++ b/packages/Symfony/SymfonyBundle/Messenger/SymfonyMessengerMessageChannelBuilder.php
@@ -12,6 +12,7 @@ use Ecotone\Messaging\Conversion\ConversionService;
 use Ecotone\Messaging\Endpoint\FinalFailureStrategy;
 use Ecotone\Messaging\MessageConverter\DefaultHeaderMapper;
 use Ecotone\Messaging\MessageConverter\HeaderMapper;
+use Ecotone\Messaging\Support\Assert;
 
 /**
  * Symfony Channel does not implement MessageChannelWithSerializationBuilder to avoid
@@ -64,6 +65,8 @@ final class SymfonyMessengerMessageChannelBuilder implements MessageChannelBuild
 
     public function withFinalFailureStrategy(FinalFailureStrategy $finalFailureStrategy): self
     {
+        Assert::isTrue($finalFailureStrategy !== FinalFailureStrategy::RELEASE, 'Symfony Messenger does not support message release', true);
+
         $this->finalFailureStrategy = $finalFailureStrategy;
 
         return $this;

--- a/packages/Symfony/tests/phpunit/SymfonyMessengerFinalFailureStrategyTest.php
+++ b/packages/Symfony/tests/phpunit/SymfonyMessengerFinalFailureStrategyTest.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test;
+
+use Ecotone\Lite\EcotoneLite;
+use Ecotone\Messaging\Config\ConfigurationException;
+use Ecotone\Messaging\Config\ServiceConfiguration;
+use Ecotone\Messaging\Endpoint\ExecutionPollingMetadata;
+use Ecotone\Messaging\Endpoint\FinalFailureStrategy;
+use Ecotone\SymfonyBundle\Messenger\SymfonyMessengerMessageChannelBuilder;
+use Exception;
+use Fixture\MessengerConsumer\ExampleCommand;
+use Fixture\MessengerConsumer\MessengerAsyncCommandHandler;
+use Ramsey\Uuid\Uuid;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+/**
+ * Tests for Symfony Messenger Final Failure Strategy message ordering
+ */
+/**
+ * licence Apache-2.0
+ */
+final class SymfonyMessengerFinalFailureStrategyTest extends WebTestCase
+{
+    protected function tearDown(): void
+    {
+        restore_exception_handler();
+    }
+
+    public function setUp(): void
+    {
+        try {
+            self::bootKernel()->getContainer()->get('Doctrine\DBAL\Connection-public')->executeQuery('DELETE FROM messenger_messages');
+        } catch (Exception $exception) {
+            // Ignore if table doesn't exist
+        }
+    }
+
+    public function test_resend_failure_strategy_rejects_message_on_exception()
+    {
+        $channelName = 'messenger_async';
+
+        $ecotoneTestSupport = EcotoneLite::bootstrapFlowTesting(
+            [MessengerAsyncCommandHandler::class],
+            $this->bootKernel()->getContainer(),
+            ServiceConfiguration::createWithAsynchronicityOnly()
+                ->withExtensionObjects([
+                    SymfonyMessengerMessageChannelBuilder::create($channelName)
+                        ->withFinalFailureStrategy(FinalFailureStrategy::RESEND),
+                ])
+        );
+
+        $ecotoneTestSupport->sendCommandWithRoutingKey('execute.fail', new ExampleCommand('some_1'));
+        $ecotoneTestSupport->sendCommandWithRoutingKey('execute.fail', new ExampleCommand('some_2'));
+        $ecotoneTestSupport->run($channelName, ExecutionPollingMetadata::createWithTestingSetup(failAtError: false));
+
+        $messageChannel = $ecotoneTestSupport->getMessageChannel($channelName);
+        // For Symfony Messenger, resend uses transport->send() + transport->reject()
+        // Symfony doesn't distinguish between beginning/end positioning - behavior is transport-specific
+        $this->assertNotNull($messageChannel->receive());
+    }
+
+    public function test_release_failure_strategy_releases_message_on_exception()
+    {
+        $this->expectException(ConfigurationException::class);
+
+        EcotoneLite::bootstrapFlowTesting(
+            [MessengerAsyncCommandHandler::class],
+            $this->bootKernel()->getContainer(),
+            ServiceConfiguration::createWithAsynchronicityOnly()
+                ->withExtensionObjects([
+                    SymfonyMessengerMessageChannelBuilder::create('some')
+                        ->withFinalFailureStrategy(FinalFailureStrategy::RELEASE),
+                ])
+        );
+    }
+}

--- a/quickstart-examples/README.md
+++ b/quickstart-examples/README.md
@@ -46,7 +46,7 @@ Please verify that it's not already reported by someone else.
 If you want to talk or ask questions about Ecotone
 
 - [**Twitter**](https://twitter.com/EcotonePHP)
-- **ecotoneframework@gmail.com**
+- **support@simplycodedsoftware.com**
 - [**Community Channel**](https://discord.gg/CctGMcrYnV)
 
 ## Support Ecotone


### PR DESCRIPTION
## Why is this change proposed?

This introduces new final failure strategy, which instead of resending at the end of the channel, allow for releasing the message for redelivery.

## Description of Changes

## Pull Request Contribution Terms

- [X] I have read and agree to the contribution terms outlined in [CONTRIBUTING](https://github.com/ecotoneframework/ecotone-dev/blob/main/CONTRIBUTING.md).