### PR TITLE
feat: Event store channel adapter

### DIFF
--- a/packages/Ecotone/src/Messaging/Config/ModuleClassList.php
+++ b/packages/Ecotone/src/Messaging/Config/ModuleClassList.php
@@ -64,6 +64,7 @@ use Ecotone\OpenTelemetry\Configuration\OpenTelemetryModule;
 use Ecotone\Projecting\Config\ProjectingAttributeModule;
 use Ecotone\Projecting\Config\ProjectingConsoleCommands;
 use Ecotone\Projecting\Config\ProjectingModule;
+use Ecotone\Projecting\EventStoreAdapter\EventStoreAdapterModule;
 use Ecotone\Redis\Configuration\RedisMessageConsumerModule;
 use Ecotone\Redis\Configuration\RedisMessagePublisherModule;
 use Ecotone\Sqs\Configuration\SqsMessageConsumerModule;
@@ -107,6 +108,7 @@ class ModuleClassList
         EventSourcedRepositoryModule::class,
         ProjectingModule::class,
         ProjectingAttributeModule::class,
+        EventStoreAdapterModule::class,
 
         /** Attribute based configurations */
         MessageHeadersPropagatorInterceptor::class,

--- a/packages/Ecotone/src/Projecting/EventStoreAdapter/EventStoreAdapterModule.php
+++ b/packages/Ecotone/src/Projecting/EventStoreAdapter/EventStoreAdapterModule.php
@@ -1,0 +1,86 @@
+<?php
+
+/*
+ * licence Enterprise
+ */
+declare(strict_types=1);
+
+namespace Ecotone\Projecting\EventStoreAdapter;
+
+use Ecotone\AnnotationFinder\AnnotationFinder;
+use Ecotone\Messaging\Attribute\ModuleAnnotation;
+use Ecotone\Messaging\Config\Annotation\AnnotationModule;
+use Ecotone\Messaging\Config\Configuration;
+use Ecotone\Messaging\Config\ModulePackageList;
+use Ecotone\Messaging\Config\ModuleReferenceSearchService;
+use Ecotone\Messaging\Config\ServiceConfiguration;
+use Ecotone\Messaging\Endpoint\InboundChannelAdapter\InboundChannelAdapterBuilder;
+use Ecotone\Messaging\Handler\InterfaceToCallRegistry;
+use Ecotone\Projecting\Config\ProjectingModule;
+
+/**
+ * @internal
+ * licence Enterprise
+ */
+#[ModuleAnnotation]
+class EventStoreAdapterModule implements AnnotationModule
+{
+    public function __construct(
+        private array $extensions = []
+    ) {
+    }
+
+    public static function create(AnnotationFinder $annotationRegistrationService, InterfaceToCallRegistry $interfaceToCallRegistry): static
+    {
+        return new self();
+    }
+
+    public function prepare(Configuration $messagingConfiguration, array $extensionObjects, ModuleReferenceSearchService $moduleReferenceSearchService, InterfaceToCallRegistry $interfaceToCallRegistry): void
+    {
+        // Collect EventStoreChannelAdapter extension objects
+        $channelAdapters = [];
+        foreach ($extensionObjects as $extensionObject) {
+            if ($extensionObject instanceof EventStoreChannelAdapter) {
+                $channelAdapters[] = $extensionObject;
+            }
+        }
+
+        // Register inbound channel adapters (polling endpoints) for each channel adapter
+        foreach ($channelAdapters as $channelAdapter) {
+            $messagingConfiguration->registerConsumer(
+                InboundChannelAdapterBuilder::createWithDirectObject(
+                    ProjectingModule::inputChannelForProjectingManager($channelAdapter->getProjectionName()),
+                    new PollingProjectionChannelAdapter(),
+                    $interfaceToCallRegistry->getFor(PollingProjectionChannelAdapter::class, 'execute')
+                )
+                    ->withEndpointId($channelAdapter->endpointId)
+            );
+        }
+    }
+
+    public function canHandle($extensionObject): bool
+    {
+        return $extensionObject instanceof EventStoreChannelAdapter;
+    }
+
+    public function getModuleExtensions(ServiceConfiguration $serviceConfiguration, array $serviceExtensions): array
+    {
+        $extensions = [...$this->extensions];
+
+        foreach ($serviceExtensions as $extensionObject) {
+            if (!($extensionObject instanceof EventStoreChannelAdapter)) {
+                continue;
+            }
+
+            $extensions[] = new EventStoreChannelAdapterProjectionBuilder($extensionObject);
+        }
+
+        return $extensions;
+    }
+
+    public function getModulePackageName(): string
+    {
+        return ModulePackageList::CORE_PACKAGE;
+    }
+}
+

--- a/packages/Ecotone/src/Projecting/EventStoreAdapter/EventStoreChannelAdapter.php
+++ b/packages/Ecotone/src/Projecting/EventStoreAdapter/EventStoreChannelAdapter.php
@@ -1,0 +1,86 @@
+<?php
+
+/*
+ * licence Enterprise
+ */
+declare(strict_types=1);
+
+namespace Ecotone\Projecting\EventStoreAdapter;
+
+/**
+ * Configuration for feeding events from event store into a streaming channel.
+ * Creates a polling projection that continuously reads events and publishes them to the specified channel.
+ *
+ * Works with both PDO Event Store and In-Memory Event Store implementations.
+ *
+ * @example
+ * #[ServiceContext]
+ * public function eventStoreFeeder(): EventStoreChannelAdapter
+ * {
+ *     return EventStoreChannelAdapter::create(
+ *         streamChannelName: 'event_stream',
+ *         endpointId: 'event_store_feeder',
+ *         fromStream: Ticket::class
+ *     );
+ * }
+ *
+ * licence Enterprise
+ */
+class EventStoreChannelAdapter
+{
+    private function __construct(
+        public readonly string $streamChannelName,
+        public readonly string $endpointId,
+        public readonly string $fromStream,
+        public readonly ?string $aggregateType = null,
+        public readonly int $batchSize = 100,
+        public readonly array $eventNames = [],
+    ) {
+    }
+
+    public static function create(
+        string $streamChannelName,
+        string $endpointId,
+        string $fromStream,
+        ?string $aggregateType = null,
+    ): self {
+        return new self($streamChannelName, $endpointId, $fromStream, $aggregateType);
+    }
+
+    public function withBatchSize(int $batchSize): self
+    {
+        return new self(
+            $this->streamChannelName,
+            $this->endpointId,
+            $this->fromStream,
+            $this->aggregateType,
+            $batchSize,
+            $this->eventNames,
+        );
+    }
+
+    /**
+     * Filter events by name using glob patterns (same as distributed bus)
+     * @param array<string> $eventNames Glob patterns like ['Ticket.*', 'Order.Created']
+     */
+    public function withEventNames(array $eventNames): self
+    {
+        return new self(
+            $this->streamChannelName,
+            $this->endpointId,
+            $this->fromStream,
+            $this->aggregateType,
+            $this->batchSize,
+            $eventNames,
+        );
+    }
+
+    /**
+     * @internal
+     */
+    public function getProjectionName(): string
+    {
+        return 'event_store_channel_adapter_' . $this->endpointId;
+    }
+}
+

--- a/packages/Ecotone/src/Projecting/EventStoreAdapter/EventStoreChannelAdapterProjection.php
+++ b/packages/Ecotone/src/Projecting/EventStoreAdapter/EventStoreChannelAdapterProjection.php
@@ -1,0 +1,81 @@
+<?php
+
+/*
+ * licence Enterprise
+ */
+declare(strict_types=1);
+
+namespace Ecotone\Projecting\EventStoreAdapter;
+
+use Ecotone\Messaging\MessageChannel;
+use Ecotone\Messaging\Support\MessageBuilder;
+use Ecotone\Modelling\Config\Routing\BusRoutingMap;
+use Ecotone\Modelling\Event;
+use Ecotone\Projecting\ProjectorExecutor;
+
+/**
+ * Internal projector that forwards events from event store to a streaming channel.
+ *
+ * @internal
+ */
+class EventStoreChannelAdapterProjection implements ProjectorExecutor
+{
+    /**
+     * @param array<string> $eventNames Glob patterns for filtering events (same as distributed bus)
+     */
+    public function __construct(
+        private MessageChannel $outputChannel,
+        private array $eventNames = []
+    ) {
+    }
+
+    public function project(Event $event, mixed $userState = null): mixed
+    {
+        if (!empty($this->eventNames)) {
+            $eventName = $event->getEventName();
+            $matched = false;
+
+            foreach ($this->eventNames as $pattern) {
+                if (BusRoutingMap::globMatch($pattern, $eventName)) {
+                    $matched = true;
+                    break;
+                }
+            }
+
+            if (!$matched) {
+                return $userState;
+            }
+        }
+
+        $payload = $event->getPayload();
+        $metadata = $event->getMetadata();
+
+        if (!isset($metadata[\Ecotone\Messaging\MessageHeaders::CONTENT_TYPE])) {
+            $metadata[\Ecotone\Messaging\MessageHeaders::CONTENT_TYPE] = 'application/x-php';
+        }
+
+        $this->outputChannel->send(
+            MessageBuilder::withPayload($payload)
+                ->setMultipleHeaders($metadata)
+                ->build()
+        );
+
+        return $userState;
+    }
+
+    public function init(): void
+    {
+        // No initialization needed
+    }
+
+    public function delete(): void
+    {
+        // No deletion needed
+    }
+
+    public function flush(): void
+    {
+        // No flushing needed
+    }
+}
+

--- a/packages/Ecotone/src/Projecting/EventStoreAdapter/EventStoreChannelAdapterProjectionBuilder.php
+++ b/packages/Ecotone/src/Projecting/EventStoreAdapter/EventStoreChannelAdapterProjectionBuilder.php
@@ -1,0 +1,65 @@
+<?php
+
+/*
+ * licence Enterprise
+ */
+declare(strict_types=1);
+
+namespace Ecotone\Projecting\EventStoreAdapter;
+
+use Ecotone\Messaging\Config\Container\Definition;
+use Ecotone\Messaging\Config\Container\MessagingContainerBuilder;
+use Ecotone\Messaging\Config\Container\Reference;
+use Ecotone\Projecting\Config\ProjectionExecutorBuilder;
+
+/**
+ * Builder for EventStoreChannelAdapter projection executor.
+ * Creates a projection that forwards all events to a streaming channel.
+ *
+ * @internal
+ */
+class EventStoreChannelAdapterProjectionBuilder implements ProjectionExecutorBuilder
+{
+    public function __construct(
+        private EventStoreChannelAdapter $channelAdapter
+    ) {
+    }
+
+    public function projectionName(): string
+    {
+        return $this->channelAdapter->getProjectionName();
+    }
+
+    public function asyncChannelName(): ?string
+    {
+        return null; // Channel adapters are always polling-based
+    }
+
+    public function partitionHeader(): ?string
+    {
+        return null; // Channel adapters don't support partitioning
+    }
+
+    public function automaticInitialization(): bool
+    {
+        return true;
+    }
+
+    public function batchSize(): int
+    {
+        return $this->channelAdapter->batchSize;
+    }
+
+    public function compile(MessagingContainerBuilder $builder): Definition|Reference
+    {
+        // Create the projection executor that forwards events to the streaming channel
+        return new Definition(
+            EventStoreChannelAdapterProjection::class,
+            [
+                Reference::toChannel($this->channelAdapter->streamChannelName),
+                $this->channelAdapter->eventNames,
+            ]
+        );
+    }
+}
+

--- a/packages/Ecotone/src/Projecting/EventStoreAdapter/PollingProjectionChannelAdapter.php
+++ b/packages/Ecotone/src/Projecting/EventStoreAdapter/PollingProjectionChannelAdapter.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Ecotone\Projecting\EventStoreAdapter;
+
+use Ecotone\Messaging\Config\Container\DefinedObject;
+use Ecotone\Messaging\Config\Container\Definition;
+
+/**
+ * licence Enterprise
+ */
+class PollingProjectionChannelAdapter implements DefinedObject
+{
+    public function execute(): bool
+    {
+        // This is executed by the inbound channel adapter, which then sends the result
+        // to the projection's input channel, triggering ProjectingManager::execute()
+        return true;
+    }
+
+    public function getDefinition(): Definition
+    {
+        return new Definition(self::class);
+    }
+}
+

--- a/packages/Ecotone/tests/Projecting/EventStoreChannelAdapterTest.php
+++ b/packages/Ecotone/tests/Projecting/EventStoreChannelAdapterTest.php
@@ -1,0 +1,255 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Ecotone\Projecting;
+
+use Ecotone\Lite\EcotoneLite;
+use Ecotone\Messaging\Attribute\InternalHandler;
+use Ecotone\Messaging\Channel\SimpleMessageChannelBuilder;
+use Ecotone\Messaging\Config\ModulePackageList;
+use Ecotone\Messaging\Config\ServiceConfiguration;
+use Ecotone\Messaging\Consumer\ConsumerPositionTracker;
+use Ecotone\Messaging\Consumer\InMemory\InMemoryConsumerPositionTracker;
+use Ecotone\Messaging\Endpoint\ExecutionPollingMetadata;
+use Ecotone\Messaging\Endpoint\PollingMetadata;
+use Ecotone\Messaging\MessageHeaders;
+use Ecotone\Modelling\Attribute\EventHandler;
+use Ecotone\Modelling\Attribute\QueryHandler;
+use Ecotone\Modelling\Event;
+use Ecotone\Projecting\EventStoreAdapter\EventStoreChannelAdapter;
+use Ecotone\Projecting\InMemory\InMemoryStreamSourceBuilder;
+use Ecotone\Test\LicenceTesting;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for EventStoreChannelAdapter with in-memory event store
+ */
+final class EventStoreChannelAdapterTest extends TestCase
+{
+    public function test_feeding_events_from_in_memory_event_store_to_streaming_channel(): void
+    {
+        $positionTracker = new InMemoryConsumerPositionTracker();
+
+        // Consumer that reads from the streaming channel
+        $consumer = new class {
+            private array $consumed = [];
+
+            #[InternalHandler(inputChannelName: 'event_stream', endpointId: 'stream_consumer')]
+            public function handle(array $event): void
+            {
+                $this->consumed[] = $event;
+            }
+
+            #[QueryHandler('getConsumed')]
+            public function getConsumed(): array
+            {
+                return $this->consumed;
+            }
+        };
+
+        $ecotone = EcotoneLite::bootstrapFlowTesting(
+            classesToResolve: [$consumer::class],
+            containerOrAvailableServices: [
+                $consumer,
+                ConsumerPositionTracker::class => $positionTracker,
+            ],
+            configuration: ServiceConfiguration::createWithDefaults()
+                ->withSkippedModulePackageNames(ModulePackageList::allPackagesExcept([ModulePackageList::ASYNCHRONOUS_PACKAGE]))
+                ->withLicenceKey(LicenceTesting::VALID_LICENCE)
+                ->withExtensionObjects([
+                    $streamSource = new InMemoryStreamSourceBuilder(),
+                    SimpleMessageChannelBuilder::createStreamingChannel('event_stream'),
+                    EventStoreChannelAdapter::create(
+                        streamChannelName: 'event_stream',
+                        endpointId: 'event_store_feeder',
+                        fromStream: 'test_stream'
+                    ),
+                    PollingMetadata::create('stream_consumer')->withTestingSetup(),
+                ])
+        );
+
+        // When events are appended to the stream source
+        $streamSource->append(
+            Event::createWithType('ticket.registered', ['ticketId' => 'ticket-1', 'assignedPerson' => 'John'], [MessageHeaders::EVENT_AGGREGATE_ID => 'ticket-1']),
+            Event::createWithType('ticket.registered', ['ticketId' => 'ticket-2', 'assignedPerson' => 'Jane'], [MessageHeaders::EVENT_AGGREGATE_ID => 'ticket-2']),
+        );
+
+        // When feeder runs (polls event store and pushes to streaming channel)
+        $ecotone->run('event_store_feeder', ExecutionPollingMetadata::createWithTestingSetup());
+
+        // When stream consumer runs
+        $ecotone->run('stream_consumer', ExecutionPollingMetadata::createWithTestingSetup(amountOfMessagesToHandle: 2));
+
+        // Then events are consumed from streaming channel
+        $consumedEvents = $ecotone->sendQueryWithRouting('getConsumed');
+        $this->assertCount(2, $consumedEvents);
+        $this->assertEquals('ticket-1', $consumedEvents[0]['ticketId']);
+        $this->assertEquals('ticket-2', $consumedEvents[1]['ticketId']);
+    }
+
+    public function test_filtering_events_by_name_using_glob_patterns(): void
+    {
+        $positionTracker = new InMemoryConsumerPositionTracker();
+
+        // Consumer that reads from the streaming channel
+        $consumer = new class {
+            private array $consumed = [];
+
+            #[InternalHandler(inputChannelName: 'event_stream', endpointId: 'stream_consumer')]
+            public function handle(array $event): void
+            {
+                $this->consumed[] = $event;
+            }
+
+            #[QueryHandler('getConsumed')]
+            public function getConsumed(): array
+            {
+                return $this->consumed;
+            }
+        };
+
+        $ecotone = EcotoneLite::bootstrapFlowTesting(
+            classesToResolve: [$consumer::class],
+            containerOrAvailableServices: [
+                $consumer,
+                ConsumerPositionTracker::class => $positionTracker,
+            ],
+            configuration: ServiceConfiguration::createWithDefaults()
+                ->withSkippedModulePackageNames(ModulePackageList::allPackagesExcept([ModulePackageList::ASYNCHRONOUS_PACKAGE]))
+                ->withLicenceKey(LicenceTesting::VALID_LICENCE)
+                ->withExtensionObjects([
+                    $streamSource = new InMemoryStreamSourceBuilder(),
+                    SimpleMessageChannelBuilder::createStreamingChannel('event_stream'),
+                    EventStoreChannelAdapter::create(
+                        streamChannelName: 'event_stream',
+                        endpointId: 'event_store_feeder',
+                        fromStream: 'test_stream'
+                    )->withEventNames(['ticket.registered']), // Only registered events
+                    PollingMetadata::create('stream_consumer')->withTestingSetup(),
+                ])
+        );
+
+        // When events are appended to the stream source
+        $streamSource->append(
+            Event::createWithType('ticket.registered', ['ticketId' => 'ticket-1'], [MessageHeaders::EVENT_AGGREGATE_ID => 'ticket-1']),
+            Event::createWithType('ticket.closed', ['ticketId' => 'ticket-1'], [MessageHeaders::EVENT_AGGREGATE_ID => 'ticket-1']),
+            Event::createWithType('ticket.registered', ['ticketId' => 'ticket-2'], [MessageHeaders::EVENT_AGGREGATE_ID => 'ticket-2']),
+        );
+
+        // When feeder runs
+        $ecotone->run('event_store_feeder', ExecutionPollingMetadata::createWithTestingSetup());
+
+        // When stream consumer runs
+        $ecotone->run('stream_consumer', ExecutionPollingMetadata::createWithTestingSetup(amountOfMessagesToHandle: 2));
+
+        // Then only registered events are consumed (closed event is filtered out)
+        $consumedEvents = $ecotone->sendQueryWithRouting('getConsumed');
+        $this->assertCount(2, $consumedEvents, 'Should only consume ticket.registered events');
+        $this->assertEquals('ticket-1', $consumedEvents[0]['ticketId']);
+        $this->assertEquals('ticket-2', $consumedEvents[1]['ticketId']);
+    }
+
+    public function test_normal_event_handler_works_alongside_event_store_channel_adapter(): void
+    {
+        $positionTracker = new InMemoryConsumerPositionTracker();
+
+        // Normal event handler that counts tickets (not a projection, just a simple event handler)
+        // This demonstrates that EventStoreChannelAdapter works alongside normal event handlers
+        $ticketCounter = new class {
+            public int $registeredCount = 0;
+            public int $closedCount = 0;
+
+            #[EventHandler('ticket.registered')]
+            public function whenRegistered(array $event): void
+            {
+                $this->registeredCount++;
+            }
+
+            #[EventHandler('ticket.closed')]
+            public function whenClosed(array $event): void
+            {
+                $this->closedCount++;
+            }
+
+            #[QueryHandler('getTicketCounts')]
+            public function getCounts(): array
+            {
+                return [
+                    'registered' => $this->registeredCount,
+                    'closed' => $this->closedCount,
+                ];
+            }
+        };
+
+        // Consumer that reads from the streaming channel
+        $consumer = new class {
+            private array $consumed = [];
+
+            #[InternalHandler(inputChannelName: 'event_stream', endpointId: 'stream_consumer')]
+            public function handle(array $event): void
+            {
+                $this->consumed[] = $event;
+            }
+
+            #[QueryHandler('getConsumed')]
+            public function getConsumed(): array
+            {
+                return $this->consumed;
+            }
+        };
+
+        $ecotone = EcotoneLite::bootstrapFlowTesting(
+            classesToResolve: [$ticketCounter::class, $consumer::class],
+            containerOrAvailableServices: [
+                $ticketCounter,
+                $consumer,
+                ConsumerPositionTracker::class => $positionTracker,
+            ],
+            configuration: ServiceConfiguration::createWithDefaults()
+                ->withSkippedModulePackageNames(ModulePackageList::allPackagesExcept([ModulePackageList::ASYNCHRONOUS_PACKAGE]))
+                ->withLicenceKey(LicenceTesting::VALID_LICENCE)
+                ->withExtensionObjects([
+                    $streamSource = new InMemoryStreamSourceBuilder(),
+                    SimpleMessageChannelBuilder::createStreamingChannel('event_stream'),
+                    EventStoreChannelAdapter::create(
+                        streamChannelName: 'event_stream',
+                        endpointId: 'event_store_feeder',
+                        fromStream: 'test_stream'
+                    ),
+                    PollingMetadata::create('stream_consumer')->withTestingSetup(),
+                ])
+        );
+
+        // When events are published via Event Bus (which triggers event handlers)
+        $ecotone->publishEventWithRoutingKey('ticket.registered', ['ticketId' => 'ticket-1'], metadata: [MessageHeaders::EVENT_AGGREGATE_ID => 'ticket-1']);
+        $ecotone->publishEventWithRoutingKey('ticket.registered', ['ticketId' => 'ticket-2'], metadata: [MessageHeaders::EVENT_AGGREGATE_ID => 'ticket-2']);
+        $ecotone->publishEventWithRoutingKey('ticket.closed', ['ticketId' => 'ticket-1'], metadata: [MessageHeaders::EVENT_AGGREGATE_ID => 'ticket-1']);
+
+        // Then normal event handler processes all events synchronously (event-driven by default)
+        $counts = $ecotone->sendQueryWithRouting('getTicketCounts');
+        $this->assertEquals(2, $counts['registered'], 'Event handler should have processed 2 ticket.registered events');
+        $this->assertEquals(1, $counts['closed'], 'Event handler should have processed 1 ticket.closed event');
+
+        // And events are also stored in stream source (for polling projection to consume)
+        $streamSource->append(
+            Event::createWithType('ticket.registered', ['ticketId' => 'ticket-1'], [MessageHeaders::EVENT_AGGREGATE_ID => 'ticket-1']),
+            Event::createWithType('ticket.registered', ['ticketId' => 'ticket-2'], [MessageHeaders::EVENT_AGGREGATE_ID => 'ticket-2']),
+            Event::createWithType('ticket.closed', ['ticketId' => 'ticket-1'], [MessageHeaders::EVENT_AGGREGATE_ID => 'ticket-1']),
+        );
+
+        // When feeder runs (polls event store and pushes to streaming channel)
+        $ecotone->run('event_store_feeder', ExecutionPollingMetadata::createWithTestingSetup());
+
+        // When stream consumer runs (handle 3 messages)
+        $ecotone->run('stream_consumer', ExecutionPollingMetadata::createWithTestingSetup(amountOfMessagesToHandle: 3));
+
+        // Then events are also consumed from streaming channel (as arrays)
+        $consumedEvents = $ecotone->sendQueryWithRouting('getConsumed');
+        $this->assertCount(3, $consumedEvents, 'Should have consumed 3 events from streaming channel');
+        $this->assertEquals('ticket-1', $consumedEvents[0]['ticketId']);
+        $this->assertEquals('ticket-2', $consumedEvents[1]['ticketId']);
+        $this->assertEquals('ticket-1', $consumedEvents[2]['ticketId']); // closed event
+    }
+}
+

--- a/packages/PdoEventSourcing/tests/Projecting/EventStoreChannelAdapterTest.php
+++ b/packages/PdoEventSourcing/tests/Projecting/EventStoreChannelAdapterTest.php
@@ -1,0 +1,263 @@
+<?php
+
+/*
+ * licence Enterprise
+ */
+declare(strict_types=1);
+
+namespace Test\Ecotone\EventSourcing\Projecting;
+
+use Ecotone\EventSourcing\EventSourcingConfiguration;
+use Ecotone\Projecting\EventStoreAdapter\EventStoreChannelAdapter;
+use Ecotone\Lite\EcotoneLite;
+use Ecotone\Messaging\Attribute\InternalHandler;
+use Ecotone\Messaging\Channel\SimpleMessageChannelBuilder;
+use Ecotone\Messaging\Config\ModulePackageList;
+use Ecotone\Messaging\Config\ServiceConfiguration;
+use Ecotone\Messaging\Consumer\ConsumerPositionTracker;
+use Ecotone\Messaging\Consumer\InMemory\InMemoryConsumerPositionTracker;
+use Ecotone\Messaging\Endpoint\ExecutionPollingMetadata;
+use Ecotone\Messaging\Endpoint\PollingMetadata;
+use Ecotone\Modelling\Attribute\EventHandler;
+use Ecotone\Modelling\Attribute\QueryHandler;
+use Ecotone\Test\LicenceTesting;
+use Test\Ecotone\EventSourcing\Fixture\Ticket\Command\CloseTicket;
+use Test\Ecotone\EventSourcing\Fixture\Ticket\Command\RegisterTicket;
+use Test\Ecotone\EventSourcing\Fixture\Ticket\Event\TicketWasClosed;
+use Test\Ecotone\EventSourcing\Fixture\Ticket\Event\TicketWasRegistered;
+use Test\Ecotone\EventSourcing\Fixture\Ticket\Ticket;
+use Test\Ecotone\EventSourcing\Fixture\Ticket\TicketEventConverter;
+
+/**
+ * Tests for EventStoreChannelAdapter - feeding events from event store to streaming channels
+ */
+final class EventStoreChannelAdapterTest extends ProjectingTestCase
+{
+    public function test_feeding_events_from_event_store_to_streaming_channel(): void
+    {
+        $positionTracker = new InMemoryConsumerPositionTracker();
+
+        // Consumer that reads from the streaming channel
+        $consumer = new class {
+            public array $consumedEvents = [];
+
+            #[InternalHandler(inputChannelName: 'event_stream', endpointId: 'stream_consumer')]
+            public function handle(TicketWasRegistered $event): void
+            {
+                $this->consumedEvents[] = $event;
+            }
+
+            #[QueryHandler('getConsumed')]
+            public function getConsumed(): array
+            {
+                return $this->consumedEvents;
+            }
+        };
+
+        $ecotone = EcotoneLite::bootstrapFlowTestingWithEventStore(
+            classesToResolve: [Ticket::class, TicketEventConverter::class, $consumer::class],
+            containerOrAvailableServices: [
+                new TicketEventConverter(),
+                $consumer,
+                self::getConnectionFactory(),
+                ConsumerPositionTracker::class => $positionTracker,
+            ],
+            configuration: ServiceConfiguration::createWithDefaults()
+                ->withSkippedModulePackageNames(ModulePackageList::allPackagesExcept([
+                    ModulePackageList::DBAL_PACKAGE,
+                    ModulePackageList::EVENT_SOURCING_PACKAGE,
+                    ModulePackageList::ASYNCHRONOUS_PACKAGE,
+                ]))
+                ->withExtensionObjects([
+                    SimpleMessageChannelBuilder::createStreamingChannel('event_stream'),
+                    EventStoreChannelAdapter::create(
+                        streamChannelName: 'event_stream',
+                        endpointId: 'event_store_feeder',
+                        fromStream: Ticket::class
+                    ),
+                    PollingMetadata::create('stream_consumer')->withTestingSetup(),
+                ]),
+            runForProductionEventStore: true,
+            licenceKey: LicenceTesting::VALID_LICENCE,
+        );
+
+        // When events are stored in event store
+        $ecotone->sendCommand(new RegisterTicket('ticket-1', 'John', 'bug'));
+        $ecotone->sendCommand(new RegisterTicket('ticket-2', 'Jane', 'feature'));
+
+        // Then consumer hasn't received anything yet
+        $this->assertCount(0, $ecotone->sendQueryWithRouting('getConsumed'));
+
+        // When feeder runs (polls event store and pushes to streaming channel)
+        $ecotone->run('event_store_feeder', ExecutionPollingMetadata::createWithTestingSetup());
+
+        // Then events are in the streaming channel but not consumed yet
+        $this->assertCount(0, $ecotone->sendQueryWithRouting('getConsumed'));
+
+        // When stream consumer runs (handle 2 messages)
+        $ecotone->run('stream_consumer', ExecutionPollingMetadata::createWithTestingSetup(amountOfMessagesToHandle: 2));
+
+        // Then events are consumed
+        $consumedEvents = $ecotone->sendQueryWithRouting('getConsumed');
+        $this->assertCount(2, $consumedEvents);
+        $this->assertEquals('ticket-1', $consumedEvents[0]->getTicketId());
+        $this->assertEquals('ticket-2', $consumedEvents[1]->getTicketId());
+    }
+
+    public function test_filtering_events_by_name_using_glob_patterns(): void
+    {
+        $positionTracker = new InMemoryConsumerPositionTracker();
+        $consumer = new class {
+            private array $consumed = [];
+
+            #[InternalHandler(endpointId: 'stream_consumer', inputChannelName: 'event_stream')]
+            public function handle(TicketWasRegistered $event): void
+            {
+                $this->consumed[] = $event;
+            }
+
+            #[QueryHandler('getConsumed')]
+            public function getConsumed(): array
+            {
+                return $this->consumed;
+            }
+        };
+
+        $ecotone = EcotoneLite::bootstrapFlowTestingWithEventStore(
+            classesToResolve: [Ticket::class, TicketEventConverter::class, $consumer::class],
+            containerOrAvailableServices: [
+                new TicketEventConverter(),
+                $consumer,
+                self::getConnectionFactory(),
+                ConsumerPositionTracker::class => $positionTracker,
+            ],
+            configuration: ServiceConfiguration::createWithDefaults()
+                ->withExtensionObjects([
+                    SimpleMessageChannelBuilder::createStreamingChannel('event_stream'),
+                    EventStoreChannelAdapter::create(
+                        streamChannelName: 'event_stream',
+                        endpointId: 'event_store_feeder',
+                        fromStream: Ticket::class
+                    )
+                        ->withEventNames(['*TicketWasRegistered']), // Only TicketWasRegistered events
+                    PollingMetadata::create('stream_consumer')->withTestingSetup(),
+                ]),
+            runForProductionEventStore: true,
+            licenceKey: LicenceTesting::VALID_LICENCE,
+        );
+
+        // When events are stored in event store (2 TicketWasRegistered + 2 TicketWasClosed)
+        $ecotone->sendCommand(new RegisterTicket('ticket-1', 'John', 'bug'));
+        $ecotone->sendCommand(new CloseTicket('ticket-1'));
+        $ecotone->sendCommand(new RegisterTicket('ticket-2', 'Jane', 'feature'));
+        $ecotone->sendCommand(new CloseTicket('ticket-2'));
+
+        // When feeder runs (polls event store and pushes filtered events to streaming channel)
+        $ecotone->run('event_store_feeder', ExecutionPollingMetadata::createWithTestingSetup());
+
+        // When stream consumer runs (handle 2 messages - only TicketWasRegistered events)
+        $ecotone->run('stream_consumer', ExecutionPollingMetadata::createWithTestingSetup(amountOfMessagesToHandle: 2));
+
+        // Then only TicketWasRegistered events are consumed (TicketWasClosed events are filtered out)
+        $consumedEvents = $ecotone->sendQueryWithRouting('getConsumed');
+        $this->assertCount(2, $consumedEvents);
+        $this->assertEquals('ticket-1', $consumedEvents[0]->getTicketId());
+        $this->assertEquals('ticket-2', $consumedEvents[1]->getTicketId());
+    }
+
+    public function test_normal_projection_works_alongside_event_store_channel_adapter(): void
+    {
+        $positionTracker = new InMemoryConsumerPositionTracker();
+
+        // Normal event handler that counts tickets (not a projection, just a simple event handler)
+        // This demonstrates that EventStoreChannelAdapter works alongside normal event handlers
+        $ticketCounter = new class {
+            public int $registeredCount = 0;
+            public int $closedCount = 0;
+
+            #[EventHandler(endpointId: 'ticket_counter.registered')]
+            public function whenRegistered(TicketWasRegistered $event): void
+            {
+                $this->registeredCount++;
+            }
+
+            #[EventHandler(endpointId: 'ticket_counter.closed')]
+            public function whenClosed(TicketWasClosed $event): void
+            {
+                $this->closedCount++;
+            }
+
+            #[QueryHandler('getTicketCounts')]
+            public function getCounts(): array
+            {
+                return ['registered' => $this->registeredCount, 'closed' => $this->closedCount];
+            }
+        };
+
+        // Consumer that reads from the streaming channel
+        $consumer = new class {
+            private array $consumed = [];
+
+            #[InternalHandler(inputChannelName: 'event_stream', endpointId: 'stream_consumer')]
+            public function handle(array $event): void
+            {
+                $this->consumed[] = $event;
+            }
+
+            #[QueryHandler('getConsumed')]
+            public function getConsumed(): array
+            {
+                return $this->consumed;
+            }
+        };
+
+        $ecotone = EcotoneLite::bootstrapFlowTestingWithEventStore(
+            classesToResolve: [Ticket::class, TicketEventConverter::class, $ticketCounter::class, $consumer::class],
+            containerOrAvailableServices: [
+                new TicketEventConverter(),
+                $ticketCounter,
+                $consumer,
+                self::getConnectionFactory(),
+                ConsumerPositionTracker::class => $positionTracker,
+            ],
+            configuration: ServiceConfiguration::createWithDefaults()
+                ->withSkippedModulePackageNames(ModulePackageList::allPackagesExcept([ModulePackageList::EVENT_SOURCING_PACKAGE, ModulePackageList::ASYNCHRONOUS_PACKAGE]))
+                ->withExtensionObjects([
+                    EventSourcingConfiguration::createWithDefaults(),
+                    SimpleMessageChannelBuilder::createStreamingChannel('event_stream'),
+                    EventStoreChannelAdapter::create(
+                        streamChannelName: 'event_stream',
+                        endpointId: 'event_store_feeder',
+                        fromStream: Ticket::class
+                    ),
+                    PollingMetadata::create('stream_consumer')->withTestingSetup(),
+                ]),
+            runForProductionEventStore: true,
+            licenceKey: LicenceTesting::VALID_LICENCE,
+        );
+
+        // When events are stored in event store
+        $ecotone->sendCommand(new RegisterTicket('ticket-1', 'John', 'bug'));
+        $ecotone->sendCommand(new RegisterTicket('ticket-2', 'Jane', 'feature'));
+        $ecotone->sendCommand(new CloseTicket('ticket-1'));
+
+        // Then normal event handler processes all events synchronously (event-driven by default)
+        $counts = $ecotone->sendQueryWithRouting('getTicketCounts');
+        $this->assertEquals(2, $counts['registered'], 'Event handler should have processed 2 TicketWasRegistered events');
+        $this->assertEquals(1, $counts['closed'], 'Event handler should have processed 1 TicketWasClosed event');
+
+        // When feeder runs (polls event store and pushes to streaming channel)
+        $ecotone->run('event_store_feeder', ExecutionPollingMetadata::createWithTestingSetup());
+
+        // When stream consumer runs (handle 3 messages)
+        $ecotone->run('stream_consumer', ExecutionPollingMetadata::createWithTestingSetup(amountOfMessagesToHandle: 3));
+
+        // Then events are also consumed from streaming channel (as arrays)
+        $consumedEvents = $ecotone->sendQueryWithRouting('getConsumed');
+        $this->assertCount(3, $consumedEvents, 'Should have consumed 3 events from streaming channel');
+        $this->assertEquals('ticket-1', $consumedEvents[0]['ticketId']);
+        $this->assertEquals('ticket-2', $consumedEvents[1]['ticketId']);
+        $this->assertEquals('ticket-1', $consumedEvents[2]['ticketId']); // CloseTicket event
+    }
+}
+


### PR DESCRIPTION
## Why is this change proposed?

## Description of Changes

Adds ability to push events from Event Store directly to Event Streaming Channel like Kafka or Amqp Streaming Channel. 

## Pull Request Contribution Terms

- [X] I have read and agree to the contribution terms outlined in [CONTRIBUTING](https://github.com/ecotoneframework/ecotone-dev/blob/main/CONTRIBUTING.md).