### PR TITLE
feat: amqp distributed publisher auto-declare config

### DIFF
--- a/packages/Amqp/src/Distribution/AmqpDistributedBusConfiguration.php
+++ b/packages/Amqp/src/Distribution/AmqpDistributedBusConfiguration.php
@@ -25,6 +25,7 @@ class AmqpDistributedBusConfiguration
     private string $referenceName;
     private string $headerMapper = '*';
     private bool $defaultPersistentDelivery = true;
+    private bool $autoDeclare = true;
     private string $distributionType;
 
     private function __construct(string $amqpConnectionReference, ?string $outputDefaultConversionMediaType, string $referenceName, string $distributionType)
@@ -95,6 +96,22 @@ class AmqpDistributedBusConfiguration
     public function getDefaultPersistentDelivery(): bool
     {
         return $this->defaultPersistentDelivery;
+    }
+
+    /**
+     * Whether to automatically declare the exchange and queues on send.
+     * When set to false, the exchange and queues must be declared manually.
+     */
+    public function withAutoDeclare(bool $autoDeclare): static
+    {
+        $this->autoDeclare = $autoDeclare;
+
+        return $this;
+    }
+
+    public function isAutoDeclare(): bool
+    {
+        return $this->autoDeclare;
     }
 
     /**


### PR DESCRIPTION
## Why is this change proposed?

This allows to disable auto-declare for amqp distributed publisher:

```php
AmqpDistributedBusConfiguration::createPublisher()
   ->withAutoDeclare(false)
```

## Pull Request Contribution Terms

- [X] I have read and agree to the contribution terms outlined in [CONTRIBUTING](https://github.com/ecotoneframework/ecotone-dev/blob/main/CONTRIBUTING.md).