### PR TITLE
Fix: ignore errors while parsing array shapes

### DIFF
--- a/packages/Ecotone/tests/Messaging/Unit/Handler/TypeDescriptorTest.php
+++ b/packages/Ecotone/tests/Messaging/Unit/Handler/TypeDescriptorTest.php
@@ -729,4 +729,12 @@ class TypeDescriptorTest extends TestCase
             Type::createWithDocBlock('array|int', 'stdClass[]')
         );
     }
+
+    public function test_it_ignores_incomplete_array_shapes(): void
+    {
+        $this->assertEquals(Type::array(), Type::create('array{'));
+        $this->assertEquals(Type::array(), Type::create('array{0'));
+        $this->assertEquals(Type::array(), Type::create('array{0:'));
+        $this->assertEquals(Type::array(), Type::create('array{0:i'));
+    }
 }


### PR DESCRIPTION
## Why is this change proposed?

`TypeResolver` is not able to parse multiline phpdoc types: it will just take the first line of type.
With the changes introduced by #523 , we can now parse array shapes, which are the most common types that are multiline, and could break some existing code.
For backward compatibility, this PR ignore malformed array shapes and returns a basic 'array' type.

@lifinsky 

## Pull Request Contribution Terms

- [X] I have read and agree to the contribution terms outlined in [CONTRIBUTING](https://github.com/ecotoneframework/ecotone-dev/blob/main/CONTRIBUTING.md).