### PR TITLE
Feat: from aggregate stream

### DIFF
--- a/packages/PdoEventSourcing/src/Attribute/FromAggregateStream.php
+++ b/packages/PdoEventSourcing/src/Attribute/FromAggregateStream.php
@@ -24,7 +24,7 @@ use Ecotone\EventSourcing\EventStore;
  * licence Enterprise
  */
 #[Attribute(Attribute::TARGET_CLASS)]
-class AggregateStream
+class FromAggregateStream
 {
     /**
      * @param class-string $aggregateClass The aggregate class to read Stream and AggregateType from.

--- a/packages/PdoEventSourcing/src/Config/ProophProjectingModule.php
+++ b/packages/PdoEventSourcing/src/Config/ProophProjectingModule.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
 namespace Ecotone\EventSourcing\Config;
 
 use Ecotone\AnnotationFinder\AnnotationFinder;
-use Ecotone\EventSourcing\Attribute\AggregateStream;
+use Ecotone\EventSourcing\Attribute\FromAggregateStream;
 use Ecotone\EventSourcing\Attribute\AggregateType;
 use Ecotone\EventSourcing\Attribute\FromStream;
 use Ecotone\EventSourcing\Attribute\Stream;
@@ -74,9 +74,9 @@ class ProophProjectingModule implements AnnotationModule
         }
 
         // Handle AggregateStream attribute
-        foreach ($annotationRegistrationService->findAnnotatedClasses(AggregateStream::class) as $classname) {
+        foreach ($annotationRegistrationService->findAnnotatedClasses(FromAggregateStream::class) as $classname) {
             $projectionAttribute = $annotationRegistrationService->findAttributeForClass($classname, ProjectionV2::class);
-            $aggregateStreamAttribute = $annotationRegistrationService->findAttributeForClass($classname, AggregateStream::class);
+            $aggregateStreamAttribute = $annotationRegistrationService->findAttributeForClass($classname, FromAggregateStream::class);
             $customScopeStrategyAttribute = $annotationRegistrationService->findAttributeForClass($classname, Partitioned::class);
 
             if (! $projectionAttribute || ! $aggregateStreamAttribute) {

--- a/packages/PdoEventSourcing/tests/Projecting/Global/SynchronousEventDrivenProjectionTest.php
+++ b/packages/PdoEventSourcing/tests/Projecting/Global/SynchronousEventDrivenProjectionTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Test\Ecotone\EventSourcing\Projecting\Global;
 
 use Doctrine\DBAL\Connection;
-use Ecotone\EventSourcing\Attribute\AggregateStream;
+use Ecotone\EventSourcing\Attribute\FromAggregateStream;
 use Ecotone\EventSourcing\Attribute\FromStream;
 use Ecotone\EventSourcing\Attribute\ProjectionDelete;
 use Ecotone\EventSourcing\Attribute\ProjectionInitialization;
@@ -239,7 +239,7 @@ final class SynchronousEventDrivenProjectionTest extends ProjectingTestCase
     public function test_aggregate_stream_throws_exception_for_non_event_sourcing_aggregate(): void
     {
         // Create a projection that references a non-EventSourcingAggregate class
-        $projection = new #[ProjectionV2('invalid_projection'), AggregateStream(\stdClass::class)] class {
+        $projection = new #[ProjectionV2('invalid_projection'), FromAggregateStream(\stdClass::class)] class {
             #[EventHandler('*')]
             public function handle(array $event): void
             {
@@ -267,7 +267,7 @@ final class SynchronousEventDrivenProjectionTest extends ProjectingTestCase
     {
         $connection = $this->getConnection();
 
-        return new #[ProjectionV2(self::NAME), AggregateStream(Order::class)] class ($connection) {
+        return new #[ProjectionV2(self::NAME), FromAggregateStream(Order::class)] class ($connection) {
             public const NAME = 'order_list_aggregate_stream';
 
             public function __construct(private Connection $connection)

--- a/packages/PdoEventSourcing/tests/Projecting/Partitioned/SynchronousEventDrivenProjectionTest.php
+++ b/packages/PdoEventSourcing/tests/Projecting/Partitioned/SynchronousEventDrivenProjectionTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Test\Ecotone\EventSourcing\Projecting\Partitioned;
 
 use Doctrine\DBAL\Connection;
-use Ecotone\EventSourcing\Attribute\AggregateStream;
+use Ecotone\EventSourcing\Attribute\FromAggregateStream;
 use Ecotone\EventSourcing\Attribute\FromStream;
 use Ecotone\EventSourcing\Attribute\ProjectionDelete;
 use Ecotone\EventSourcing\Attribute\ProjectionInitialization;
@@ -192,7 +192,7 @@ final class SynchronousEventDrivenProjectionTest extends ProjectingTestCase
     {
         $connection = $this->getConnection();
 
-        return new #[ProjectionV2(self::NAME), Partitioned, AggregateStream(Order::class)] class ($connection) {
+        return new #[ProjectionV2(self::NAME), Partitioned, FromAggregateStream(Order::class)] class ($connection) {
             public const NAME = 'order_list_partitioned_aggregate_stream';
 
             public function __construct(private Connection $connection)


### PR DESCRIPTION
## Why is this change proposed?

For ProjectionV2 we do have FromStream, however that requires putting manual stream name and aggregate type, which requires config duplication. 

Instead this PR introduces `FromAggregateStream(Aggregate::class)`, which will read from `Aggregate` class for `Stream and AggregateType attributes` and use it for config. That will require much less configs.


## Description of Changes

## Pull Request Contribution Terms

- [X] I have read and agree to the contribution terms outlined in [CONTRIBUTING](https://github.com/ecotoneframework/ecotone-dev/blob/main/CONTRIBUTING.md).