### PR TITLE
Default async config in tests

### DIFF
--- a/packages/Ecotone/src/Messaging/Config/Annotation/ModuleConfiguration/AsynchronousModule.php
+++ b/packages/Ecotone/src/Messaging/Config/Annotation/ModuleConfiguration/AsynchronousModule.php
@@ -36,8 +36,9 @@ class AsynchronousModule implements AnnotationModule, RoutingEventHandler
 {
     /**
      * @param array<string, array<string>> $asyncEndpoints
+     * @param array<string, array<string>> $streamSourcesAsyncEndpoints
      */
-    private function __construct(private array $asyncEndpoints)
+    private function __construct(private array $asyncEndpoints, private array $streamSourcesAsyncEndpoints)
     {
     }
 
@@ -55,6 +56,7 @@ class AsynchronousModule implements AnnotationModule, RoutingEventHandler
         );
 
         $registeredAsyncEndpoints = [];
+        $streamSourcesAsyncEndpoints = [];
         foreach ($asynchronousClasses as $asynchronousClass) {
             /** @var Asynchronous $asyncClass */
             $asyncClass = AnnotatedDefinitionReference::getSingleAnnotationForClass($annotationRegistrationService, $asynchronousClass, Asynchronous::class);
@@ -65,16 +67,17 @@ class AsynchronousModule implements AnnotationModule, RoutingEventHandler
                     if ($annotationForMethod instanceof QueryHandler) {
                         continue;
                     }
-                    if ($endpoint->hasClassAnnotation(StreamBasedSource::class)) {
-                        continue;
-                    }
                     if (in_array(get_class($annotationForMethod), [CommandHandler::class, EventHandler::class])) {
                         if ($annotationForMethod->isEndpointIdGenerated()) {
                             throw ConfigurationException::create("{$endpoint} should have endpointId defined for handling asynchronously");
                         }
                     }
 
-                    $registeredAsyncEndpoints[$annotationForMethod->getEndpointId()] = $asyncClass->getChannelName();
+                    if ($endpoint->hasClassAnnotation(StreamBasedSource::class)) {
+                        $streamSourcesAsyncEndpoints[$annotationForMethod->getEndpointId()] = $asyncClass->getChannelName();
+                    }else {
+                        $registeredAsyncEndpoints[$annotationForMethod->getEndpointId()] = $asyncClass->getChannelName();
+                    }
                 }
             }
         }
@@ -100,7 +103,7 @@ class AsynchronousModule implements AnnotationModule, RoutingEventHandler
             }
         }
 
-        return new self($registeredAsyncEndpoints);
+        return new self($registeredAsyncEndpoints, $streamSourcesAsyncEndpoints);
     }
 
     public function getSynchronousChannelFor(string $handlerChannelName, string $endpointIdToLookFor): ?string
@@ -141,28 +144,10 @@ class AsynchronousModule implements AnnotationModule, RoutingEventHandler
 
         foreach ($endpointChannels as $endpointChannel => $asyncChannels) {
             $messagingConfiguration->registerAsynchronousEndpoint($asyncChannels, $endpointChannel);
-
-            /** Default polling metadata for tests */
-            if ($serviceConfiguration->isModulePackageEnabled(ModulePackageList::TEST_PACKAGE)) {
-                foreach ($asyncChannels as $asyncEndpointChannel) {
-                    if (! $this->hasPollingMetadata($pollingMetadata, $asyncEndpointChannel)) {
-                        if ($this->isInMemoryPollableChannel($polingChannelBuilders, $asyncEndpointChannel)) {
-                            $messagingConfiguration->registerPollingMetadata(
-                                PollingMetadata::create($asyncEndpointChannel)
-                                    ->setStopOnError(true)
-                                    ->setFinishWhenNoMessages(true)
-                            );
-
-                            continue;
-                        }
-
-                        $messagingConfiguration->registerPollingMetadata(
-                            PollingMetadata::create($asyncEndpointChannel)
-                                ->withTestingSetup(100, 100, true)
-                        );
-                    }
-                }
-            }
+            $this->registerDefaultPollingMetadata($serviceConfiguration, $asyncChannels, $pollingMetadata, $polingChannelBuilders, $messagingConfiguration);
+        }
+        foreach ($this->streamSourcesAsyncEndpoints as $endpointChannel => $asyncChannels) {
+            $this->registerDefaultPollingMetadata($serviceConfiguration, $asyncChannels, $pollingMetadata, $polingChannelBuilders, $messagingConfiguration);
         }
     }
 
@@ -269,6 +254,31 @@ class AsynchronousModule implements AnnotationModule, RoutingEventHandler
             Assert::isTrue(! in_array($annotationForMethod->getInputChannelName(), $asynchronous->getChannelName()), "Command Handler routing key can't be equal to asynchronous channel name in {$registration}");
         } elseif ($annotationForMethod instanceof EventHandler) {
             Assert::isTrue(! in_array($annotationForMethod->getListenTo(), $asynchronous->getChannelName()), "Event Handler listen to routing can't be equal to asynchronous channel name in {$registration}");
+        }
+    }
+
+    public function registerDefaultPollingMetadata(ServiceConfiguration $serviceConfiguration, array $asyncChannels, array $pollingMetadata, array $polingChannelBuilders, Configuration $messagingConfiguration): void
+    {
+        /** Default polling metadata for tests */
+        if ($serviceConfiguration->isModulePackageEnabled(ModulePackageList::TEST_PACKAGE)) {
+            foreach ($asyncChannels as $asyncEndpointChannel) {
+                if (!$this->hasPollingMetadata($pollingMetadata, $asyncEndpointChannel)) {
+                    if ($this->isInMemoryPollableChannel($polingChannelBuilders, $asyncEndpointChannel)) {
+                        $messagingConfiguration->registerPollingMetadata(
+                            PollingMetadata::create($asyncEndpointChannel)
+                                ->setStopOnError(true)
+                                ->setFinishWhenNoMessages(true)
+                        );
+
+                        continue;
+                    }
+
+                    $messagingConfiguration->registerPollingMetadata(
+                        PollingMetadata::create($asyncEndpointChannel)
+                            ->withTestingSetup(100, 100, true)
+                    );
+                }
+            }
         }
     }
 }

--- a/packages/PdoEventSourcing/tests/Integration/AsynchronousEventDrivenProjectionTest.php
+++ b/packages/PdoEventSourcing/tests/Integration/AsynchronousEventDrivenProjectionTest.php
@@ -4,9 +4,11 @@ declare(strict_types=1);
 
 namespace Test\Ecotone\EventSourcing\Integration;
 
+use Ecotone\Dbal\DbalBackedMessageChannelBuilder;
 use Ecotone\EventSourcing\EventSourcingConfiguration;
 use Ecotone\Lite\EcotoneLite;
 use Ecotone\Lite\Test\FlowTestSupport;
+use Ecotone\Messaging\Channel\SimpleMessageChannelBuilder;
 use Ecotone\Messaging\Config\ModulePackageList;
 use Ecotone\Messaging\Config\ServiceConfiguration;
 use Enqueue\Dbal\DbalConnectionFactory;
@@ -39,6 +41,58 @@ final class AsynchronousEventDrivenProjectionTest extends EventSourcingMessaging
         $ecotone->run(InProgressTicketList::PROJECTION_CHANNEL);
 
         self::assertEquals([], $ecotone->sendQueryWithRouting('getInProgressTickets'));
+    }
+
+    public function test_asynchronous_projection_runs_on_default_testing_pollable_setup(): void
+    {
+        $ecotone = self::bootstrapEcotone(
+            classesToResolve: [
+                InProgressTicketList::class,
+            ],
+            namespaces: [
+                'Test\Ecotone\EventSourcing\Fixture\Ticket',
+            ],
+            extensionObjects: [
+                SimpleMessageChannelBuilder::createQueueChannel(InProgressTicketList::PROJECTION_CHANNEL, true),
+            ]
+        );
+
+        $ecotone->sendCommand(new RegisterTicket('123', 'Johnny', 'alert'));
+
+        $currentTime = microtime(true);
+        $ecotone->run(InProgressTicketList::PROJECTION_CHANNEL);
+        $finishTime = microtime(true);
+
+        // less than ~100 ms
+        self::assertLessThan(100, ($finishTime - $currentTime) * 1000);
+
+        self::assertEquals([['ticket_id' => '123', 'ticket_type' => 'alert']], $ecotone->sendQueryWithRouting('getInProgressTickets'));
+    }
+
+    public function test_asynchronous_projection_runs_on_default_testing_pollable_setup_with_dbal_channel(): void
+    {
+        $ecotone = self::bootstrapEcotone(
+            classesToResolve: [
+                InProgressTicketList::class,
+            ],
+            namespaces: [
+                'Test\Ecotone\EventSourcing\Fixture\Ticket',
+            ],
+            extensionObjects: [
+                DbalBackedMessageChannelBuilder::create(InProgressTicketList::PROJECTION_CHANNEL),
+            ]
+        );
+
+        $ecotone->sendCommand(new RegisterTicket('123', 'Johnny', 'alert'));
+
+        $currentTime = microtime(true);
+        $ecotone->run(InProgressTicketList::PROJECTION_CHANNEL);
+        $finishTime = microtime(true);
+
+        // around ~100 ms as default testing setup is 100ms
+        self::assertLessThan(150, ($finishTime - $currentTime) * 1000);
+
+        self::assertEquals([['ticket_id' => '123', 'ticket_type' => 'alert']], $ecotone->sendQueryWithRouting('getInProgressTickets'));
     }
 
     public function test_operations_on_asynchronous_event_driven_projection(): void
@@ -147,22 +201,27 @@ final class AsynchronousEventDrivenProjectionTest extends EventSourcingMessaging
 
     }
 
-    private static function bootstrapEcotone(): FlowTestSupport
+    private static function bootstrapEcotone(
+        $classesToResolve = [],
+        $namespaces = [
+            'Test\Ecotone\EventSourcing\Fixture\Ticket',
+            'Test\Ecotone\EventSourcing\Fixture\TicketWithAsynchronousEventDrivenProjection',
+        ],
+        array $extensionObjects = [],
+    ): FlowTestSupport
     {
         return EcotoneLite::bootstrapFlowTestingWithEventStore(
+            classesToResolve: $classesToResolve,
             containerOrAvailableServices: [new InProgressTicketList(self::getConnection()), new TicketEventConverter(), DbalConnectionFactory::class => self::getConnectionFactory()],
             configuration: ServiceConfiguration::createWithDefaults()
                 ->withEnvironment('prod')
                 ->withSkippedModulePackageNames(ModulePackageList::allPackagesExcept([ModulePackageList::EVENT_SOURCING_PACKAGE, ModulePackageList::ASYNCHRONOUS_PACKAGE]))
-                ->withNamespaces([
-                    'Test\Ecotone\EventSourcing\Fixture\Ticket',
-                    'Test\Ecotone\EventSourcing\Fixture\TicketWithAsynchronousEventDrivenProjection',
-                ])
-                ->withExtensionObjects([
+                ->withNamespaces($namespaces)
+                ->withExtensionObjects(array_merge([
                     EventSourcingConfiguration::createWithDefaults(),
-                ]),
+                ], $extensionObjects)),
             pathToRootCatalog: __DIR__ . '/../../',
-            runForProductionEventStore: true
+            runForProductionEventStore: true,
         );
     }
 }


### PR DESCRIPTION
## Why is this change proposed?

This ensures that default async configuration for Message Consumers is set up even for Asynchronous Projections (as currently it works only for Async Event Handlers)

## Pull Request Contribution Terms

- [X] I have read and agree to the contribution terms outlined in [CONTRIBUTING](https://github.com/ecotoneframework/ecotone-dev/blob/main/CONTRIBUTING.md).