### PR TITLE
Multiple message handlers

### DIFF
--- a/packages/Ecotone/tests/Modelling/Fixture/MultipleMessageHandlers/InvoiceOrder.php
+++ b/packages/Ecotone/tests/Modelling/Fixture/MultipleMessageHandlers/InvoiceOrder.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Test\Ecotone\Modelling\Fixture\MultipleMessageHandlers;
+
+use Ecotone\Messaging\Attribute\Parameter\Payload;
+use Ecotone\Modelling\Attribute\EventHandler;
+use Ecotone\Modelling\Attribute\Identifier;
+use Ecotone\Modelling\Attribute\Saga;
+
+#[Saga]
+class InvoiceOrder
+{
+    private array $products;
+
+    public function __construct(
+        #[Identifier] private string $debtorId,
+    ) {
+        $this->products = [];
+    }
+
+    public function products(): array
+    {
+        return $this->products;
+    }
+
+    #[EventHandler(endpointId: 'createWhenProductBecameBillable', identifierMapping: ['debtorId' => 'payload.debtor'])]
+    public static function createWhenProductBecameBillable(
+        #[Payload] ProductBecameBillable $event
+    ): self {
+        $invoiceOrder = new self($event->debtor);
+        $invoiceOrder->products[] = $event->productId;
+
+        return $invoiceOrder;
+    }
+
+    #[EventHandler(endpointId: 'createWhenDebtorWasChanged', identifierMapping: ['debtorId' => 'payload.newDebtor'])]
+    public static function createWhenDebtorWasChanged(
+        #[Payload] ProductDebtorWasChanged $event
+    ): self {
+        $invoiceOrder = new self($event->newDebtor);
+        $invoiceOrder->products[] = $event->productId;
+
+        return $invoiceOrder;
+    }
+
+    #[EventHandler(endpointId: 'removeProductWhenDebtorWasChanged', identifierMapping: ['debtorId' => 'payload.oldDebtor'])]
+    public function removeProductWhenDebtorWasChanged(
+        #[Payload] ProductDebtorWasChanged $event
+    ): void {
+        unset($this->products[$event->productId]);
+    }
+
+    #[EventHandler(endpointId: 'addProductWhenDebtorWasChanged', identifierMapping: ['debtorId' => 'payload.newDebtor'])]
+    public function addProductWhenDebtorWasChanged(
+        #[Payload] ProductDebtorWasChanged $event
+    ): void {
+        if (!in_array($event->productId, $this->products, true)) {
+            $this->products[] = $event->productId;
+        }
+    }
+}

--- a/packages/Ecotone/tests/Modelling/Fixture/MultipleMessageHandlers/ProductBecameBillable.php
+++ b/packages/Ecotone/tests/Modelling/Fixture/MultipleMessageHandlers/ProductBecameBillable.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Test\Ecotone\Modelling\Fixture\MultipleMessageHandlers;
+
+class ProductBecameBillable
+{
+    public function __construct(
+        public string $productId,
+        public string $debtor,
+    ) {
+    }
+}

--- a/packages/Ecotone/tests/Modelling/Fixture/MultipleMessageHandlers/ProductDebtorWasChanged.php
+++ b/packages/Ecotone/tests/Modelling/Fixture/MultipleMessageHandlers/ProductDebtorWasChanged.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Test\Ecotone\Modelling\Fixture\MultipleMessageHandlers;
+
+class ProductDebtorWasChanged
+{
+    public function __construct(
+        public string $productId,
+        public string $oldDebtor,
+        public string $newDebtor,
+    ) {
+    }
+}

--- a/packages/Ecotone/tests/Modelling/Unit/MultipleMessageHandlersTest.php
+++ b/packages/Ecotone/tests/Modelling/Unit/MultipleMessageHandlersTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Modelling\Unit;
+
+use Ecotone\Lite\EcotoneLite;
+use Ecotone\Messaging\Channel\SimpleMessageChannelBuilder;
+use Ecotone\Messaging\Config\ServiceConfiguration;
+use PHPUnit\Framework\TestCase;
+use Test\Ecotone\Modelling\Fixture\MultipleMessageHandlers\InvoiceOrder;
+use Test\Ecotone\Modelling\Fixture\MultipleMessageHandlers\ProductBecameBillable;
+use Test\Ecotone\Modelling\Fixture\MultipleMessageHandlers\ProductDebtorWasChanged;
+
+class MultipleMessageHandlersTest extends TestCase
+{
+    public function test_multiple_message_handlers(): void
+    {
+        $ecotone = EcotoneLite::bootstrapFlowTesting(
+            configuration: ServiceConfiguration::createWithDefaults()
+                ->withNamespaces(['Test\Ecotone\Modelling\Fixture\MultipleMessageHandlers'])
+                ->withExtensionObjects([
+                    SimpleMessageChannelBuilder::createQueueChannel('invoiceOrder')
+                ])
+            ,
+        );
+
+        $ecotone->publishEvent(new ProductBecameBillable(productId: 'product-1', debtor: 'debtor-1'));
+
+        self::assertEquals(['product-1'], $ecotone->getAggregate(InvoiceOrder::class, 'debtor-1')->products());
+
+        $ecotone->publishEvent(new ProductDebtorWasChanged(productId: 'product-1', oldDebtor: 'debtor-1', newDebtor: 'debtor-2'));
+
+        self::assertEquals([], $ecotone->getAggregate(InvoiceOrder::class, 'debtor-1')->products());
+        self::assertEquals(['product-1'], $ecotone->getAggregate(InvoiceOrder::class, 'debtor-1')->products());
+    }
+}


### PR DESCRIPTION
## Why is this change proposed?

Consider following scenario. 

- When product becomes billable (`ProductBecameBillable`), it should be added to `InvoiceOrder` identified by `Debtor` of billable product. `InvoiceOrder` can be created when this occurs.
- `Debtor` of a product can change overtime (`ProductDebtorWasChanged`). When it happens, following outcome should take place:
- - product should be removed from `InvoiceOrde` identified by old `Debtor`
- - product should be added to `InvoiceOrder` identified by new `Debtor`. `InvoiceOrder` of new `Debtor` may not yet exists, therefore it can be created when this occurs.

Above scenario require aggregate to have multiple factory methods and action channels:

`ProductBecameBillable` - factory method of `InvoiceOrder`
`ProductDebtorWasChanged` - factory method + two action channels, one to remove and second to add product to `InvoiceOrder`

Proper identifier mapping is defined in `EventHandler` definition as shown in `packages/Ecotone/tests/Modelling/Fixture/MultipleMessageHandlers/InvoiceOrder.php`

However, current implementation require that Message Handlers on Aggregate and Saga can be used either for single factory method and single action method together, or for multiple actions methods and forbid that implementation.

## Description of Changes

tbd

## Pull Request Contribution Terms

- [X] I have read and agree to the contribution terms outlined in [CONTRIBUTING](https://github.com/ecotoneframework/ecotone-dev/blob/main/CONTRIBUTING.md).