### PR TITLE
Improve type hints of MultiTenantConfiguration tenantToConnectionMapping

### DIFF
--- a/packages/Dbal/src/MultiTenant/MultiTenantConfiguration.php
+++ b/packages/Dbal/src/MultiTenant/MultiTenantConfiguration.php
@@ -25,7 +25,7 @@ final class MultiTenantConfiguration
     }
 
     /**
-     * @param array<string, string> $tenantToConnectionMapping
+     * @param array<string, string|ConnectionReference> $tenantToConnectionMapping
      */
     public static function create(string $tenantHeaderName, array $tenantToConnectionMapping, string $referenceName = DbalConnectionFactory::class): self
     {
@@ -33,7 +33,7 @@ final class MultiTenantConfiguration
     }
 
     /**
-     * @param array<string, string> $tenantToConnectionMapping
+     * @param array<string, string|ConnectionReference> $tenantToConnectionMapping
      */
     public static function createWithDefaultConnection(string $tenantHeaderName, array $tenantToConnectionMapping, string|ConnectionReference $defaultConnectionName, string $referenceName = DbalConnectionFactory::class): self
     {


### PR DESCRIPTION
## Why is this change proposed?

`\Ecotone\Dbal\MultiTenant\MultiTenantConfiguration::__construct(tenantToConnectionMapping)` accepts
array<string, string|ConnectionReference>, the create methods should to.

## Description of Changes

Adds ConnectionReference to allowed typed in tenantToConnectionMapping array

## Pull Request Contribution Terms

- [X] I have read and agree to the contribution terms outlined in [CONTRIBUTING](https://github.com/ecotoneframework/ecotone-dev/blob/main/CONTRIBUTING.md).