### PR TITLE
Symfony bundle: use buildDir for proxy cache

### DIFF
--- a/packages/Symfony/DependencyInjection/EcotoneExtension.php
+++ b/packages/Symfony/DependencyInjection/EcotoneExtension.php
@@ -78,7 +78,7 @@ class EcotoneExtension extends Extension
 
         $container->register(ServiceCacheConfiguration::REFERENCE_NAME, ServiceCacheConfiguration::class)
             ->setArguments([
-                '%kernel.cache_dir%/ecotone',
+                '%kernel.build_dir%/ecotone',
                 true,
             ]);
 


### PR DESCRIPTION
## Why is this change proposed?

It is recommended by Symfony to separate read-only cache (buildDir) from read-write cache (cacheDir)
buildDir is the same directory as cache dir by default.

See: https://symfony.com/doc/current/reference/configuration/kernel.html#kernel-build-dir

## Pull Request Contribution Terms

- [X] I have read and agree to the contribution terms outlined in [CONTRIBUTING](https://github.com/ecotoneframework/ecotone-dev/blob/main/CONTRIBUTING.md).