### PR TITLE
MRE: Static converters are applied in incorrect order

### DIFF
--- a/packages/Ecotone/tests/Messaging/Unit/Conversion/ConversionServiceTest.php
+++ b/packages/Ecotone/tests/Messaging/Unit/Conversion/ConversionServiceTest.php
@@ -211,6 +211,63 @@ class ConversionServiceTest extends TestCase
             )
         );
     }
+
+    /**
+     * @dataProvider provideConvertors
+     */
+    public function test_it_wrong_conversion_calling(array $convertors): void
+    {
+        $ecotone = EcotoneLite::bootstrapFlowTesting(
+            classesToResolve: $convertors,
+            containerOrAvailableServices: [],
+        );
+
+        /** @var ConversionService $conversionService */
+        $conversionService = $ecotone->getGateway(ConversionService::class);
+
+        $data = 'some-data';
+
+        $this->assertEquals(
+            $data,
+            $conversionService->convert(
+                new SomeStringableDataTwo($data),
+                Type::create(SomeStringableDataTwo::class),
+                MediaType::createApplicationXPHP(),
+                Type::string(),
+                MediaType::createApplicationXPHP()
+            )
+        );
+    }
+
+    public static function provideConvertors(): iterable
+    {
+        $converterOne = new class () {
+            #[Converter]
+            public static function convert(string $value): SomeStringableDataOne
+            {
+                // Should not be called
+                return new SomeStringableDataOne('other-value');
+            }
+        };
+
+        $converterTwo = new class () {
+            #[Converter]
+            public static function convertToString(SomeStringableDataTwo $value): string
+            {
+                return $value->value;
+            }
+        };
+
+        yield 'Passed' => [[
+            $converterTwo::class,
+            $converterOne::class,
+        ]];
+
+        yield 'Failed' => [[
+            $converterOne::class,
+            $converterTwo::class,
+        ]];
+    }
 }
 
 class SomeStringableDataOne implements \Stringable


### PR DESCRIPTION
## Why is this change proposed?
We created a minimal test that registers two static converters:
`ConverterOne` — a generic converter (string → `SomeStringableDataOne`)
`ConverterTwo` — a specific converter (`SomeStringableDataTwo` → string)

When Ecotone is bootstrapped with these converters in different order, conversion behavior changes — proving that converter resolution depends on registration order instead of type specificity.

## Pull Request Contribution Terms

- [X] I have read and agree to the contribution terms outlined in [CONTRIBUTING](https://github.com/ecotoneframework/ecotone-dev/blob/main/CONTRIBUTING.md).