### PR TITLE
Add a test to reproduce the static converter bug.

### DIFF
--- a/packages/PdoEventSourcing/tests/Fixture/MetadataPropagatingForAggregate/Balance.php
+++ b/packages/PdoEventSourcing/tests/Fixture/MetadataPropagatingForAggregate/Balance.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Test\Ecotone\EventSourcing\Fixture\MetadataPropagatingForAggregate;
+
+use Ecotone\Modelling\Attribute\CommandHandler;
+use Ecotone\Modelling\Attribute\EventSourcingAggregate;
+use Ecotone\Modelling\Attribute\EventSourcingHandler;
+use Ecotone\Modelling\Attribute\Identifier;
+use Ecotone\Modelling\WithAggregateVersioning;
+use Ramsey\Uuid\Rfc4122\UuidV4;
+
+#[EventSourcingAggregate]
+/**
+ * licence Apache-2.0
+ */
+class Balance
+{
+    use WithAggregateVersioning;
+
+    #[Identifier]
+    private UuidV4 $balanceId;
+
+    #[CommandHandler('create')]
+    public static function create(UuidV4 $balanceId): array
+    {
+        return [new BalanceCreated($balanceId)];
+    }
+
+    #[EventSourcingHandler]
+    public function whenOrderWasPlaced(BalanceCreated $event): void
+    {
+        $this->balanceId = $event->balanceId;
+    }
+}

--- a/packages/PdoEventSourcing/tests/Fixture/MetadataPropagatingForAggregate/BalanceCreated.php
+++ b/packages/PdoEventSourcing/tests/Fixture/MetadataPropagatingForAggregate/BalanceCreated.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Test\Ecotone\EventSourcing\Fixture\MetadataPropagatingForAggregate;
+
+use Ramsey\Uuid\Rfc4122\UuidV4;
+
+/**
+ * licence Apache-2.0
+ */
+class BalanceCreated
+{
+    public function __construct(public UuidV4 $balanceId)
+    {
+    }
+}

--- a/packages/PdoEventSourcing/tests/Fixture/MetadataPropagatingForAggregate/UuidV4Converter.php
+++ b/packages/PdoEventSourcing/tests/Fixture/MetadataPropagatingForAggregate/UuidV4Converter.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Ecotone\EventSourcing\Fixture\MetadataPropagatingForAggregate;
+
+use Ecotone\Messaging\Attribute\Converter;
+use Ramsey\Uuid\Rfc4122\UuidV4;
+use Ramsey\Uuid\UuidFactory;
+
+/**
+ * licence Apache-2.0
+ */
+final class UuidV4Converter
+{
+    #[Converter]
+    public static function convertFromString(string $uuid): UuidV4
+    {
+        $factory = new UuidFactory();
+
+        /** @var UuidV4 $uuidV4 */
+        $uuidV4 = $factory->fromString($uuid);
+
+        return $uuidV4;
+    }
+
+    #[Converter]
+    public static function convertToString(UuidV4 $uuid): string
+    {
+        return $uuid->toString();
+    }
+}


### PR DESCRIPTION
## Why is this change proposed?
Added a test that demonstrates the bug in StaticCallConverter. If the matches method in StaticCallConverter always returns false, the test passes — clearly illustrating the problem described in [issue #532](https://github.com/ecotoneframework/ecotone-dev/issues/532)

## Pull Request Contribution Terms

- [X] I have read and agree to the contribution terms outlined in [CONTRIBUTING](https://github.com/ecotoneframework/ecotone-dev/blob/main/CONTRIBUTING.md).