### PR TITLE
fix stringable conversion for static converters

### DIFF
--- a/packages/Ecotone/src/Messaging/Conversion/StaticCallConverter.php
+++ b/packages/Ecotone/src/Messaging/Conversion/StaticCallConverter.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 namespace Ecotone\Messaging\Conversion;
 
 use Ecotone\Messaging\Handler\Type;

--- a/packages/Ecotone/tests/Messaging/Unit/Conversion/ReferenceServiceConverterBuilderTest.php
+++ b/packages/Ecotone/tests/Messaging/Unit/Conversion/ReferenceServiceConverterBuilderTest.php
@@ -9,6 +9,8 @@ use Ecotone\Messaging\Attribute\Converter;
 use Ecotone\Messaging\Config\ServiceConfiguration;
 use Ecotone\Messaging\Handler\ServiceActivator\ServiceActivatorBuilder;
 use Ecotone\Messaging\Support\InvalidArgumentException;
+use Ecotone\Modelling\Attribute\CommandHandler;
+use Ecotone\Modelling\Attribute\EventHandler;
 use Ecotone\Test\ComponentTestBuilder;
 use PHPUnit\Framework\TestCase;
 use stdClass;
@@ -135,7 +137,6 @@ class ReferenceServiceConverterBuilderTest extends TestCase
 
         $ecotone = EcotoneLite::bootstrapFlowTesting(
             [$staticConverter::class],
-            [$staticConverter],
             configuration: ServiceConfiguration::createWithDefaults()
                 ->addExtensionObject(
                     ServiceActivatorBuilder::createWithDirectReference(ServiceExpectingOneArgument::create(), 'withArrayStdClasses')
@@ -149,6 +150,43 @@ class ReferenceServiceConverterBuilderTest extends TestCase
                 $inputChannel,
                 ['some']
             )
+        );
+    }
+
+    public function test_static_converter_stringable_conversion(): void
+    {
+        $staticConverter = new class () {
+            #[Converter]
+            public static function convert(string $data): stdClass
+            {
+                return new stdClass();
+            }
+        };
+        $handler = new class () {
+            public stdClass $handled;
+
+            #[CommandHandler('test')]
+            public function handler(stdClass $data): void
+            {
+                $this->handled = $data;
+            }
+        };
+
+        $stringableObject = new class {
+            public function __toString(): string
+            {
+                return 'some';
+            }
+        };
+
+        EcotoneLite::bootstrapFlowTesting(
+            [$staticConverter::class, $handler::class],
+            [$handler],
+        )->sendCommandWithRoutingKey('test', $stringableObject);
+
+        $this->assertEquals(
+            new stdClass(),
+            $handler->handled
         );
     }
 }


### PR DESCRIPTION
## Why is this change proposed?
Fixes issue #532 

## Description of Changes
Allow implicit php type conversion in `StaticCallConverter.php`

## Pull Request Contribution Terms

- [X] I have read and agree to the contribution terms outlined in [CONTRIBUTING](https://github.com/ecotoneframework/ecotone-dev/blob/main/CONTRIBUTING.md).