### PR TITLE
Fix StaticCallConverter

### DIFF
--- a/packages/Ecotone/src/Messaging/Conversion/StaticCallConverter.php
+++ b/packages/Ecotone/src/Messaging/Conversion/StaticCallConverter.php
@@ -6,6 +6,7 @@ namespace Ecotone\Messaging\Conversion;
 
 use Ecotone\Messaging\Handler\Type;
 use Ecotone\Messaging\Handler\Type\ObjectType;
+use Ecotone\Messaging\Handler\Type\UnionType;
 
 /**
  * licence Apache-2.0
@@ -35,7 +36,10 @@ class StaticCallConverter implements Converter
             return false;
         }
 
-        if ($sourceType instanceof ObjectType && ! $this->sourceType instanceof ObjectType) {
+        if ($sourceType instanceof ObjectType
+            &&  ! $this->sourceType instanceof ObjectType
+            && ! $this->sourceType instanceof UnionType
+        ) {
             return false;
         }
 

--- a/packages/Ecotone/src/Messaging/Conversion/StaticCallConverter.php
+++ b/packages/Ecotone/src/Messaging/Conversion/StaticCallConverter.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Ecotone\Messaging\Conversion;
 
 use Ecotone\Messaging\Handler\Type;
+use Ecotone\Messaging\Handler\Type\ObjectType;
 
 /**
  * licence Apache-2.0
@@ -28,9 +29,21 @@ class StaticCallConverter implements Converter
      */
     public function matches(Type $sourceType, MediaType $sourceMediaType, Type $targetType, MediaType $targetMediaType): bool
     {
-        return $sourceMediaType->isCompatibleWithParsed(MediaType::APPLICATION_X_PHP)
-            && $targetMediaType->isCompatibleWithParsed(MediaType::APPLICATION_X_PHP)
-            && $sourceType->isCompatibleWith($this->sourceType)
+        if (! $sourceMediaType->isCompatibleWithParsed(MediaType::APPLICATION_X_PHP)
+            || ! $targetMediaType->isCompatibleWithParsed(MediaType::APPLICATION_X_PHP)
+        ) {
+            return false;
+        }
+
+        if ($sourceType instanceof ObjectType && ! $this->sourceType instanceof ObjectType) {
+            return false;
+        }
+
+        if ($this->targetType instanceof ObjectType && ! $targetType instanceof ObjectType) {
+            return false;
+        }
+
+        return $sourceType->isCompatibleWith($this->sourceType)
             && $targetType->acceptType($this->targetType);
     }
 }

--- a/packages/Ecotone/src/Messaging/Conversion/StaticCallConverter.php
+++ b/packages/Ecotone/src/Messaging/Conversion/StaticCallConverter.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Ecotone\Messaging\Conversion;
 
 use Ecotone\Messaging\Handler\Type;
+use Ecotone\Messaging\Handler\Type\BuiltinType;
 use Ecotone\Messaging\Handler\Type\ObjectType;
 use Ecotone\Messaging\Handler\Type\UnionType;
 
@@ -40,6 +41,10 @@ class StaticCallConverter implements Converter
             &&  ! $this->sourceType instanceof ObjectType
             && ! $this->sourceType instanceof UnionType
         ) {
+            return false;
+        }
+
+        if ($this->sourceType instanceof BuiltinType && $sourceType instanceof ObjectType) {
             return false;
         }
 

--- a/packages/Ecotone/tests/Messaging/Fixture/Service/ServiceExpectingOneArgument.php
+++ b/packages/Ecotone/tests/Messaging/Fixture/Service/ServiceExpectingOneArgument.php
@@ -10,6 +10,7 @@ use Ecotone\Messaging\Config\Container\Definition;
 use Ecotone\Messaging\Message;
 use Ramsey\Uuid\UuidInterface;
 use stdClass;
+use Stringable;
 
 /**
  * Class ServiceExpectingOneArgument
@@ -111,6 +112,11 @@ class ServiceExpectingOneArgument implements DefinedObject
     public function withMessage(Message $message): Message
     {
         return $message;
+    }
+
+    public function withStringable(Stringable $value): string
+    {
+        return (string) $value;
     }
 
     /**

--- a/packages/PdoEventSourcing/tests/Fixture/MetadataPropagatingForAggregate/Balance.php
+++ b/packages/PdoEventSourcing/tests/Fixture/MetadataPropagatingForAggregate/Balance.php
@@ -20,7 +20,7 @@ class Balance
     #[Identifier]
     private UuidV4 $balanceId;
 
-    #[CommandHandler('create')]
+    #[CommandHandler('createBalance')]
     public static function create(UuidV4 $balanceId): array
     {
         return [new BalanceCreated($balanceId)];

--- a/packages/PdoEventSourcing/tests/Fixture/MetadataPropagatingForAggregate/Balance.php
+++ b/packages/PdoEventSourcing/tests/Fixture/MetadataPropagatingForAggregate/Balance.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Test\Ecotone\EventSourcing\Fixture\MetadataPropagatingForAggregate;
+
+use Ecotone\Modelling\Attribute\CommandHandler;
+use Ecotone\Modelling\Attribute\EventSourcingAggregate;
+use Ecotone\Modelling\Attribute\EventSourcingHandler;
+use Ecotone\Modelling\Attribute\Identifier;
+use Ecotone\Modelling\WithAggregateVersioning;
+use Ramsey\Uuid\Rfc4122\UuidV4;
+
+#[EventSourcingAggregate]
+/**
+ * licence Apache-2.0
+ */
+class Balance
+{
+    use WithAggregateVersioning;
+
+    #[Identifier]
+    private UuidV4 $balanceId;
+
+    #[CommandHandler('create')]
+    public static function create(UuidV4 $balanceId): array
+    {
+        return [new BalanceCreated($balanceId)];
+    }
+
+    #[EventSourcingHandler]
+    public function whenOrderWasPlaced(BalanceCreated $event): void
+    {
+        $this->balanceId = $event->balanceId;
+    }
+}

--- a/packages/PdoEventSourcing/tests/Fixture/MetadataPropagatingForAggregate/BalanceCreated.php
+++ b/packages/PdoEventSourcing/tests/Fixture/MetadataPropagatingForAggregate/BalanceCreated.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Test\Ecotone\EventSourcing\Fixture\MetadataPropagatingForAggregate;
+
+use Ramsey\Uuid\Rfc4122\UuidV4;
+
+/**
+ * licence Apache-2.0
+ */
+class BalanceCreated
+{
+    public function __construct(public UuidV4 $balanceId)
+    {
+    }
+}

--- a/packages/PdoEventSourcing/tests/Fixture/MetadataPropagatingForAggregate/BalanceCreatedConverter.php
+++ b/packages/PdoEventSourcing/tests/Fixture/MetadataPropagatingForAggregate/BalanceCreatedConverter.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Ecotone\EventSourcing\Fixture\MetadataPropagatingForAggregate;
+
+use Ecotone\Messaging\Attribute\Converter;
+
+/**
+ * licence Apache-2.0
+ */
+final class BalanceCreatedConverter
+{
+    #[Converter]
+    public function from(BalanceCreated $event): array
+    {
+        return ['balanceId' => UuidV4Converter::convertToString($event->balanceId)];
+    }
+
+    #[Converter]
+    public function to(array $event): BalanceCreated
+    {
+        return new BalanceCreated(UuidV4Converter::convertFromString($event['balanceId']));
+    }
+}

--- a/packages/PdoEventSourcing/tests/Fixture/MetadataPropagatingForAggregate/UuidV4Converter.php
+++ b/packages/PdoEventSourcing/tests/Fixture/MetadataPropagatingForAggregate/UuidV4Converter.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Ecotone\EventSourcing\Fixture\MetadataPropagatingForAggregate;
+
+use Ecotone\Messaging\Attribute\Converter;
+use Ramsey\Uuid\Rfc4122\UuidV4;
+use Ramsey\Uuid\UuidFactory;
+
+/**
+ * licence Apache-2.0
+ */
+final class UuidV4Converter
+{
+    #[Converter]
+    public static function convertFromString(string $uuid): UuidV4
+    {
+        $factory = new UuidFactory();
+
+        /** @var UuidV4 $uuidV4 */
+        $uuidV4 = $factory->fromString($uuid);
+
+        return $uuidV4;
+    }
+
+    #[Converter]
+    public static function convertToString(UuidV4 $uuid): string
+    {
+        return $uuid->toString();
+    }
+}

--- a/packages/PdoEventSourcing/tests/Integration/HeaderPropagationTest.php
+++ b/packages/PdoEventSourcing/tests/Integration/HeaderPropagationTest.php
@@ -12,6 +12,7 @@ use Ramsey\Uuid\Uuid;
 use Ramsey\Uuid\UuidFactory;
 use Test\Ecotone\EventSourcing\EventSourcingMessagingTestCase;
 use Test\Ecotone\EventSourcing\Fixture\MetadataPropagatingForAggregate\Balance;
+use Test\Ecotone\EventSourcing\Fixture\MetadataPropagatingForAggregate\BalanceCreatedConverter;
 use Test\Ecotone\EventSourcing\Fixture\MetadataPropagatingForAggregate\Order;
 use Test\Ecotone\EventSourcing\Fixture\MetadataPropagatingForAggregate\OrderWasPlacedConverter;
 use Test\Ecotone\EventSourcing\Fixture\MetadataPropagatingForAggregate\UuidV4Converter;
@@ -91,11 +92,15 @@ final class HeaderPropagationTest extends TestCase
         $this->assertSame($correlationId, $headers[MessageHeaders::MESSAGE_CORRELATION_ID]);
     }
 
-    public function test_with_custom_converter()
+    public function test_with_stringable_header_converter()
     {
         $ecotoneTestSupport = EcotoneLite::bootstrapFlowTestingWithEventStore(
-            [Balance::class, UuidV4Converter::class],
-            [new UuidV4Converter(), DbalConnectionFactory::class => EventSourcingMessagingTestCase::getConnectionFactory()]
+            [Balance::class, UuidV4Converter::class, BalanceCreatedConverter::class],
+            [
+                new UuidV4Converter(),
+                new BalanceCreatedConverter(),
+                DbalConnectionFactory::class => EventSourcingMessagingTestCase::getConnectionFactory(),
+            ],
         );
 
         $factory = new UuidFactory();
@@ -104,7 +109,7 @@ final class HeaderPropagationTest extends TestCase
 
         $flowTestSupport = $ecotoneTestSupport
             ->sendCommandWithRoutingKey(
-                'create',
+                'createBalance',
                 $balanceId,
                 metadata: ['userId' => $userId]
             );


### PR DESCRIPTION
## Why is this change proposed?
Fixes [issue #532](https://github.com/ecotoneframework/ecotone-dev/issues/532).

## Description of Changes
The bug occurred in StaticCallConverter, where a converter parameter typed as string was incorrectly treated as compatible with Stringable. This behavior is not allowed in strict mode, since Stringable objects cannot be implicitly cast to string.

This fix ensures that type matching is handled correctly when comparing an object type against a non-object type.

## Pull Request Contribution Terms

- [X] I have read and agree to the contribution terms outlined in [CONTRIBUTING](https://github.com/ecotoneframework/ecotone-dev/blob/main/CONTRIBUTING.md).