### PR TITLE
Projecting improvements 1

### DIFF
--- a/packages/Ecotone/src/Messaging/Scheduling/Duration.php
+++ b/packages/Ecotone/src/Messaging/Scheduling/Duration.php
@@ -29,6 +29,11 @@ final class Duration
         return new self((int) round($seconds * 1_000_000));
     }
 
+    public static function minutes(int|float $seconds): self
+    {
+        return new self((int) round($seconds * 60 * 1_000_000));
+    }
+
     public static function zero(): self
     {
         return new self(0);

--- a/packages/Ecotone/src/Projecting/Config/ProjectingConsoleCommands.php
+++ b/packages/Ecotone/src/Projecting/Config/ProjectingConsoleCommands.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 namespace Ecotone\Projecting\Config;
 
 use Ecotone\Messaging\Attribute\ConsoleCommand;
+use Ecotone\Messaging\Attribute\ConsoleParameterOption;
 use Ecotone\Projecting\ProjectionRegistry;
 use InvalidArgumentException;
 
@@ -18,12 +19,21 @@ class ProjectingConsoleCommands
     }
 
     #[ConsoleCommand('ecotone:projection:init')]
-    public function initProjection(string $name): void
+    public function initProjection(?string $name = null, #[ConsoleParameterOption] bool $all = false): void
     {
-        if (! $this->registry->has($name)) {
-            throw new InvalidArgumentException("There is no projection with name {$name}");
+        if ($name === null) {
+            if (! $all) {
+                throw new InvalidArgumentException('You need to provide projection name or use --all option');
+            }
+            foreach ($this->registry->projectionNames() as $projection) {
+                $this->registry->get($projection)->init();
+            }
+        } else {
+            if (! $this->registry->has($name)) {
+                throw new InvalidArgumentException("There is no projection with name {$name}");
+            }
+            $this->registry->get($name)->init();
         }
-        $this->registry->get($name)->init();
     }
 
     #[ConsoleCommand('ecotone:projection:backfill')]

--- a/packages/Ecotone/src/Projecting/InMemory/InMemoryProjectionRegistry.php
+++ b/packages/Ecotone/src/Projecting/InMemory/InMemoryProjectionRegistry.php
@@ -36,4 +36,9 @@ class InMemoryProjectionRegistry implements ProjectionRegistry
 
         return $this->projectionManagers[$id];
     }
+
+    public function projectionNames(): iterable
+    {
+        return array_keys($this->projectionManagers);
+    }
 }

--- a/packages/Ecotone/src/Projecting/ProjectingManager.php
+++ b/packages/Ecotone/src/Projecting/ProjectingManager.php
@@ -19,6 +19,7 @@ class ProjectingManager
         private PartitionProvider      $partitionProvider,
         private string                 $projectionName,
         private int                    $batchSize = 1000,
+        private bool                   $autoInit = true,
     ) {
         if ($batchSize < 1) {
             throw new InvalidArgumentException('Batch size must be at least 1');
@@ -28,7 +29,9 @@ class ProjectingManager
     // This is the method that is linked to the event bus routing channel
     public function execute(?string $partitionKey = null): void
     {
-        $this->init();
+        if ($this->autoInit) {
+            $this->init();
+        }
 
         do {
             $transaction = $this->projectionStateStorage->beginTransaction();

--- a/packages/Ecotone/src/Projecting/ProjectionRegistry.php
+++ b/packages/Ecotone/src/Projecting/ProjectionRegistry.php
@@ -12,4 +12,6 @@ use Psr\Container\ContainerInterface;
 interface ProjectionRegistry extends ContainerInterface
 {
     public function get(string $id): ProjectingManager;
+    /** @return iterable<string> */
+    public function projectionNames(): iterable;
 }

--- a/packages/PdoEventSourcing/src/Projecting/PartitionState/DbalProjectionStateStorage.php
+++ b/packages/PdoEventSourcing/src/Projecting/PartitionState/DbalProjectionStateStorage.php
@@ -15,6 +15,7 @@ use Ecotone\Projecting\ProjectionStateStorage;
 use Ecotone\Projecting\Transaction;
 use Enqueue\Dbal\DbalConnectionFactory;
 
+use Enqueue\Dbal\ManagerRegistryConnectionFactory;
 use function json_decode;
 use function json_encode;
 
@@ -28,7 +29,7 @@ class DbalProjectionStateStorage implements ProjectionStateStorage
     private bool $initialized = false;
 
     public function __construct(
-        DbalConnectionFactory $connectionFactory,
+        DbalConnectionFactory|ManagerRegistryConnectionFactory $connectionFactory,
         private string        $stateTable = 'ecotone_projection_state',
     ) {
         $this->connection = $connectionFactory->createContext()->getDbalConnection();

--- a/packages/PdoEventSourcing/src/Projecting/StreamSource/EventStoreGlobalStreamSourceBuilder.php
+++ b/packages/PdoEventSourcing/src/Projecting/StreamSource/EventStoreGlobalStreamSourceBuilder.php
@@ -11,6 +11,7 @@ use Ecotone\EventSourcing\EventStore;
 use Ecotone\Messaging\Config\Container\Definition;
 use Ecotone\Messaging\Config\Container\MessagingContainerBuilder;
 use Ecotone\Messaging\Config\Container\Reference;
+use Ecotone\Messaging\Scheduling\Duration;
 use Ecotone\Messaging\Scheduling\EcotoneClockInterface;
 use Ecotone\Projecting\Config\ProjectionComponentBuilder;
 use Ecotone\Projecting\StreamSource;
@@ -36,6 +37,8 @@ class EventStoreGlobalStreamSourceBuilder implements ProjectionComponentBuilder
                 Reference::to(EventStore::class),
                 Reference::to(EcotoneClockInterface::class),
                 $this->streamName,
+                5_000,
+                new Definition(Duration::class, [60], 'seconds')
             ],
         );
     }

--- a/packages/PdoEventSourcing/src/Projecting/StreamSource/GapAwarePosition.php
+++ b/packages/PdoEventSourcing/src/Projecting/StreamSource/GapAwarePosition.php
@@ -74,8 +74,18 @@ class GapAwarePosition
         return $this->gaps;
     }
 
-    public function advanceTo(int $position): void
+    public function advanceTo(int $position, bool $processGaps = true): void
     {
+        if ($processGaps === false) {
+            if ($position > $this->position) {
+                $this->position = $position;
+            } elseif ($position <= $this->position) {
+                throw new InvalidArgumentException('Cannot advance to a position less than or equal to the current position. Current position: ' . $this->position . ', new position: ' . $position);
+            }
+            return;
+        }
+
+        // With gap processing
         if ($position === $this->position + 1) {
             $this->position++;
         } elseif (in_array($position, $this->gaps, true)) {


### PR DESCRIPTION
## Description of Changes
- fix DbalProjectionStorage when using manager registry in the container
- Init all projections in one console command: `ecotone:projecting:init --all=true`
- better gap timeout processing for event store stream source (default to 60 seconds timeout)
- don't add gaps if the event timestamp is after gap timeout (avoids adding gaps while backfilling)

## Pull Request Contribution Terms

- [X] I have read and agree to the contribution terms outlined in [CONTRIBUTING](https://github.com/ecotoneframework/ecotone-dev/blob/main/CONTRIBUTING.md).