### PR TITLE
feat: disable global DbalTransaction and pause Collector during projection batch execution

### DIFF
--- a/packages/Ecotone/src/Messaging/Channel/Collector/CollectorPauseInterceptor.php
+++ b/packages/Ecotone/src/Messaging/Channel/Collector/CollectorPauseInterceptor.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ecotone\Messaging\Channel\Collector;
+
+use Ecotone\Messaging\Handler\Processor\MethodInvoker\MethodInvocation;
+
+/**
+ * licence Apache-2.0
+ */
+final class CollectorPauseInterceptor
+{
+    public function pauseCollecting(MethodInvocation $methodInvocation): mixed
+    {
+        CollectorStorage::pause();
+        try {
+            return $methodInvocation->proceed();
+        } finally {
+            CollectorStorage::resume();
+        }
+    }
+}

--- a/packages/Ecotone/src/Messaging/Channel/Collector/CollectorStorage.php
+++ b/packages/Ecotone/src/Messaging/Channel/Collector/CollectorStorage.php
@@ -17,6 +17,8 @@ use Ecotone\Messaging\Message;
  */
 final class CollectorStorage
 {
+    private static int $pauseDepth = 0;
+
     /**
      * @param CollectedMessage[] $collectedMessages
      */
@@ -24,6 +26,21 @@ final class CollectorStorage
         private bool $enabled = false,
         private array $collectedMessages = []
     ) {
+    }
+
+    public static function pause(): void
+    {
+        self::$pauseDepth++;
+    }
+
+    public static function resume(): void
+    {
+        self::$pauseDepth--;
+    }
+
+    public static function isPaused(): bool
+    {
+        return self::$pauseDepth > 0;
     }
 
     public function enable(): void

--- a/packages/Ecotone/src/Messaging/Channel/Collector/Config/CollectorModule.php
+++ b/packages/Ecotone/src/Messaging/Channel/Collector/Config/CollectorModule.php
@@ -7,6 +7,7 @@ namespace Ecotone\Messaging\Channel\Collector\Config;
 use Ecotone\AnnotationFinder\AnnotationFinder;
 use Ecotone\Messaging\Attribute\AsynchronousRunningEndpoint;
 use Ecotone\Messaging\Attribute\ModuleAnnotation;
+use Ecotone\Messaging\Channel\Collector\CollectorPauseInterceptor;
 use Ecotone\Messaging\Channel\Collector\CollectorSenderInterceptor;
 use Ecotone\Messaging\Channel\Collector\CollectorStorage;
 use Ecotone\Messaging\Channel\DynamicChannel\DynamicMessageChannelBuilder;
@@ -26,6 +27,7 @@ use Ecotone\Messaging\Handler\InterfaceToCallRegistry;
 use Ecotone\Messaging\Handler\Processor\MethodInvoker\AroundInterceptorBuilder;
 use Ecotone\Messaging\Precedence;
 use Ecotone\Modelling\CommandBus;
+use Ecotone\Projecting\Attribute\ProjectionFlush;
 
 #[ModuleAnnotation]
 /**
@@ -51,6 +53,7 @@ final class CollectorModule extends NoExternalConfigurationModule implements Ann
         }
 
 
+        $hasCollectorEnabled = false;
         foreach ($pollableMessageChannels as $pollableMessageChannel) {
             $channelConfiguration = $globalPollableChannelConfiguration;
 
@@ -64,6 +67,7 @@ final class CollectorModule extends NoExternalConfigurationModule implements Ann
                 continue;
             }
 
+            $hasCollectorEnabled = true;
             $collectorReference = Reference::to('polling.'.$pollableMessageChannel->getMessageChannelName().'.collector_storage');
             $messagingConfiguration->registerServiceDefinition($collectorReference, new Definition(CollectorStorage::class));
             $messagingConfiguration->registerChannelInterceptor(
@@ -88,6 +92,21 @@ final class CollectorModule extends NoExternalConfigurationModule implements Ann
                     $collectorSenderInterceptorInterfaceToCall,
                     Precedence::COLLECTOR_SENDER_PRECEDENCE,
                     CommandBus::class . '||' . AsynchronousRunningEndpoint::class
+                )
+            );
+        }
+
+        if ($hasCollectorEnabled) {
+            $messagingConfiguration->registerServiceDefinition(
+                CollectorPauseInterceptor::class,
+                new Definition(CollectorPauseInterceptor::class)
+            );
+            $messagingConfiguration->registerAroundMethodInterceptor(
+                AroundInterceptorBuilder::create(
+                    CollectorPauseInterceptor::class,
+                    $interfaceToCallRegistry->getFor(CollectorPauseInterceptor::class, 'pauseCollecting'),
+                    Precedence::COLLECTOR_SENDER_PRECEDENCE,
+                    ProjectionFlush::class
                 )
             );
         }

--- a/packages/Ecotone/src/Messaging/Channel/Collector/MessageCollectorChannelInterceptor.php
+++ b/packages/Ecotone/src/Messaging/Channel/Collector/MessageCollectorChannelInterceptor.php
@@ -23,7 +23,7 @@ final class MessageCollectorChannelInterceptor extends AbstractChannelIntercepto
 
     public function preSend(Message $message, MessageChannel $messageChannel): ?Message
     {
-        if ($this->collectorStorage->isEnabled()) {
+        if ($this->collectorStorage->isEnabled() && ! CollectorStorage::isPaused()) {
             $this->collectorStorage->collect($message, $this->logger);
 
             $message = null;

--- a/packages/Ecotone/src/Projecting/Config/ProjectingModule.php
+++ b/packages/Ecotone/src/Projecting/Config/ProjectingModule.php
@@ -58,6 +58,8 @@ class ProjectingModule implements AnnotationModule
         return new self();
     }
 
+    private const WITHOUT_DBAL_TRANSACTION_CLASS = 'Ecotone\Dbal\DbalTransaction\WithoutDbalTransaction';
+
     public function prepare(Configuration $messagingConfiguration, array $extensionObjects, ModuleReferenceSearchService $moduleReferenceSearchService, InterfaceToCallRegistry $interfaceToCallRegistry): void
     {
         $serviceConfiguration = ExtensionObjectResolver::resolveUnique(ServiceConfiguration::class, $extensionObjects, ServiceConfiguration::createWithDefaults());
@@ -97,26 +99,27 @@ class ProjectingModule implements AnnotationModule
             );
             $projectionRegistryMap[$projectionName] = new Reference($projectingManagerReference);
 
-            $messagingConfiguration->registerMessageHandler(
-                MessageProcessorActivatorBuilder::create()
-                    ->chainInterceptedProcessor(
-                        MethodInvokerBuilder::create(
-                            $projectingManagerReference,
-                            InterfaceToCallReference::create(ProjectingManager::class, 'execute'),
-                            [
-                                $projectionBuilder->partitionHeader()
-                                    ? HeaderBuilder::create('partitionKeyValue', $projectionBuilder->partitionHeader())
-                                    : ($projectionBuilder->isPartitioned()
-                                        ? new PartitionHeaderBuilder('partitionKeyValue')
-                                        : ValueBuilder::create('partitionKeyValue', null)),
-                                HeaderBuilder::createOptional('manualInitialization', ProjectingHeaders::MANUAL_INITIALIZATION),
-                            ],
-                        )
+            $executeHandlerBuilder = MessageProcessorActivatorBuilder::create()
+                ->chainInterceptedProcessor(
+                    MethodInvokerBuilder::create(
+                        $projectingManagerReference,
+                        InterfaceToCallReference::create(ProjectingManager::class, 'execute'),
+                        [
+                            $projectionBuilder->partitionHeader()
+                                ? HeaderBuilder::create('partitionKeyValue', $projectionBuilder->partitionHeader())
+                                : ($projectionBuilder->isPartitioned()
+                                    ? new PartitionHeaderBuilder('partitionKeyValue')
+                                    : ValueBuilder::create('partitionKeyValue', null)),
+                            HeaderBuilder::createOptional('manualInitialization', ProjectingHeaders::MANUAL_INITIALIZATION),
+                        ],
                     )
-                    ->withEndpointId(self::endpointIdForProjection($projectionName))
-                    ->withInputChannelName(self::inputChannelForProjectingManager($projectionName))
-                    ->withEndpointAnnotations([new AttributeDefinition('Ecotone\Dbal\DbalTransaction\WithoutDbalTransaction')])
-            );
+                )
+                ->withEndpointId(self::endpointIdForProjection($projectionName))
+                ->withInputChannelName(self::inputChannelForProjectingManager($projectionName));
+            if (class_exists(self::WITHOUT_DBAL_TRANSACTION_CLASS)) {
+                $executeHandlerBuilder = $executeHandlerBuilder->withEndpointAnnotations([new AttributeDefinition(self::WITHOUT_DBAL_TRANSACTION_CLASS)]);
+            }
+            $messagingConfiguration->registerMessageHandler($executeHandlerBuilder);
 
             $messagingConfiguration->registerMessageHandler(
                 MessageProcessorActivatorBuilder::create()
@@ -161,26 +164,27 @@ class ProjectingModule implements AnnotationModule
             ])
         );
 
-        $messagingConfiguration->registerMessageHandler(
-            MessageProcessorActivatorBuilder::create()
-                ->chainInterceptedProcessor(
-                    MethodInvokerBuilder::create(
-                        BackfillExecutorHandler::class,
-                        InterfaceToCallReference::create(BackfillExecutorHandler::class, 'executeBackfillBatch'),
-                        [
-                            PayloadBuilder::create('projectionName'),
-                            HeaderBuilder::createOptional('limit', 'backfill.limit'),
-                            HeaderBuilder::createOptional('offset', 'backfill.offset'),
-                            HeaderBuilder::createOptional('streamName', 'backfill.streamName'),
-                            HeaderBuilder::createOptional('aggregateType', 'backfill.aggregateType'),
-                            HeaderBuilder::createOptional('eventStoreReferenceName', 'backfill.eventStoreReferenceName'),
-                        ],
-                    )
+        $backfillHandlerBuilder = MessageProcessorActivatorBuilder::create()
+            ->chainInterceptedProcessor(
+                MethodInvokerBuilder::create(
+                    BackfillExecutorHandler::class,
+                    InterfaceToCallReference::create(BackfillExecutorHandler::class, 'executeBackfillBatch'),
+                    [
+                        PayloadBuilder::create('projectionName'),
+                        HeaderBuilder::createOptional('limit', 'backfill.limit'),
+                        HeaderBuilder::createOptional('offset', 'backfill.offset'),
+                        HeaderBuilder::createOptional('streamName', 'backfill.streamName'),
+                        HeaderBuilder::createOptional('aggregateType', 'backfill.aggregateType'),
+                        HeaderBuilder::createOptional('eventStoreReferenceName', 'backfill.eventStoreReferenceName'),
+                    ],
                 )
-                ->withEndpointId('backfill_executor_handler')
-                ->withInputChannelName(BackfillExecutorHandler::BACKFILL_EXECUTOR_CHANNEL)
-                ->withEndpointAnnotations([new AttributeDefinition('Ecotone\Dbal\DbalTransaction\WithoutDbalTransaction')])
-        );
+            )
+            ->withEndpointId('backfill_executor_handler')
+            ->withInputChannelName(BackfillExecutorHandler::BACKFILL_EXECUTOR_CHANNEL);
+        if (class_exists(self::WITHOUT_DBAL_TRANSACTION_CLASS)) {
+            $backfillHandlerBuilder = $backfillHandlerBuilder->withEndpointAnnotations([new AttributeDefinition(self::WITHOUT_DBAL_TRANSACTION_CLASS)]);
+        }
+        $messagingConfiguration->registerMessageHandler($backfillHandlerBuilder);
 
         // Register console commands
         $messagingConfiguration->registerServiceDefinition(ProjectingConsoleCommands::class, new Definition(ProjectingConsoleCommands::class, [new Reference(ProjectionRegistry::class)]));

--- a/packages/Ecotone/src/Projecting/Config/ProjectingModule.php
+++ b/packages/Ecotone/src/Projecting/Config/ProjectingModule.php
@@ -115,6 +115,7 @@ class ProjectingModule implements AnnotationModule
                     )
                     ->withEndpointId(self::endpointIdForProjection($projectionName))
                     ->withInputChannelName(self::inputChannelForProjectingManager($projectionName))
+                    ->withEndpointAnnotations([new AttributeDefinition('Ecotone\Dbal\DbalTransaction\WithoutDbalTransaction')])
             );
 
             $messagingConfiguration->registerMessageHandler(
@@ -178,6 +179,7 @@ class ProjectingModule implements AnnotationModule
                 )
                 ->withEndpointId('backfill_executor_handler')
                 ->withInputChannelName(BackfillExecutorHandler::BACKFILL_EXECUTOR_CHANNEL)
+                ->withEndpointAnnotations([new AttributeDefinition('Ecotone\Dbal\DbalTransaction\WithoutDbalTransaction')])
         );
 
         // Register console commands

--- a/packages/Ecotone/tests/Messaging/Unit/Channel/Collector/CollectorStoragePauseTest.php
+++ b/packages/Ecotone/tests/Messaging/Unit/Channel/Collector/CollectorStoragePauseTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Ecotone\Messaging\Unit\Channel\Collector;
+
+use Ecotone\Messaging\Channel\Collector\CollectorStorage;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @internal
+ */
+final class CollectorStoragePauseTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        while (CollectorStorage::isPaused()) {
+            CollectorStorage::resume();
+        }
+    }
+
+    public function test_not_paused_by_default(): void
+    {
+        self::assertFalse(CollectorStorage::isPaused());
+    }
+
+    public function test_pause_and_resume(): void
+    {
+        CollectorStorage::pause();
+        self::assertTrue(CollectorStorage::isPaused());
+
+        CollectorStorage::resume();
+        self::assertFalse(CollectorStorage::isPaused());
+    }
+
+    public function test_nested_pause_requires_matching_resume_count(): void
+    {
+        CollectorStorage::pause();
+        CollectorStorage::pause();
+        self::assertTrue(CollectorStorage::isPaused());
+
+        CollectorStorage::resume();
+        self::assertTrue(CollectorStorage::isPaused());
+
+        CollectorStorage::resume();
+        self::assertFalse(CollectorStorage::isPaused());
+    }
+}

--- a/packages/Ecotone/tests/Projecting/ProjectingTest.php
+++ b/packages/Ecotone/tests/Projecting/ProjectingTest.php
@@ -13,6 +13,7 @@ use Ecotone\Lite\EcotoneLite;
 use Ecotone\Messaging\Attribute\Asynchronous;
 use Ecotone\Messaging\Attribute\Endpoint\Priority;
 use Ecotone\Messaging\Attribute\Interceptor\Around;
+use Ecotone\Messaging\Channel\PollableChannel\PollableChannelConfiguration;
 use Ecotone\Messaging\Channel\SimpleMessageChannelBuilder;
 use Ecotone\Messaging\Config\ConfigurationException;
 use Ecotone\Messaging\Config\ModulePackageList;
@@ -23,6 +24,7 @@ use Ecotone\Messaging\Handler\Processor\MethodInvoker\MethodInvocation;
 use Ecotone\Messaging\MessageHeaders;
 use Ecotone\Modelling\Attribute\EventHandler;
 use Ecotone\Modelling\Event;
+use Ecotone\Modelling\EventBus;
 use Ecotone\Projecting\Attribute;
 use Ecotone\Projecting\Attribute\Partitioned;
 use Ecotone\Projecting\Attribute\ProjectionDeployment;
@@ -42,6 +44,7 @@ use Ecotone\Test\LicenceTesting;
 use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
+use stdClass;
 
 /**
  * @internal
@@ -1011,5 +1014,66 @@ class ProjectingTest extends TestCase
         $ecotone->initializeProjection('userland_storage_projection');
 
         self::assertTrue($userlandStorage->wasUsed, 'Userland state storage should be prioritized and used');
+    }
+
+    public function test_collector_is_paused_during_projection_flush(): void
+    {
+        $projection = new #[ProjectionV2('collector_projection'), FromStream('test_stream')] class () {
+            public array $processedEvents = [];
+            public int $flushCount = 0;
+            public ?EventBus $eventBus = null;
+
+            #[EventHandler('*')]
+            public function handle(array $event, #[\Ecotone\Messaging\Attribute\Parameter\Reference] EventBus $eventBus): void
+            {
+                $this->eventBus = $eventBus;
+                $this->processedEvents[] = $event;
+            }
+
+            #[ProjectionFlush]
+            public function flush(): void
+            {
+                $this->flushCount++;
+                if ($this->eventBus && count($this->processedEvents) > 0) {
+                    $this->eventBus->publish(new stdClass());
+                }
+            }
+        };
+
+        $notificationHandler = new class () {
+            public int $receivedCount = 0;
+
+            #[Asynchronous('notifications')]
+            #[EventHandler(endpointId: 'notification_handler')]
+            public function handle(stdClass $event): void
+            {
+                $this->receivedCount++;
+            }
+        };
+
+        $ecotone = EcotoneLite::bootstrapFlowTesting(
+            [$projection::class, $notificationHandler::class],
+            [$projection, $notificationHandler],
+            ServiceConfiguration::createWithDefaults()
+                ->withSkippedModulePackageNames(ModulePackageList::allPackagesExcept([ModulePackageList::ASYNCHRONOUS_PACKAGE]))
+                ->withLicenceKey(LicenceTesting::VALID_LICENCE)
+                ->withExtensionObjects([
+                    PollableChannelConfiguration::neverRetry('notifications')->withCollector(true),
+                ]),
+            enableAsynchronousProcessing: [
+                SimpleMessageChannelBuilder::createQueueChannel('notifications'),
+            ],
+        );
+
+        $ecotone->withEvents([
+            Event::createWithType('test-event', ['name' => 'Test']),
+        ]);
+
+        $ecotone->triggerProjection('collector_projection');
+
+        self::assertCount(1, $projection->processedEvents);
+        self::assertGreaterThanOrEqual(1, $projection->flushCount);
+        $message = $ecotone->getMessageChannel('notifications')->receive();
+        self::assertNotNull($message, 'Message sent during flush should bypass collector and go directly to channel');
     }
 }


### PR DESCRIPTION
## Why is this change proposed?

When ProjectionV2 runs asynchronously or during backfill, the global `DbalTransactionInterceptor` wraps the entire execution in one big transaction — overriding the projection's own per-batch transaction management. This means all batches commit or rollback together instead of independently. Additionally, the `CollectorSenderInterceptor` collects messages sent during `flush()` and releases them only after all batches complete, outside the per-batch transaction scope.

## Description of Changes

- **Disable global DbalTransaction for projection execute and backfill handlers** — Added `WithoutDbalTransaction` endpoint annotation to both the `execute()` and `BackfillExecutorHandler` message handlers in `ProjectingModule`. In async mode, the projection's own `executeSingleBatch()` now manages real per-batch transactions (since `isTransactionActive()` returns `false`). In synchronous mode (within CommandBus), the existing transaction is still detected and reused via `NoOpTransaction`.

- **Pause Collector during ProjectionFlush** — Added a static `pause()`/`resume()` mechanism to `CollectorStorage` and a new `CollectorPauseInterceptor` (around interceptor on `ProjectionFlush` pointcut). When a projection batch executes, collector is paused so messages sent during `flush()` go directly to the channel within the batch transaction, rather than being collected and released later.

- **Updated `MessageCollectorChannelInterceptor`** — `preSend()` now checks `CollectorStorage::isPaused()` and lets messages through when paused.

- **Tests** — Unit tests for `CollectorStorage` pause/resume mechanism, integration test verifying messages sent during projection flush bypass the collector.

### Flow: Async Projection with Collector (after fix)

```mermaid
sequenceDiagram
    participant AsyncConsumer
    participant ProjectingManager
    participant executeSingleBatch
    participant Flush
    participant Channel

    AsyncConsumer->>ProjectingManager: execute() [no global DbalTransaction]
    loop Per batch
        ProjectingManager->>executeSingleBatch: [ProjectionFlush pointcut]
        Note over executeSingleBatch: beginTransaction() → real DB transaction
        Note over executeSingleBatch: CollectorStorage::pause()
        executeSingleBatch->>Flush: flush()
        Flush->>Channel: send message (bypasses collector)
        Note over executeSingleBatch: commit transaction
        Note over executeSingleBatch: CollectorStorage::resume()
    end
```

## Pull Request Contribution Terms

- [x] I have read and agree to the contribution terms outlined in [CONTRIBUTING](https://github.com/ecotoneframework/ecotone-dev/blob/main/CONTRIBUTING.md).