### PR TITLE
Allow interfaces in EventSourcingHandler

### DIFF
--- a/packages/Ecotone/src/Messaging/Handler/InterfaceParameter.php
+++ b/packages/Ecotone/src/Messaging/Handler/InterfaceParameter.php
@@ -185,7 +185,7 @@ final class InterfaceParameter
     /**
      * @return bool
      */
-    public function isObjectTypeHint(): bool
+    public function isClassOrInterface(): bool
     {
         return class_exists($this->getTypeHint()) || interface_exists($this->getTypeHint());
     }

--- a/packages/Ecotone/src/Messaging/Handler/InterfaceParameter.php
+++ b/packages/Ecotone/src/Messaging/Handler/InterfaceParameter.php
@@ -187,7 +187,7 @@ final class InterfaceParameter
      */
     public function isObjectTypeHint(): bool
     {
-        return class_exists($this->getTypeHint());
+        return class_exists($this->getTypeHint()) || interface_exists($this->getTypeHint());
     }
 
     public function __toString()

--- a/packages/Ecotone/src/Modelling/EventSourcingExecutor/EventSourcingHandlerExecutorBuilder.php
+++ b/packages/Ecotone/src/Modelling/EventSourcingExecutor/EventSourcingHandlerExecutorBuilder.php
@@ -48,8 +48,8 @@ final class EventSourcingHandlerExecutorBuilder
                 if ($methodToCheck->getInterfaceParameterAmount() < 1) {
                     throw ConfigurationException::create("{$methodToCheck} is Event Sourcing Handler and should have at least one parameter.");
                 }
-                if (! $methodToCheck->getFirstParameter()->isObjectTypeHint()) {
-                    throw ConfigurationException::create("{$methodToCheck} is Event Sourcing Handler and should have first parameter as Event Class type hint.");
+                if (! $methodToCheck->getFirstParameter()->isClassOrInterface()) {
+                    throw ConfigurationException::create("{$methodToCheck} is Event Sourcing Handler and should have first parameter as Event Class or Interface type hint.");
                 }
                 if (! $methodToCheck->hasReturnTypeVoid()) {
                     throw ConfigurationException::create("{$methodToCheck} is Event Sourcing Handler and should return void return type");

--- a/packages/Ecotone/tests/Modelling/Fixture/AggregateServiceBuilder/AggregateCreated.php
+++ b/packages/Ecotone/tests/Modelling/Fixture/AggregateServiceBuilder/AggregateCreated.php
@@ -7,7 +7,7 @@ namespace Test\Ecotone\Modelling\Fixture\AggregateServiceBuilder;
 /**
  * licence Apache-2.0
  */
-final class AggregateCreated
+final class AggregateCreated implements AggregateCreatedInterface
 {
     public function __construct(public int $id)
     {

--- a/packages/Ecotone/tests/Modelling/Fixture/AggregateServiceBuilder/AggregateCreatedInterface.php
+++ b/packages/Ecotone/tests/Modelling/Fixture/AggregateServiceBuilder/AggregateCreatedInterface.php
@@ -1,0 +1,11 @@
+<?php
+declare(strict_types=1);
+
+namespace Test\Ecotone\Modelling\Fixture\AggregateServiceBuilder;
+
+/**
+ * licence Apache-2.0
+ */
+interface AggregateCreatedInterface
+{
+}

--- a/packages/Ecotone/tests/Modelling/Fixture/AggregateServiceBuilder/EventSourcingAggregateExample.php
+++ b/packages/Ecotone/tests/Modelling/Fixture/AggregateServiceBuilder/EventSourcingAggregateExample.php
@@ -42,7 +42,7 @@ final class EventSourcingAggregateExample
     }
 
     #[EventSourcingHandler]
-    public function applyAggregateCreated(AggregateCreated $event): void
+    public function applyAggregateCreated(AggregateCreatedInterface $event): void
     {
         $this->id = $event->id;
     }


### PR DESCRIPTION
## Why is this change proposed?
According to [documentation](https://docs.ecotone.tech/modelling/command-handling/external-command-handlers/event-handling#subscribe-to-interface-or-abstract-class) it's possible to use Interfaces or Abstract Classes in EventHandlers. However, when I try to use an interface in an EventSourcingHandler, I get the error "<...> is Event Sourcing Handler and should have first parameter as Event Class type hint."

## Description of Changes
Add `|| interface_exists` check in InterfaceParameter::isObjectTypeHint

## Pull Request Contribution Terms

- [x] I have read and agree to the contribution terms outlined in [CONTRIBUTING](https://github.com/ecotoneframework/ecotone-dev/blob/main/CONTRIBUTING.md).