### PR TITLE
Projecting: fix gap aware position handling existing gaps when gap detection is off

### DIFF
--- a/packages/PdoEventSourcing/tests/Projecting/GapAwarePositionTest.php
+++ b/packages/PdoEventSourcing/tests/Projecting/GapAwarePositionTest.php
@@ -110,4 +110,13 @@ class GapAwarePositionTest extends TestCase
         $gapAware->cutoffGapsBelow(3);
         $this->assertSame([5, 7, 9, 12], $gapAware->getGaps());
     }
+
+    public function test_advance_to_without_inserting_gaps_can_process_existent_gap(): void
+    {
+        $gapAware = new GapAwarePosition(0);
+        $gapAware->advanceTo(5); // gaps: 1,2,3,4
+        $gapAware->advanceTo(3, false);
+        $this->assertSame(5, $gapAware->getPosition());
+        $this->assertSame([1, 2, 4], $gapAware->getGaps());
+    }
 }


### PR DESCRIPTION
## Why is this change proposed?
Fix gaps not being correctly handled when they are old.

## Pull Request Contribution Terms

- [X] I have read and agree to the contribution terms outlined in [CONTRIBUTING](https://github.com/ecotoneframework/ecotone-dev/blob/main/CONTRIBUTING.md).