### PR TITLE
feat: Bump minimum PHP to 8.2

### DIFF
--- a/.github/workflows/split-testing.yml
+++ b/.github/workflows/split-testing.yml
@@ -20,9 +20,9 @@ jobs:
       fail-fast: true
       matrix:
         include:
-          - php-version: '8.1'
+          - php-version: '8.2'
           - php-version: '8.4'
-          - php-version: '8.1'
+          - php-version: '8.2'
             stability: prefer-lowest
 
     services:

--- a/composer.json
+++ b/composer.json
@@ -110,7 +110,7 @@
         }
     },
     "require": {
-        "php": "^8.1",
+        "php": "^8.2",
         "doctrine/dbal": "^3.9|^4.0",
         "doctrine/persistence": "^2.5|^3.4",
         "enqueue/amqp-lib": "^0.10.25",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,13 +25,13 @@ services:
       APP_MERGE_PLUGIN: "yes"
     env_file:
       - ".env"
-  app8_1:
-    image: simplycodedsoftware/php:8.1.31
+  app8_2:
+    image: simplycodedsoftware/php:8.2.31
     volumes:
       - "$PWD:/data/app"
     working_dir: "/data/app"
     command: sleep 99999
-    container_name: "ecotone_development_8_1"
+    container_name: "ecotone_development_8_2"
     user: "${USER_PID:-1000}:${USER_PID:-1000}"
     extra_hosts:
       - "host.docker.internal:host-gateway"

--- a/packages/Ecotone/composer.json
+++ b/packages/Ecotone/composer.json
@@ -38,7 +38,7 @@
         }
     },
     "require": {
-        "php": "^8.1",
+        "php": "^8.2",
         "laminas/laminas-code": "^4",
         "psr/clock": "^1.0",
         "psr/container": "^1.1.1|^2.0.1",

--- a/packages/Symfony/tests/phpunit/AmqpMessengerIntegrationTest.php
+++ b/packages/Symfony/tests/phpunit/AmqpMessengerIntegrationTest.php
@@ -51,10 +51,6 @@ final class AmqpMessengerIntegrationTest extends WebTestCase
 
     public function test_single_command(): void
     {
-        if (version_compare(PHP_VERSION, '8.1', '<')) {
-            $this->markTestSkipped('TypeError: Symfony\Component\Messenger\Bridge\Amqp\Transport\Connection::nack(): Return value must be of type bool, null returned');
-        }
-
         $this->messaging->sendCommandWithRoutingKey('amqp.test.example_command', new AmqpExampleCommand('single_1'));
         $this->assertCount(0, $this->messaging->sendQueryWithRouting('amqp.consumer.getCommands'));
 
@@ -66,10 +62,6 @@ final class AmqpMessengerIntegrationTest extends WebTestCase
 
     public function test_multiple_commands(): void
     {
-        if (version_compare(PHP_VERSION, '8.1', '<')) {
-            $this->markTestSkipped('TypeError: Symfony\Component\Messenger\Bridge\Amqp\Transport\Connection::nack(): Return value must be of type bool, null returned');
-        }
-
         $this->messaging->sendCommandWithRoutingKey('amqp.test.example_command', new AmqpExampleCommand('multi_1'));
         $this->messaging->sendCommandWithRoutingKey('amqp.test.example_command', new AmqpExampleCommand('multi_2'));
         /** Consumer not yet run */

--- a/release.sh
+++ b/release.sh
@@ -1,3 +1,0 @@
-#!/usr/bin/env bash
-
-docker run -v $HOME/.gitconfig:/root/.gitconfig -v $PWD:/data/app -v $HOME/.ssh:/root/.ssh --workdir=/data/app --entrypoint vendor/bin/monorepo-builder simplycodedsoftware/php:8.1 release "$1"


### PR DESCRIPTION
## Why is this change proposed?

Bump minimum PHP to 8.2, as 8.1 comes to end of security upgrades by end of the year.

## Description of Changes

## Pull Request Contribution Terms

- [X] I have read and agree to the contribution terms outlined in [CONTRIBUTING](https://github.com/ecotoneframework/ecotone-dev/blob/main/CONTRIBUTING.md).