### PR TITLE
feat: open-source global ProjectionV2 with sync/async event-driven execution

### DIFF
--- a/.claude/skills/ecotone-event-sourcing/references/testing-patterns.md
+++ b/.claude/skills/ecotone-event-sourcing/references/testing-patterns.md
@@ -112,10 +112,25 @@ Key points:
 
 ```php
 $ecotone->initializeProjection('name');  // Setup
-$ecotone->triggerProjection('name');     // Process events
+$ecotone->triggerProjection('name');     // Process events (backfill -- emits events)
 $ecotone->resetProjection('name');       // Clear + reinit
 $ecotone->deleteProjection('name');      // Cleanup
 ```
+
+### Rebuild vs Backfill
+
+`triggerProjection()` calls `prepareBackfill()` for V2 projections (`shouldReset: false`) -- events ARE emitted via `EventStreamEmitter` during replay. This matches the `ecotone:projection:backfill` console command.
+
+To test rebuild behavior (emissions suppressed), access `ProjectionRegistry` directly:
+
+```php
+use Ecotone\Projecting\ProjectionRegistry;
+
+// Rebuild: replays events but suppresses EventStreamEmitter emissions
+$ecotone->getGateway(ProjectionRegistry::class)->get('projection_name')->prepareRebuild();
+```
+
+This matches the `ecotone:projection:rebuild` console command behavior.
 
 ## Testing Versioned Events with Upcasters
 

--- a/.claude/skills/ecotone-event-sourcing/references/usage-examples.md
+++ b/.claude/skills/ecotone-event-sourcing/references/usage-examples.md
@@ -197,6 +197,12 @@ class NotificationProjection
 }
 ```
 
+**Emit suppression during rebuild:** When a projection is rebuilt via `prepareRebuild()` (console command `ecotone:projection:rebuild`), emitted events via `EventStreamEmitter` are automatically suppressed. The projection state is replayed from events, but `linkTo()` and `emit()` calls do not publish to downstream streams. This prevents duplicate events in linked streams during rebuild.
+
+**Backfill does emit:** In contrast, `triggerProjection()` / `prepareBackfill()` does NOT suppress emissions -- events are emitted normally during backfill. Use rebuild when you want to replay without side effects.
+
+**Blue/green deployment:** Use `#[ProjectionDeployment(live: false)]` to suppress emissions during normal running (not just rebuild). This is for blue/green scenarios where a new projection version is catching up in the background.
+
 ### Configuration Attributes
 
 ```php

--- a/packages/Ecotone/src/EventSourcing/Attribute/FromAggregateStream.php
+++ b/packages/Ecotone/src/EventSourcing/Attribute/FromAggregateStream.php
@@ -21,7 +21,7 @@ use Ecotone\EventSourcing\EventStore;
  * class OrderListProjection { ... }
  * ```
  */
-#[Attribute(Attribute::TARGET_CLASS | Attribute::IS_REPEATABLE)]
+#[Attribute(Attribute::TARGET_CLASS | Attribute::TARGET_METHOD | Attribute::IS_REPEATABLE)]
 readonly class FromAggregateStream
 {
     /**

--- a/packages/Ecotone/src/EventSourcing/Attribute/ProjectionState.php
+++ b/packages/Ecotone/src/EventSourcing/Attribute/ProjectionState.php
@@ -3,8 +3,8 @@
 namespace Ecotone\EventSourcing\Attribute;
 
 use Attribute;
-use Ecotone\EventSourcing\Config\InboundChannelAdapter\ProjectionEventHandler;
 use Ecotone\Messaging\Attribute\Parameter\Header;
+use Ecotone\Projecting\ProjectingHeaders;
 
 #[Attribute(Attribute::TARGET_PARAMETER)]
 /**
@@ -14,6 +14,6 @@ final class ProjectionState extends Header
 {
     public function __construct()
     {
-        parent::__construct(ProjectionEventHandler::PROJECTION_STATE);
+        parent::__construct(ProjectingHeaders::PROJECTION_STATE);
     }
 }

--- a/packages/Ecotone/src/Projecting/Attribute/ProjectionBackfill.php
+++ b/packages/Ecotone/src/Projecting/Attribute/ProjectionBackfill.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * licence Enterprise
+ * licence Apache-2.0
  */
 declare(strict_types=1);
 

--- a/packages/Ecotone/src/Projecting/Attribute/ProjectionExecution.php
+++ b/packages/Ecotone/src/Projecting/Attribute/ProjectionExecution.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * licence Enterprise
+ * licence Apache-2.0
  */
 declare(strict_types=1);
 

--- a/packages/Ecotone/src/Projecting/Attribute/ProjectionFlush.php
+++ b/packages/Ecotone/src/Projecting/Attribute/ProjectionFlush.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * licence Enterprise
+ * licence Apache-2.0
  */
 declare(strict_types=1);
 

--- a/packages/Ecotone/src/Projecting/Attribute/ProjectionV2.php
+++ b/packages/Ecotone/src/Projecting/Attribute/ProjectionV2.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * licence Enterprise
+ * licence Apache-2.0
  */
 declare(strict_types=1);
 

--- a/packages/Ecotone/src/Projecting/Config/EcotoneProjectionExecutorBuilder.php
+++ b/packages/Ecotone/src/Projecting/Config/EcotoneProjectionExecutorBuilder.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * licence Enterprise
+ * licence Apache-2.0
  */
 declare(strict_types=1);
 

--- a/packages/Ecotone/src/Projecting/Config/EcotoneProjectionExecutorBuilder.php
+++ b/packages/Ecotone/src/Projecting/Config/EcotoneProjectionExecutorBuilder.php
@@ -13,6 +13,7 @@ use Ecotone\Messaging\Config\ConfigurationException;
 use Ecotone\Messaging\Config\Container\Definition;
 use Ecotone\Messaging\Config\Container\MessagingContainerBuilder;
 use Ecotone\Messaging\Config\Container\Reference;
+use Ecotone\Messaging\Config\LicenceDecider;
 use Ecotone\Messaging\Gateway\MessagingEntrypointService;
 use Ecotone\Messaging\Handler\ChannelResolver;
 use Ecotone\Messaging\Handler\Router\RouterProcessor;
@@ -168,6 +169,7 @@ class EcotoneProjectionExecutorBuilder implements ProjectionExecutorBuilder
             new Reference(MessageHeadersPropagatorInterceptor::class),
             $this->projectionName,
             $routerProcessor,
+            Reference::to(LicenceDecider::class),
             $this->initChannel,
             $this->deleteChannel,
             $this->flushChannel,

--- a/packages/Ecotone/src/Projecting/Config/EcotoneProjectionExecutorBuilder.php
+++ b/packages/Ecotone/src/Projecting/Config/EcotoneProjectionExecutorBuilder.php
@@ -51,6 +51,8 @@ class EcotoneProjectionExecutorBuilder implements ProjectionExecutorBuilder
         private ?string $resetChannel = null,
         private ?int    $rebuildPartitionBatchSize = null,
         private ?string $rebuildAsyncChannelName = null,
+        private bool    $hasRebuild = false,
+        private bool    $hasDeployment = false,
     ) {
         if ($this->partitionHeader && ! $this->automaticInitialization) {
             throw new ConfigurationException("Cannot set partition header for projection {$this->projectionName} with automatic initialization disabled");
@@ -148,6 +150,14 @@ class EcotoneProjectionExecutorBuilder implements ProjectionExecutorBuilder
     public function rebuildAsyncChannelName(): ?string
     {
         return $this->rebuildAsyncChannelName;
+    }
+
+    public function isOpenSourceEligible(): bool
+    {
+        return ! $this->isPartitioned()
+            && $this->backfillAsyncChannelName === null
+            && ! $this->hasRebuild
+            && ! $this->hasDeployment;
     }
 
     public function compile(MessagingContainerBuilder $builder): Definition|Reference

--- a/packages/Ecotone/src/Projecting/Config/PartitionProviderRegistryModule.php
+++ b/packages/Ecotone/src/Projecting/Config/PartitionProviderRegistryModule.php
@@ -19,6 +19,7 @@ use Ecotone\Messaging\Config\Container\Reference;
 use Ecotone\Messaging\Config\ModulePackageList;
 use Ecotone\Messaging\Config\ModuleReferenceSearchService;
 use Ecotone\Messaging\Handler\InterfaceToCallRegistry;
+use Ecotone\Messaging\Support\LicensingException;
 use Ecotone\Projecting\Attribute\PartitionProvider as PartitionProviderAttribute;
 use Ecotone\Projecting\Attribute\ProjectionV2;
 use Ecotone\Projecting\PartitionProviderReference;
@@ -56,6 +57,10 @@ class PartitionProviderRegistryModule extends NoExternalConfigurationModule impl
 
     public function prepare(Configuration $messagingConfiguration, array $extensionObjects, ModuleReferenceSearchService $moduleReferenceSearchService, InterfaceToCallRegistry $interfaceToCallRegistry): void
     {
+        if (! empty($this->userlandPartitionProviderReferences) && ! $messagingConfiguration->isRunningForEnterpriseLicence()) {
+            throw LicensingException::create('Custom #[PartitionProvider] implementations require Ecotone Enterprise licence.');
+        }
+
         $partitionProviderReferences = ExtensionObjectResolver::resolve(
             PartitionProviderReference::class,
             $extensionObjects

--- a/packages/Ecotone/src/Projecting/Config/PartitionProviderRegistryModule.php
+++ b/packages/Ecotone/src/Projecting/Config/PartitionProviderRegistryModule.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * licence Enterprise
+ * licence Apache-2.0
  */
 declare(strict_types=1);
 

--- a/packages/Ecotone/src/Projecting/Config/ProjectingAttributeModule.php
+++ b/packages/Ecotone/src/Projecting/Config/ProjectingAttributeModule.php
@@ -15,6 +15,7 @@ use Ecotone\EventSourcing\Attribute\ProjectionInitialization;
 use Ecotone\EventSourcing\Attribute\ProjectionReset;
 use Ecotone\Messaging\Attribute\Asynchronous;
 use Ecotone\Messaging\Attribute\ModuleAnnotation;
+use Ecotone\Messaging\Attribute\Parameter\Header;
 use Ecotone\Messaging\Config\Annotation\AnnotatedDefinitionReference;
 use Ecotone\Messaging\Config\Annotation\AnnotationModule;
 use Ecotone\Messaging\Config\Configuration;
@@ -35,6 +36,7 @@ use Ecotone\Messaging\Support\LicensingException;
 use Ecotone\Modelling\Attribute\EventHandler;
 use Ecotone\Modelling\Attribute\NamedEvent;
 use Ecotone\Projecting\Attribute\Partitioned;
+use Ecotone\Projecting\ProjectingHeaders;
 use Ecotone\Projecting\Attribute\Polling;
 use Ecotone\Projecting\Attribute\ProjectionBackfill;
 use Ecotone\Projecting\Attribute\ProjectionDeployment;
@@ -46,6 +48,7 @@ use Ecotone\Projecting\Attribute\Streaming;
 use Ecotone\Projecting\EventStoreAdapter\PollingProjectionChannelAdapter;
 use Ecotone\Projecting\EventStoreAdapter\StreamingProjectionMessageHandler;
 use LogicException;
+use ReflectionMethod;
 
 /**
  * This module register projection based on attributes
@@ -63,7 +66,8 @@ class ProjectingAttributeModule implements AnnotationModule
         private array $projectionBuilders = [],
         private array $lifecycleHandlers = [],
         private array $pollingProjections = [],
-        private array $eventStreamingProjections = []
+        private array $eventStreamingProjections = [],
+        private bool $hasFlushWithProjectionState = false,
     ) {
     }
 
@@ -151,6 +155,7 @@ class ProjectingAttributeModule implements AnnotationModule
             $annotationRegistrationService->findCombined(ProjectionV2::class, ProjectionFlush::class),
             $annotationRegistrationService->findCombined(ProjectionV2::class, ProjectionReset::class),
         );
+        $hasFlushWithProjectionState = false;
         foreach ($lifecycleAnnotations as $lifecycleAnnotation) {
             /** @var ProjectionV2 $projectionAttribute */
             $projectionAttribute = $lifecycleAnnotation->getAnnotationForClass();
@@ -163,6 +168,9 @@ class ProjectingAttributeModule implements AnnotationModule
                 $projectionBuilder->setDeleteChannel($inputChannel);
             } elseif ($lifecycleAnnotation->getAnnotationForMethod() instanceof ProjectionFlush) {
                 $projectionBuilder->setFlushChannel($inputChannel);
+                if (self::flushMethodUsesProjectionState($lifecycleAnnotation->getClassName(), $lifecycleAnnotation->getMethodName())) {
+                    $hasFlushWithProjectionState = true;
+                }
             } elseif ($lifecycleAnnotation->getAnnotationForMethod() instanceof ProjectionReset) {
                 $projectionBuilder->setResetChannel($inputChannel);
             }
@@ -178,7 +186,7 @@ class ProjectingAttributeModule implements AnnotationModule
                 ->withInputChannelName($inputChannel);
         }
 
-        return new self(array_values($projectionBuilders), $lifecycleHandlers, $pollingProjections, $eventStreamingProjections);
+        return new self(array_values($projectionBuilders), $lifecycleHandlers, $pollingProjections, $eventStreamingProjections, $hasFlushWithProjectionState);
     }
 
     public function prepare(Configuration $messagingConfiguration, array $extensionObjects, ModuleReferenceSearchService $moduleReferenceSearchService, InterfaceToCallRegistry $interfaceToCallRegistry): void
@@ -189,6 +197,9 @@ class ProjectingAttributeModule implements AnnotationModule
             }
             if (! empty($this->eventStreamingProjections)) {
                 throw LicensingException::create('#[Streaming] projections require Ecotone Enterprise licence.');
+            }
+            if ($this->hasFlushWithProjectionState) {
+                throw LicensingException::create('Using #[ProjectionState] in #[ProjectionFlush] methods requires Ecotone Enterprise licence.');
             }
         }
 
@@ -308,6 +319,19 @@ class ProjectingAttributeModule implements AnnotationModule
                 'Partitioned projections cannot use streaming.'
             );
         }
+    }
+
+    private static function flushMethodUsesProjectionState(string $className, string $methodName): bool
+    {
+        $reflectionMethod = new ReflectionMethod($className, $methodName);
+        foreach ($reflectionMethod->getParameters() as $parameter) {
+            foreach ($parameter->getAttributes(Header::class, \ReflectionAttribute::IS_INSTANCEOF) as $attribute) {
+                if ($attribute->newInstance()->getHeaderName() === ProjectingHeaders::PROJECTION_STATE) {
+                    return true;
+                }
+            }
+        }
+        return false;
     }
 
     private static function resolveAutomaticInitialization(

--- a/packages/Ecotone/src/Projecting/Config/ProjectingAttributeModule.php
+++ b/packages/Ecotone/src/Projecting/Config/ProjectingAttributeModule.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * licence Enterprise
+ * licence Apache-2.0
  */
 declare(strict_types=1);
 

--- a/packages/Ecotone/src/Projecting/Config/ProjectingAttributeModule.php
+++ b/packages/Ecotone/src/Projecting/Config/ProjectingAttributeModule.php
@@ -31,6 +31,7 @@ use Ecotone\Messaging\Handler\Processor\MethodInvoker\MethodInvokerBuilder;
 use Ecotone\Messaging\Handler\ServiceActivator\MessageProcessorActivatorBuilder;
 use Ecotone\Messaging\Handler\ServiceActivator\ServiceActivatorBuilder;
 use Ecotone\Messaging\Support\Assert;
+use Ecotone\Messaging\Support\LicensingException;
 use Ecotone\Modelling\Attribute\EventHandler;
 use Ecotone\Modelling\Attribute\NamedEvent;
 use Ecotone\Projecting\Attribute\Partitioned;
@@ -105,6 +106,8 @@ class ProjectingAttributeModule implements AnnotationModule
                 partitioned: $partitionAttribute !== null,
                 rebuildPartitionBatchSize: $rebuildAttribute?->partitionBatchSize,
                 rebuildAsyncChannelName: $rebuildAttribute?->asyncChannelName,
+                hasRebuild: $rebuildAttribute !== null,
+                hasDeployment: $projectionDeployment !== null,
             );
 
             $asyncAttribute = self::getProjectionAsynchronousAttribute($annotationRegistrationService, $projectionClassName);
@@ -180,6 +183,15 @@ class ProjectingAttributeModule implements AnnotationModule
 
     public function prepare(Configuration $messagingConfiguration, array $extensionObjects, ModuleReferenceSearchService $moduleReferenceSearchService, InterfaceToCallRegistry $interfaceToCallRegistry): void
     {
+        if (! $messagingConfiguration->isRunningForEnterpriseLicence()) {
+            if (! empty($this->pollingProjections)) {
+                throw LicensingException::create('#[Polling] projections require Ecotone Enterprise licence.');
+            }
+            if (! empty($this->eventStreamingProjections)) {
+                throw LicensingException::create('#[Streaming] projections require Ecotone Enterprise licence.');
+            }
+        }
+
         foreach ($this->lifecycleHandlers as $lifecycleHandler) {
             $messagingConfiguration->registerMessageHandler($lifecycleHandler);
         }

--- a/packages/Ecotone/src/Projecting/Config/ProjectingConsoleCommands.php
+++ b/packages/Ecotone/src/Projecting/Config/ProjectingConsoleCommands.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * licence Enterprise
+ * licence Apache-2.0
  */
 declare(strict_types=1);
 

--- a/packages/Ecotone/src/Projecting/Config/ProjectingModule.php
+++ b/packages/Ecotone/src/Projecting/Config/ProjectingModule.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * licence Enterprise
+ * licence Apache-2.0
  */
 declare(strict_types=1);
 

--- a/packages/Ecotone/src/Projecting/Config/ProjectingModule.php
+++ b/packages/Ecotone/src/Projecting/Config/ProjectingModule.php
@@ -15,7 +15,6 @@ use Ecotone\Messaging\Attribute\Asynchronous;
 use Ecotone\Messaging\Attribute\WithoutDatabaseTransaction;
 use Ecotone\Messaging\Attribute\WithoutMessageCollector;
 use Ecotone\Messaging\Config\Configuration;
-use Ecotone\Messaging\Config\ConfigurationException;
 use Ecotone\Messaging\Config\Container\AttributeDefinition;
 use Ecotone\Messaging\Config\Container\Definition;
 use Ecotone\Messaging\Config\Container\InterfaceToCallReference;
@@ -23,6 +22,7 @@ use Ecotone\Messaging\Config\Container\Reference;
 use Ecotone\Messaging\Config\ModulePackageList;
 use Ecotone\Messaging\Config\ModuleReferenceSearchService;
 use Ecotone\Messaging\Config\ServiceConfiguration;
+use Ecotone\Messaging\Support\LicensingException;
 use Ecotone\Messaging\Endpoint\Interceptor\TerminationListener;
 use Ecotone\Messaging\Gateway\MessagingEntrypointService;
 use Ecotone\Messaging\Handler\InterfaceToCallRegistry;
@@ -67,7 +67,11 @@ class ProjectingModule implements AnnotationModule
         $projectionBuilders = ExtensionObjectResolver::resolve(ProjectionExecutorBuilder::class, $extensionObjects);
 
         if (! empty($projectionBuilders) && ! $messagingConfiguration->isRunningForEnterpriseLicence()) {
-            throw ConfigurationException::create('Projections are part of Ecotone Enterprise. To use projections, please acquire an enterprise licence.');
+            foreach ($projectionBuilders as $builder) {
+                if (! $builder instanceof EcotoneProjectionExecutorBuilder || ! $builder->isOpenSourceEligible()) {
+                    throw LicensingException::create('Projections with enterprise features (Partitioned, Streaming, Polling, ProjectionRebuild, ProjectionDeployment, async backfill) require Ecotone Enterprise licence.');
+                }
+            }
         }
 
         $messagingConfiguration->registerServiceDefinition(
@@ -122,10 +126,14 @@ class ProjectingModule implements AnnotationModule
 
             $asyncAttribute = $projectionBuilder instanceof EcotoneProjectionExecutorBuilder ? $projectionBuilder->getAsyncAttribute() : null;
             if ($asyncAttribute !== null) {
+                $endpointAnnotations = $asyncAttribute->getEndpointAnnotations();
+                if ($messagingConfiguration->isRunningForEnterpriseLicence()) {
+                    $endpointAnnotations = array_merge($endpointAnnotations, [new WithoutDatabaseTransaction(), new WithoutMessageCollector()]);
+                }
                 $handlerBuilder = $handlerBuilder->withEndpointAnnotations([
                     AttributeDefinition::fromObject(new Asynchronous(
                         $asyncAttribute->getChannelName(),
-                        array_merge($asyncAttribute->getEndpointAnnotations(), [new WithoutDatabaseTransaction(), new WithoutMessageCollector()]),
+                        $endpointAnnotations,
                     )),
                 ]);
             }

--- a/packages/Ecotone/src/Projecting/Config/ProjectingModuleRoutingExtension.php
+++ b/packages/Ecotone/src/Projecting/Config/ProjectingModuleRoutingExtension.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * licence Enterprise
+ * licence Apache-2.0
  */
 declare(strict_types=1);
 

--- a/packages/Ecotone/src/Projecting/Config/ProjectionExecutorBuilder.php
+++ b/packages/Ecotone/src/Projecting/Config/ProjectionExecutorBuilder.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * licence Enterprise
+ * licence Apache-2.0
  */
 declare(strict_types=1);
 

--- a/packages/Ecotone/src/Projecting/Config/ProjectionStateStorageRegistryModule.php
+++ b/packages/Ecotone/src/Projecting/Config/ProjectionStateStorageRegistryModule.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * licence Enterprise
+ * licence Apache-2.0
  */
 declare(strict_types=1);
 

--- a/packages/Ecotone/src/Projecting/Config/ProjectionStateStorageRegistryModule.php
+++ b/packages/Ecotone/src/Projecting/Config/ProjectionStateStorageRegistryModule.php
@@ -21,6 +21,7 @@ use Ecotone\Messaging\Config\Container\Reference;
 use Ecotone\Messaging\Config\ModulePackageList;
 use Ecotone\Messaging\Config\ModuleReferenceSearchService;
 use Ecotone\Messaging\Handler\InterfaceToCallRegistry;
+use Ecotone\Messaging\Support\LicensingException;
 use Ecotone\Projecting\Attribute\ProjectionV2;
 use Ecotone\Projecting\Attribute\StateStorage as StateStorageAttribute;
 use Ecotone\Projecting\InMemory\InMemoryProjectionStateStorage;
@@ -58,6 +59,10 @@ class ProjectionStateStorageRegistryModule extends NoExternalConfigurationModule
 
     public function prepare(Configuration $messagingConfiguration, array $extensionObjects, ModuleReferenceSearchService $moduleReferenceSearchService, InterfaceToCallRegistry $interfaceToCallRegistry): void
     {
+        if (! empty($this->userlandStateStorageReferences) && ! $messagingConfiguration->isRunningForEnterpriseLicence()) {
+            throw LicensingException::create('Custom #[StateStorage] implementations require Ecotone Enterprise licence.');
+        }
+
         $stateStorageReferences = ExtensionObjectResolver::resolve(
             ProjectionStateStorageReference::class,
             $extensionObjects

--- a/packages/Ecotone/src/Projecting/Config/StreamFilterRegistryModule.php
+++ b/packages/Ecotone/src/Projecting/Config/StreamFilterRegistryModule.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * licence Enterprise
+ * licence Apache-2.0
  */
 declare(strict_types=1);
 

--- a/packages/Ecotone/src/Projecting/Config/StreamFilterRegistryModule.php
+++ b/packages/Ecotone/src/Projecting/Config/StreamFilterRegistryModule.php
@@ -147,7 +147,7 @@ class StreamFilterRegistryModule implements AnnotationModule
         return $projectionEventNames;
     }
 
-    private static function resolveFromAggregateStream(
+    public static function resolveFromAggregateStream(
         AnnotationFinder $annotationFinder,
         FromAggregateStream $attribute,
         string $projectionName,

--- a/packages/Ecotone/src/Projecting/Config/StreamSourceRegistryModule.php
+++ b/packages/Ecotone/src/Projecting/Config/StreamSourceRegistryModule.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * licence Enterprise
+ * licence Apache-2.0
  */
 declare(strict_types=1);
 

--- a/packages/Ecotone/src/Projecting/Config/StreamSourceRegistryModule.php
+++ b/packages/Ecotone/src/Projecting/Config/StreamSourceRegistryModule.php
@@ -20,6 +20,7 @@ use Ecotone\Messaging\Config\Container\Reference;
 use Ecotone\Messaging\Config\ModulePackageList;
 use Ecotone\Messaging\Config\ModuleReferenceSearchService;
 use Ecotone\Messaging\Handler\InterfaceToCallRegistry;
+use Ecotone\Messaging\Support\LicensingException;
 use Ecotone\Projecting\Attribute\StreamSource as StreamSourceAttribute;
 use Ecotone\Projecting\StreamSource;
 use Ecotone\Projecting\StreamSourceReference;
@@ -48,6 +49,10 @@ class StreamSourceRegistryModule extends NoExternalConfigurationModule implement
 
     public function prepare(Configuration $messagingConfiguration, array $extensionObjects, ModuleReferenceSearchService $moduleReferenceSearchService, InterfaceToCallRegistry $interfaceToCallRegistry): void
     {
+        if (! empty($this->userlandStreamSourceReferences) && ! $messagingConfiguration->isRunningForEnterpriseLicence()) {
+            throw LicensingException::create('Custom #[StreamSource] implementations require Ecotone Enterprise licence.');
+        }
+
         $streamSourceReferences = ExtensionObjectResolver::resolve(
             StreamSourceReference::class,
             $extensionObjects

--- a/packages/Ecotone/src/Projecting/EcotoneProjectorExecutor.php
+++ b/packages/Ecotone/src/Projecting/EcotoneProjectorExecutor.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * licence Enterprise
+ * licence Apache-2.0
  */
 declare(strict_types=1);
 

--- a/packages/Ecotone/src/Projecting/EcotoneProjectorExecutor.php
+++ b/packages/Ecotone/src/Projecting/EcotoneProjectorExecutor.php
@@ -34,7 +34,7 @@ class EcotoneProjectorExecutor implements ProjectorExecutor
     ) {
     }
 
-    public function project(Event $event, mixed $userState = null): mixed
+    public function project(Event $event, mixed $userState = null, bool $isRebuilding = false): mixed
     {
         $metadata = $event->getMetadata();
         $metadata[ProjectingHeaders::PROJECTION_STATE] = $userState ?? null;
@@ -42,7 +42,7 @@ class EcotoneProjectorExecutor implements ProjectorExecutor
         if ($this->licenceDecider->hasEnterpriseLicence()) {
             $metadata[ProjectingHeaders::PROJECTION_NAME] = $this->projectionName;
         }
-        $metadata[ProjectingHeaders::PROJECTION_LIVE] = $this->isLive;
+        $metadata[ProjectingHeaders::PROJECTION_LIVE] = $this->isLive && !$isRebuilding;
         $metadata[MessageHeaders::STREAM_BASED_SOURCED] = true; // this one is required for correct header propagation in EventStreamEmitter...
         $metadata[MessageHeaders::REPLY_CHANNEL] = $responseQueue = new QueueChannel('response_channel');
 

--- a/packages/Ecotone/src/Projecting/EcotoneProjectorExecutor.php
+++ b/packages/Ecotone/src/Projecting/EcotoneProjectorExecutor.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 namespace Ecotone\Projecting;
 
 use Ecotone\Messaging\Channel\QueueChannel;
+use Ecotone\Messaging\Config\LicenceDecider;
 use Ecotone\Messaging\Gateway\MessagingEntrypointService;
 use Ecotone\Messaging\Handler\MessageProcessor;
 use Ecotone\Messaging\MessageHeaders;
@@ -22,8 +23,9 @@ class EcotoneProjectorExecutor implements ProjectorExecutor
     public function __construct(
         private MessagingEntrypointService $messagingEntrypoint,
         private MessageHeadersPropagatorInterceptor $messageHeadersPropagatorInterceptor,
-        private string $projectionName, // this is required for event stream emitter so it can create a stream with this name
+        private string $projectionName,
         private MessageProcessor $routerProcessor,
+        private LicenceDecider $licenceDecider,
         private ?string $initChannel = null,
         private ?string $deleteChannel = null,
         private ?string $flushChannel = null,
@@ -37,7 +39,9 @@ class EcotoneProjectorExecutor implements ProjectorExecutor
         $metadata = $event->getMetadata();
         $metadata[ProjectingHeaders::PROJECTION_STATE] = $userState ?? null;
         $metadata[ProjectingHeaders::PROJECTION_EVENT_NAME] = $event->getEventName();
-        $metadata[ProjectingHeaders::PROJECTION_NAME] = $this->projectionName;
+        if ($this->licenceDecider->hasEnterpriseLicence()) {
+            $metadata[ProjectingHeaders::PROJECTION_NAME] = $this->projectionName;
+        }
         $metadata[ProjectingHeaders::PROJECTION_LIVE] = $this->isLive;
         $metadata[MessageHeaders::STREAM_BASED_SOURCED] = true; // this one is required for correct header propagation in EventStreamEmitter...
         $metadata[MessageHeaders::REPLY_CHANNEL] = $responseQueue = new QueueChannel('response_channel');
@@ -65,37 +69,30 @@ class EcotoneProjectorExecutor implements ProjectorExecutor
     public function init(): void
     {
         if ($this->initChannel) {
-            $this->messagingEntrypoint->sendWithHeaders([], [
-                ProjectingHeaders::PROJECTION_NAME => $this->projectionName,
-            ], $this->initChannel);
+            $this->messagingEntrypoint->sendWithHeaders([], $this->withProjectionName([]), $this->initChannel);
         }
     }
 
     public function delete(): void
     {
         if ($this->deleteChannel) {
-            $this->messagingEntrypoint->sendWithHeaders([], [
-                ProjectingHeaders::PROJECTION_NAME => $this->projectionName,
-            ], $this->deleteChannel);
+            $this->messagingEntrypoint->sendWithHeaders([], $this->withProjectionName([]), $this->deleteChannel);
         }
     }
 
     public function flush(mixed $userState = null): void
     {
         if ($this->flushChannel) {
-            $this->messagingEntrypoint->sendWithHeaders([], [
-                ProjectingHeaders::PROJECTION_NAME => $this->projectionName,
+            $this->messagingEntrypoint->sendWithHeaders([], $this->withProjectionName([
                 ProjectingHeaders::PROJECTION_STATE => $userState,
-            ], $this->flushChannel);
+            ]), $this->flushChannel);
         }
     }
 
     public function reset(?string $partitionKey = null): void
     {
         if ($this->resetChannel) {
-            $headers = [
-                ProjectingHeaders::PROJECTION_NAME => $this->projectionName,
-            ];
+            $headers = $this->withProjectionName([]);
 
             if ($partitionKey !== null) {
                 $headers[ProjectingHeaders::REBUILD_PARTITION_KEY] = $partitionKey;
@@ -109,5 +106,13 @@ class EcotoneProjectorExecutor implements ProjectorExecutor
 
             $this->messagingEntrypoint->sendWithHeaders([], $headers, $this->resetChannel);
         }
+    }
+
+    private function withProjectionName(array $headers): array
+    {
+        if ($this->licenceDecider->hasEnterpriseLicence()) {
+            $headers[ProjectingHeaders::PROJECTION_NAME] = $this->projectionName;
+        }
+        return $headers;
     }
 }

--- a/packages/Ecotone/src/Projecting/EventStoreAdapter/EventStoreChannelAdapterProjection.php
+++ b/packages/Ecotone/src/Projecting/EventStoreAdapter/EventStoreChannelAdapterProjection.php
@@ -29,7 +29,7 @@ class EventStoreChannelAdapterProjection implements ProjectorExecutor
     ) {
     }
 
-    public function project(Event $event, mixed $userState = null): mixed
+    public function project(Event $event, mixed $userState = null, bool $isRebuilding = false): mixed
     {
         if (! empty($this->eventNames)) {
             $eventName = $event->getEventName();

--- a/packages/Ecotone/src/Projecting/InMemory/InMemoryProjectionRegistry.php
+++ b/packages/Ecotone/src/Projecting/InMemory/InMemoryProjectionRegistry.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * licence Enterprise
+ * licence Apache-2.0
  */
 declare(strict_types=1);
 

--- a/packages/Ecotone/src/Projecting/InMemory/InMemoryProjectionStateStorage.php
+++ b/packages/Ecotone/src/Projecting/InMemory/InMemoryProjectionStateStorage.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * licence Enterprise
+ * licence Apache-2.0
  */
 declare(strict_types=1);
 

--- a/packages/Ecotone/src/Projecting/InMemory/InMemoryProjector.php
+++ b/packages/Ecotone/src/Projecting/InMemory/InMemoryProjector.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * licence Enterprise
+ * licence Apache-2.0
  */
 declare(strict_types=1);
 

--- a/packages/Ecotone/src/Projecting/InMemory/InMemoryProjector.php
+++ b/packages/Ecotone/src/Projecting/InMemory/InMemoryProjector.php
@@ -15,7 +15,7 @@ class InMemoryProjector implements ProjectorExecutor, Countable
 {
     private array $projectedEvents = [];
 
-    public function project(Event $event, mixed $userState = null): mixed
+    public function project(Event $event, mixed $userState = null, bool $isRebuilding = false): mixed
     {
         $this->projectedEvents[] = $event;
         return $userState;

--- a/packages/Ecotone/src/Projecting/InMemory/InMemoryStreamSource.php
+++ b/packages/Ecotone/src/Projecting/InMemory/InMemoryStreamSource.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * licence Enterprise
+ * licence Apache-2.0
  */
 declare(strict_types=1);
 

--- a/packages/Ecotone/src/Projecting/NoOpTransaction.php
+++ b/packages/Ecotone/src/Projecting/NoOpTransaction.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * licence Enterprise
+ * licence Apache-2.0
  */
 declare(strict_types=1);
 

--- a/packages/Ecotone/src/Projecting/PartitionBatchExecutorHandler.php
+++ b/packages/Ecotone/src/Projecting/PartitionBatchExecutorHandler.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * licence Enterprise
+ * licence Apache-2.0
  */
 declare(strict_types=1);
 

--- a/packages/Ecotone/src/Projecting/PartitionProvider.php
+++ b/packages/Ecotone/src/Projecting/PartitionProvider.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * licence Enterprise
+ * licence Apache-2.0
  */
 declare(strict_types=1);
 

--- a/packages/Ecotone/src/Projecting/PartitionProviderReference.php
+++ b/packages/Ecotone/src/Projecting/PartitionProviderReference.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * licence Enterprise
+ * licence Apache-2.0
  */
 
 declare(strict_types=1);

--- a/packages/Ecotone/src/Projecting/PartitionProviderRegistry.php
+++ b/packages/Ecotone/src/Projecting/PartitionProviderRegistry.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * licence Enterprise
+ * licence Apache-2.0
  */
 declare(strict_types=1);
 

--- a/packages/Ecotone/src/Projecting/ProjectingHeaders.php
+++ b/packages/Ecotone/src/Projecting/ProjectingHeaders.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * licence Enterprise
+ * licence Apache-2.0
  */
 declare(strict_types=1);
 

--- a/packages/Ecotone/src/Projecting/ProjectingManager.php
+++ b/packages/Ecotone/src/Projecting/ProjectingManager.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * licence Enterprise
+ * licence Apache-2.0
  */
 declare(strict_types=1);
 

--- a/packages/Ecotone/src/Projecting/ProjectingManager.php
+++ b/packages/Ecotone/src/Projecting/ProjectingManager.php
@@ -98,7 +98,7 @@ class ProjectingManager
 
                 $batchProcessedEvents = 0;
                 foreach ($streamPage->events as $event) {
-                    $userState = $this->projectorExecutor->project($event, $userState);
+                    $userState = $this->projectorExecutor->project($event, $userState, $shouldReset);
                     $batchProcessedEvents++;
                 }
                 if ($batchProcessedEvents > 0) {

--- a/packages/Ecotone/src/Projecting/ProjectionInitializationStatus.php
+++ b/packages/Ecotone/src/Projecting/ProjectionInitializationStatus.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * licence Enterprise
+ * licence Apache-2.0
  */
 declare(strict_types=1);
 

--- a/packages/Ecotone/src/Projecting/ProjectionPartitionState.php
+++ b/packages/Ecotone/src/Projecting/ProjectionPartitionState.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * licence Enterprise
+ * licence Apache-2.0
  */
 declare(strict_types=1);
 

--- a/packages/Ecotone/src/Projecting/ProjectionRegistry.php
+++ b/packages/Ecotone/src/Projecting/ProjectionRegistry.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * licence Enterprise
+ * licence Apache-2.0
  */
 declare(strict_types=1);
 

--- a/packages/Ecotone/src/Projecting/ProjectionStateStorage.php
+++ b/packages/Ecotone/src/Projecting/ProjectionStateStorage.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * licence Enterprise
+ * licence Apache-2.0
  */
 declare(strict_types=1);
 

--- a/packages/Ecotone/src/Projecting/ProjectionStateStorageReference.php
+++ b/packages/Ecotone/src/Projecting/ProjectionStateStorageReference.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * licence Enterprise
+ * licence Apache-2.0
  */
 declare(strict_types=1);
 

--- a/packages/Ecotone/src/Projecting/ProjectionStateStorageRegistry.php
+++ b/packages/Ecotone/src/Projecting/ProjectionStateStorageRegistry.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * licence Enterprise
+ * licence Apache-2.0
  */
 declare(strict_types=1);
 

--- a/packages/Ecotone/src/Projecting/ProjectionV2StateHandler.php
+++ b/packages/Ecotone/src/Projecting/ProjectionV2StateHandler.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * licence Apache-2.0
+ */
+declare(strict_types=1);
+
+namespace Ecotone\Projecting;
+
+class ProjectionV2StateHandler
+{
+    public function __construct(private ProjectionRegistry $projectionRegistry)
+    {
+    }
+
+    public function getProjectionState(
+        string $projectionName,
+        ?string $aggregateId = null,
+        ?string $streamName = null,
+        ?string $aggregateType = null,
+    ): mixed {
+        $partitionKey = null;
+        if ($aggregateId !== null && $streamName !== null && $aggregateType !== null) {
+            $partitionKey = AggregatePartitionKey::compose($streamName, $aggregateType, $aggregateId);
+        }
+
+        $state = $this->projectionRegistry->get($projectionName)->loadState($partitionKey);
+
+        return $state?->userState ?? [];
+    }
+}

--- a/packages/Ecotone/src/Projecting/ProjectorExecutor.php
+++ b/packages/Ecotone/src/Projecting/ProjectorExecutor.php
@@ -15,7 +15,7 @@ interface ProjectorExecutor
      * @param mixed|null $userState
      * @return mixed the new user state
      */
-    public function project(Event $event, mixed $userState = null): mixed;
+    public function project(Event $event, mixed $userState = null, bool $isRebuilding = false): mixed;
     public function init(): void;
     public function delete(): void;
     public function flush(mixed $userState = null): void;

--- a/packages/Ecotone/src/Projecting/ProjectorExecutor.php
+++ b/packages/Ecotone/src/Projecting/ProjectorExecutor.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * licence Enterprise
+ * licence Apache-2.0
  */
 declare(strict_types=1);
 

--- a/packages/Ecotone/src/Projecting/SinglePartitionProvider.php
+++ b/packages/Ecotone/src/Projecting/SinglePartitionProvider.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * licence Enterprise
+ * licence Apache-2.0
  */
 declare(strict_types=1);
 

--- a/packages/Ecotone/src/Projecting/StreamFilter.php
+++ b/packages/Ecotone/src/Projecting/StreamFilter.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * licence Enterprise
+ * licence Apache-2.0
  */
 declare(strict_types=1);
 

--- a/packages/Ecotone/src/Projecting/StreamFilterRegistry.php
+++ b/packages/Ecotone/src/Projecting/StreamFilterRegistry.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * licence Enterprise
+ * licence Apache-2.0
  */
 declare(strict_types=1);
 

--- a/packages/Ecotone/src/Projecting/StreamPage.php
+++ b/packages/Ecotone/src/Projecting/StreamPage.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * licence Enterprise
+ * licence Apache-2.0
  */
 declare(strict_types=1);
 

--- a/packages/Ecotone/src/Projecting/StreamSource.php
+++ b/packages/Ecotone/src/Projecting/StreamSource.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * licence Enterprise
+ * licence Apache-2.0
  */
 declare(strict_types=1);
 

--- a/packages/Ecotone/src/Projecting/StreamSourceReference.php
+++ b/packages/Ecotone/src/Projecting/StreamSourceReference.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * licence Enterprise
+ * licence Apache-2.0
  */
 declare(strict_types=1);
 

--- a/packages/Ecotone/src/Projecting/StreamSourceRegistry.php
+++ b/packages/Ecotone/src/Projecting/StreamSourceRegistry.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * licence Enterprise
+ * licence Apache-2.0
  */
 declare(strict_types=1);
 

--- a/packages/Ecotone/src/Projecting/Transaction.php
+++ b/packages/Ecotone/src/Projecting/Transaction.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * licence Enterprise
+ * licence Apache-2.0
  */
 declare(strict_types=1);
 

--- a/packages/Ecotone/tests/Projecting/ProjectingTest.php
+++ b/packages/Ecotone/tests/Projecting/ProjectingTest.php
@@ -16,6 +16,7 @@ use Ecotone\Messaging\Attribute\Interceptor\Around;
 use Ecotone\Messaging\Channel\SimpleMessageChannelBuilder;
 use Ecotone\Messaging\Config\ConfigurationException;
 use Ecotone\Messaging\Config\ModulePackageList;
+use Ecotone\Messaging\Support\LicensingException;
 use Ecotone\Messaging\Config\ServiceConfiguration;
 use Ecotone\Messaging\Endpoint\ExecutionPollingMetadata;
 use Ecotone\Messaging\Endpoint\Interceptor\PcntlTerminationListener;
@@ -537,8 +538,7 @@ class ProjectingTest extends TestCase
 
     public function test_it_throws_exception_when_no_licence(): void
     {
-        $this->expectException(ConfigurationException::class);
-        $this->expectExceptionMessage('Projections are part of Ecotone Enterprise. To use projections, please acquire an enterprise licence.');
+        $this->expectException(LicensingException::class);
 
         $projection = new #[ProjectionV2('test'), FromStream('test_stream')] class {
             #[EventHandler('*')]

--- a/packages/Ecotone/tests/Projecting/ProjectionV2EnterpriseTest.php
+++ b/packages/Ecotone/tests/Projecting/ProjectionV2EnterpriseTest.php
@@ -4,10 +4,13 @@ declare(strict_types=1);
 
 namespace Test\Ecotone\Projecting;
 
+use Ecotone\Dbal\MultiTenant\MultiTenantConfiguration;
 use Ecotone\EventSourcing\Attribute\FromStream;
 use Ecotone\EventSourcing\Attribute\ProjectionDelete;
 use Ecotone\EventSourcing\Attribute\ProjectionInitialization;
 use Ecotone\EventSourcing\Attribute\ProjectionReset;
+use Ecotone\EventSourcing\Attribute\ProjectionState;
+use Ecotone\EventSourcing\EventSourcingConfiguration;
 use Ecotone\Lite\EcotoneLite;
 use Ecotone\Messaging\Attribute\Asynchronous;
 use Ecotone\Messaging\Channel\SimpleMessageChannelBuilder;
@@ -447,5 +450,62 @@ final class ProjectionV2EnterpriseTest extends TestCase
         } catch (MethodInvocationException $e) {
             self::assertStringContainsString('projection.name', $e->getMessage(), 'Exception should mention missing projection.name header. Got: ' . $e->getMessage());
         }
+    }
+
+    public function test_flush_with_projection_state_requires_licence(): void
+    {
+        $projection = new #[ProjectionV2('test'), FromStream('test_stream')] class {
+            #[EventHandler('*')]
+            public function handle(array $event): array
+            {
+                return $event;
+            }
+
+            #[ProjectionFlush]
+            public function flush(#[ProjectionState] array $state = []): void
+            {
+            }
+        };
+
+        $this->expectException(LicensingException::class);
+
+        EcotoneLite::bootstrapFlowTesting(
+            [$projection::class],
+            [$projection],
+            configuration: ServiceConfiguration::createWithDefaults()
+                ->withSkippedModulePackageNames(ModulePackageList::allPackages())
+        );
+    }
+
+    public function test_multi_tenant_connection_with_projection_requires_licence(): void
+    {
+        $projection = new #[ProjectionV2('test'), FromStream('test_stream')] class {
+            #[EventHandler('*')]
+            public function handle(array $event): void
+            {
+            }
+        };
+
+        $this->expectException(LicensingException::class);
+
+        EcotoneLite::bootstrapFlowTesting(
+            [$projection::class],
+            [$projection],
+            configuration: ServiceConfiguration::createWithDefaults()
+                ->withSkippedModulePackageNames(ModulePackageList::allPackagesExcept([
+                    ModulePackageList::EVENT_SOURCING_PACKAGE,
+                    ModulePackageList::DBAL_PACKAGE,
+                ]))
+                ->withExtensionObjects([
+                    EventSourcingConfiguration::createInMemory(),
+                    MultiTenantConfiguration::create(
+                        'tenant',
+                        [
+                            'tenant_a' => 'tenant_a_connection',
+                            'tenant_b' => 'tenant_b_connection',
+                        ]
+                    ),
+                ])
+        );
     }
 }

--- a/packages/Ecotone/tests/Projecting/ProjectionV2EnterpriseTest.php
+++ b/packages/Ecotone/tests/Projecting/ProjectionV2EnterpriseTest.php
@@ -1,0 +1,419 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Ecotone\Projecting;
+
+use Ecotone\EventSourcing\Attribute\FromStream;
+use Ecotone\EventSourcing\Attribute\ProjectionDelete;
+use Ecotone\EventSourcing\Attribute\ProjectionInitialization;
+use Ecotone\EventSourcing\Attribute\ProjectionReset;
+use Ecotone\Lite\EcotoneLite;
+use Ecotone\Messaging\Attribute\Asynchronous;
+use Ecotone\Messaging\Channel\SimpleMessageChannelBuilder;
+use Ecotone\Messaging\Config\ModulePackageList;
+use Ecotone\Messaging\Config\ServiceConfiguration;
+use Ecotone\Messaging\Support\LicensingException;
+use Ecotone\Modelling\Attribute\EventHandler;
+use Ecotone\Modelling\Event;
+use Ecotone\Projecting\Attribute\Partitioned;
+use Ecotone\Projecting\Attribute\Polling;
+use Ecotone\Projecting\Attribute\ProjectionBackfill;
+use Ecotone\Projecting\Attribute\ProjectionDeployment;
+use Ecotone\Projecting\Attribute\ProjectionExecution;
+use Ecotone\Projecting\Attribute\ProjectionFlush;
+use Ecotone\Projecting\Attribute\ProjectionRebuild;
+use Ecotone\Projecting\Attribute\ProjectionV2;
+use Ecotone\Projecting\Attribute\Streaming;
+use Ecotone\Projecting\Attribute;
+use Ecotone\Projecting\NoOpTransaction;
+use Ecotone\Projecting\PartitionProvider;
+use Ecotone\Projecting\ProjectionPartitionState;
+use Ecotone\Projecting\ProjectionStateStorage;
+use Ecotone\Projecting\StreamFilter;
+use Ecotone\Projecting\StreamPage;
+use Ecotone\Projecting\StreamSource;
+use Ecotone\Projecting\Transaction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @internal
+ */
+final class ProjectionV2EnterpriseTest extends TestCase
+{
+    public function test_global_sync_projection_works_without_licence(): void
+    {
+        $projection = new #[ProjectionV2('test'), FromStream('test_stream')] class {
+            public array $handledEvents = [];
+
+            #[EventHandler('*')]
+            public function handle(array $event): void
+            {
+                $this->handledEvents[] = $event;
+            }
+        };
+
+        $ecotone = EcotoneLite::bootstrapFlowTesting(
+            [$projection::class],
+            [$projection],
+            configuration: ServiceConfiguration::createWithDefaults()
+                ->withSkippedModulePackageNames(ModulePackageList::allPackages())
+        );
+
+        $ecotone->withEvents([Event::createWithType('test-event', ['name' => 'Test'])]);
+        $ecotone->publishEventWithRoutingKey('trigger', []);
+
+        $this->assertCount(1, $projection->handledEvents);
+    }
+
+    public function test_global_async_projection_works_without_licence(): void
+    {
+        $projection = new #[ProjectionV2('test'), FromStream('test_stream'), Asynchronous('async')] class {
+            public array $handledEvents = [];
+
+            #[EventHandler('*')]
+            public function handle(array $event): void
+            {
+                $this->handledEvents[] = $event;
+            }
+        };
+
+        $ecotone = EcotoneLite::bootstrapFlowTesting(
+            [$projection::class],
+            [$projection],
+            configuration: ServiceConfiguration::createWithDefaults()
+                ->withSkippedModulePackageNames(ModulePackageList::allPackagesExcept([ModulePackageList::ASYNCHRONOUS_PACKAGE]))
+                ->addExtensionObject(SimpleMessageChannelBuilder::createQueueChannel('async'))
+        );
+
+        $this->assertNotNull($ecotone);
+    }
+
+    public function test_sync_backfill_works_without_licence(): void
+    {
+        $projection = new #[ProjectionV2('test'), FromStream('test_stream'), ProjectionBackfill] class {
+            public array $handledEvents = [];
+
+            #[EventHandler('*')]
+            public function handle(array $event): void
+            {
+                $this->handledEvents[] = $event;
+            }
+        };
+
+        $ecotone = EcotoneLite::bootstrapFlowTesting(
+            [$projection::class],
+            [$projection],
+            configuration: ServiceConfiguration::createWithDefaults()
+                ->withSkippedModulePackageNames(ModulePackageList::allPackages())
+        );
+
+        $this->assertNotNull($ecotone);
+    }
+
+    public function test_lifecycle_hooks_work_without_licence(): void
+    {
+        $projection = new #[ProjectionV2('test'), FromStream('test_stream')] class {
+            public bool $initialized = false;
+            public bool $deleted = false;
+            public bool $reset = false;
+            public bool $flushed = false;
+            public array $handledEvents = [];
+
+            #[EventHandler('*')]
+            public function handle(array $event): void
+            {
+                $this->handledEvents[] = $event;
+            }
+
+            #[ProjectionInitialization]
+            public function init(): void
+            {
+                $this->initialized = true;
+            }
+
+            #[ProjectionDelete]
+            public function remove(): void
+            {
+                $this->deleted = true;
+            }
+
+            #[ProjectionReset]
+            public function resetState(): void
+            {
+                $this->reset = true;
+            }
+
+            #[ProjectionFlush]
+            public function flush(): void
+            {
+                $this->flushed = true;
+            }
+        };
+
+        $ecotone = EcotoneLite::bootstrapFlowTesting(
+            [$projection::class],
+            [$projection],
+            configuration: ServiceConfiguration::createWithDefaults()
+                ->withSkippedModulePackageNames(ModulePackageList::allPackages())
+        );
+
+        $this->assertNotNull($ecotone);
+    }
+
+    public function test_projection_execution_batch_size_works_without_licence(): void
+    {
+        $projection = new #[ProjectionV2('test'), FromStream('test_stream'), ProjectionExecution(eventLoadingBatchSize: 50)] class {
+            public array $handledEvents = [];
+
+            #[EventHandler('*')]
+            public function handle(array $event): void
+            {
+                $this->handledEvents[] = $event;
+            }
+        };
+
+        $ecotone = EcotoneLite::bootstrapFlowTesting(
+            [$projection::class],
+            [$projection],
+            configuration: ServiceConfiguration::createWithDefaults()
+                ->withSkippedModulePackageNames(ModulePackageList::allPackages())
+        );
+
+        $this->assertNotNull($ecotone);
+    }
+
+    public function test_partitioned_projection_requires_licence(): void
+    {
+        $projection = new #[ProjectionV2('test'), FromStream('test_stream'), Partitioned] class {
+            #[EventHandler('*')]
+            public function handle(array $event): void
+            {
+            }
+        };
+
+        $this->expectException(LicensingException::class);
+
+        EcotoneLite::bootstrapFlowTesting(
+            [$projection::class],
+            [$projection],
+            configuration: ServiceConfiguration::createWithDefaults()
+                ->withSkippedModulePackageNames(ModulePackageList::allPackages())
+        );
+    }
+
+    public function test_streaming_projection_requires_licence(): void
+    {
+        $projection = new #[ProjectionV2('test'), Streaming('streaming_channel')] class {
+            #[EventHandler('*')]
+            public function handle(array $event): void
+            {
+            }
+        };
+
+        $this->expectException(LicensingException::class);
+
+        EcotoneLite::bootstrapFlowTesting(
+            [$projection::class],
+            [$projection],
+            configuration: ServiceConfiguration::createWithDefaults()
+                ->withSkippedModulePackageNames(ModulePackageList::allPackagesExcept([ModulePackageList::ASYNCHRONOUS_PACKAGE]))
+        );
+    }
+
+    public function test_polling_projection_requires_licence(): void
+    {
+        $projection = new #[ProjectionV2('test'), FromStream('test_stream'), Polling('test_endpoint')] class {
+            #[EventHandler('*')]
+            public function handle(array $event): void
+            {
+            }
+        };
+
+        $this->expectException(LicensingException::class);
+
+        EcotoneLite::bootstrapFlowTesting(
+            [$projection::class],
+            [$projection],
+            configuration: ServiceConfiguration::createWithDefaults()
+                ->withSkippedModulePackageNames(ModulePackageList::allPackages())
+        );
+    }
+
+    public function test_async_backfill_requires_licence(): void
+    {
+        $projection = new #[ProjectionV2('test'), FromStream('test_stream'), ProjectionBackfill(asyncChannelName: 'backfill_channel')] class {
+            #[EventHandler('*')]
+            public function handle(array $event): void
+            {
+            }
+        };
+
+        $this->expectException(LicensingException::class);
+
+        EcotoneLite::bootstrapFlowTesting(
+            [$projection::class],
+            [$projection],
+            configuration: ServiceConfiguration::createWithDefaults()
+                ->withSkippedModulePackageNames(ModulePackageList::allPackages())
+        );
+    }
+
+    public function test_rebuild_requires_licence(): void
+    {
+        $projection = new #[ProjectionV2('test'), FromStream('test_stream'), ProjectionRebuild] class {
+            #[EventHandler('*')]
+            public function handle(array $event): void
+            {
+            }
+        };
+
+        $this->expectException(LicensingException::class);
+
+        EcotoneLite::bootstrapFlowTesting(
+            [$projection::class],
+            [$projection],
+            configuration: ServiceConfiguration::createWithDefaults()
+                ->withSkippedModulePackageNames(ModulePackageList::allPackages())
+        );
+    }
+
+    public function test_deployment_requires_licence(): void
+    {
+        $projection = new #[ProjectionV2('test'), FromStream('test_stream'), ProjectionDeployment(manualKickOff: true)] class {
+            #[EventHandler('*')]
+            public function handle(array $event): void
+            {
+            }
+        };
+
+        $this->expectException(LicensingException::class);
+
+        EcotoneLite::bootstrapFlowTesting(
+            [$projection::class],
+            [$projection],
+            configuration: ServiceConfiguration::createWithDefaults()
+                ->withSkippedModulePackageNames(ModulePackageList::allPackages())
+        );
+    }
+
+    public function test_custom_stream_source_requires_licence(): void
+    {
+        $projection = new #[ProjectionV2('test'), FromStream('test_stream')] class {
+            #[EventHandler('*')]
+            public function handle(array $event): void
+            {
+            }
+        };
+
+        $customStreamSource = new #[Attribute\StreamSource] class implements StreamSource {
+            public function canHandle(string $projectionName): bool
+            {
+                return true;
+            }
+
+            public function load(string $projectionName, ?string $lastPosition, int $count, ?string $partitionKey = null): StreamPage
+            {
+                return new StreamPage([], '0');
+            }
+        };
+
+        $this->expectException(LicensingException::class);
+
+        EcotoneLite::bootstrapFlowTesting(
+            [$projection::class, $customStreamSource::class],
+            [$projection, $customStreamSource],
+            configuration: ServiceConfiguration::createWithDefaults()
+                ->withSkippedModulePackageNames(ModulePackageList::allPackages())
+        );
+    }
+
+    public function test_custom_state_storage_requires_licence(): void
+    {
+        $projection = new #[ProjectionV2('test'), FromStream('test_stream')] class {
+            #[EventHandler('*')]
+            public function handle(array $event): void
+            {
+            }
+        };
+
+        $customStateStorage = new #[Attribute\StateStorage] class implements ProjectionStateStorage {
+            public function canHandle(string $projectionName): bool
+            {
+                return true;
+            }
+
+            public function loadPartition(string $projectionName, ?string $partitionKey = null, bool $lock = true): ?ProjectionPartitionState
+            {
+                return null;
+            }
+
+            public function initPartition(string $projectionName, ?string $partitionKey = null): ?ProjectionPartitionState
+            {
+                return null;
+            }
+
+            public function savePartition(ProjectionPartitionState $projectionState): void
+            {
+            }
+
+            public function delete(string $projectionName): void
+            {
+            }
+
+            public function init(string $projectionName): void
+            {
+            }
+
+            public function beginTransaction(): Transaction
+            {
+                return new NoOpTransaction();
+            }
+        };
+
+        $this->expectException(LicensingException::class);
+
+        EcotoneLite::bootstrapFlowTesting(
+            [$projection::class, $customStateStorage::class],
+            [$projection, $customStateStorage],
+            configuration: ServiceConfiguration::createWithDefaults()
+                ->withSkippedModulePackageNames(ModulePackageList::allPackages())
+        );
+    }
+
+    public function test_custom_partition_provider_requires_licence(): void
+    {
+        $projection = new #[ProjectionV2('test'), FromStream('test_stream')] class {
+            #[EventHandler('*')]
+            public function handle(array $event): void
+            {
+            }
+        };
+
+        $customPartitionProvider = new #[Attribute\PartitionProvider] class implements PartitionProvider {
+            public function canHandle(string $projectionName): bool
+            {
+                return true;
+            }
+
+            public function count(StreamFilter $filter): int
+            {
+                return 0;
+            }
+
+            public function partitions(StreamFilter $filter, ?int $limit = null, int $offset = 0): iterable
+            {
+                return [];
+            }
+        };
+
+        $this->expectException(LicensingException::class);
+
+        EcotoneLite::bootstrapFlowTesting(
+            [$projection::class, $customPartitionProvider::class],
+            [$projection, $customPartitionProvider],
+            configuration: ServiceConfiguration::createWithDefaults()
+                ->withSkippedModulePackageNames(ModulePackageList::allPackages())
+        );
+    }
+}

--- a/packages/Ecotone/tests/Projecting/ProjectionV2EnterpriseTest.php
+++ b/packages/Ecotone/tests/Projecting/ProjectionV2EnterpriseTest.php
@@ -441,8 +441,11 @@ final class ProjectionV2EnterpriseTest extends TestCase
 
         $ecotone->withEvents([Event::createWithType('test-event', ['name' => 'Test'], [MessageHeaders::EVENT_AGGREGATE_ID => '1'])]);
 
-        $this->expectException(MethodInvocationException::class);
-
-        $ecotone->publishEventWithRoutingKey('trigger', []);
+        try {
+            $ecotone->publishEventWithRoutingKey('trigger', []);
+            self::fail('Should have thrown exception');
+        } catch (MethodInvocationException $e) {
+            self::assertStringContainsString('projection.name', $e->getMessage(), 'Exception should mention missing projection.name header. Got: ' . $e->getMessage());
+        }
     }
 }

--- a/packages/Ecotone/tests/Projecting/ProjectionV2EnterpriseTest.php
+++ b/packages/Ecotone/tests/Projecting/ProjectionV2EnterpriseTest.php
@@ -4,13 +4,11 @@ declare(strict_types=1);
 
 namespace Test\Ecotone\Projecting;
 
-use Ecotone\Dbal\MultiTenant\MultiTenantConfiguration;
 use Ecotone\EventSourcing\Attribute\FromStream;
 use Ecotone\EventSourcing\Attribute\ProjectionDelete;
 use Ecotone\EventSourcing\Attribute\ProjectionInitialization;
 use Ecotone\EventSourcing\Attribute\ProjectionReset;
 use Ecotone\EventSourcing\Attribute\ProjectionState;
-use Ecotone\EventSourcing\EventSourcingConfiguration;
 use Ecotone\Lite\EcotoneLite;
 use Ecotone\Messaging\Attribute\Asynchronous;
 use Ecotone\Messaging\Channel\SimpleMessageChannelBuilder;
@@ -477,35 +475,4 @@ final class ProjectionV2EnterpriseTest extends TestCase
         );
     }
 
-    public function test_multi_tenant_connection_with_projection_requires_licence(): void
-    {
-        $projection = new #[ProjectionV2('test'), FromStream('test_stream')] class {
-            #[EventHandler('*')]
-            public function handle(array $event): void
-            {
-            }
-        };
-
-        $this->expectException(LicensingException::class);
-
-        EcotoneLite::bootstrapFlowTesting(
-            [$projection::class],
-            [$projection],
-            configuration: ServiceConfiguration::createWithDefaults()
-                ->withSkippedModulePackageNames(ModulePackageList::allPackagesExcept([
-                    ModulePackageList::EVENT_SOURCING_PACKAGE,
-                    ModulePackageList::DBAL_PACKAGE,
-                ]))
-                ->withExtensionObjects([
-                    EventSourcingConfiguration::createInMemory(),
-                    MultiTenantConfiguration::create(
-                        'tenant',
-                        [
-                            'tenant_a' => 'tenant_a_connection',
-                            'tenant_b' => 'tenant_b_connection',
-                        ]
-                    ),
-                ])
-        );
-    }
 }

--- a/packages/Ecotone/tests/Projecting/ProjectionV2EnterpriseTest.php
+++ b/packages/Ecotone/tests/Projecting/ProjectionV2EnterpriseTest.php
@@ -18,6 +18,7 @@ use Ecotone\Modelling\Attribute\EventHandler;
 use Ecotone\Modelling\Event;
 use Ecotone\Projecting\Attribute\Partitioned;
 use Ecotone\Projecting\Attribute\Polling;
+use Ecotone\Projecting\Attribute\ProjectionName;
 use Ecotone\Projecting\Attribute\ProjectionBackfill;
 use Ecotone\Projecting\Attribute\ProjectionDeployment;
 use Ecotone\Projecting\Attribute\ProjectionExecution;
@@ -34,6 +35,8 @@ use Ecotone\Projecting\StreamFilter;
 use Ecotone\Projecting\StreamPage;
 use Ecotone\Projecting\StreamSource;
 use Ecotone\Projecting\Transaction;
+use Ecotone\Messaging\Handler\MethodInvocationException;
+use Ecotone\Messaging\MessageHeaders;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -415,5 +418,31 @@ final class ProjectionV2EnterpriseTest extends TestCase
             configuration: ServiceConfiguration::createWithDefaults()
                 ->withSkippedModulePackageNames(ModulePackageList::allPackages())
         );
+    }
+
+    public function test_projection_name_header_is_not_available_without_licence(): void
+    {
+        $projection = new #[ProjectionV2('test'), FromStream('test_stream')] class {
+            public array $handledEvents = [];
+
+            #[EventHandler('*')]
+            public function handle(array $event, #[ProjectionName] string $projectionName): void
+            {
+                $this->handledEvents[] = ['event' => $event, 'projectionName' => $projectionName];
+            }
+        };
+
+        $ecotone = EcotoneLite::bootstrapFlowTesting(
+            [$projection::class],
+            [$projection],
+            configuration: ServiceConfiguration::createWithDefaults()
+                ->withSkippedModulePackageNames(ModulePackageList::allPackages())
+        );
+
+        $ecotone->withEvents([Event::createWithType('test-event', ['name' => 'Test'], [MessageHeaders::EVENT_AGGREGATE_ID => '1'])]);
+
+        $this->expectException(MethodInvocationException::class);
+
+        $ecotone->publishEventWithRoutingKey('trigger', []);
     }
 }

--- a/packages/PdoEventSourcing/src/Config/EventSourcingModule.php
+++ b/packages/PdoEventSourcing/src/Config/EventSourcingModule.php
@@ -80,6 +80,7 @@ use Ecotone\Modelling\Config\MessageBusChannel;
 use Ecotone\Modelling\Config\Routing\BusRouteSelector;
 use Ecotone\Modelling\Config\Routing\BusRoutingKeyResolver;
 use Ecotone\Modelling\Config\Routing\BusRoutingMapBuilder;
+use Ecotone\Projecting\Attribute\ProjectionV2;
 use Symfony\Component\Uid\Uuid;
 
 #[ModuleAnnotation]
@@ -123,10 +124,19 @@ class EventSourcingModule extends NoExternalConfigurationModule
             $aggregateTypeMapping[$aggregateWithCustomType] = $attribute->getName();
         }
 
+        $v2ProjectionNames = [];
+        foreach ($annotationRegistrationService->findAnnotatedClasses(ProjectionV2::class) as $className) {
+            $v2ProjectionNames[] = $annotationRegistrationService->getAttributeForClass($className, ProjectionV2::class)->name;
+        }
+
         $projectionStateGateways = [];
         foreach ($annotationRegistrationService->findAnnotatedMethods(ProjectionStateGateway::class) as $projectionStateGatewayConfiguration) {
             /** @var ProjectionStateGateway $attribute */
             $attribute = $projectionStateGatewayConfiguration->getAnnotationForMethod();
+
+            if (in_array($attribute->getProjectionName(), $v2ProjectionNames, true)) {
+                continue;
+            }
 
             $projectionStateGateways[] = GatewayProxyBuilder::create(
                 $projectionStateGatewayConfiguration->getClassName(),

--- a/packages/PdoEventSourcing/src/Config/ProophProjectingModule.php
+++ b/packages/PdoEventSourcing/src/Config/ProophProjectingModule.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * licence Enterprise
+ * licence Apache-2.0
  */
 declare(strict_types=1);
 

--- a/packages/PdoEventSourcing/src/Config/ProophProjectingModule.php
+++ b/packages/PdoEventSourcing/src/Config/ProophProjectingModule.php
@@ -10,6 +10,9 @@ namespace Ecotone\EventSourcing\Config;
 use Ecotone\AnnotationFinder\AnnotationFinder;
 use Ecotone\Dbal\Configuration\DbalConfiguration;
 use Ecotone\Dbal\Database\DbalTableManagerReference;
+use Ecotone\Dbal\MultiTenant\MultiTenantConfiguration;
+use Ecotone\EventSourcing\Attribute\FromAggregateStream;
+use Ecotone\EventSourcing\Attribute\ProjectionStateGateway;
 use Ecotone\EventSourcing\Database\ProjectionStateTableManager;
 use Ecotone\EventSourcing\EventSourcingConfiguration;
 use Ecotone\EventSourcing\PdoStreamTableNameProvider;
@@ -23,19 +26,28 @@ use Ecotone\Messaging\Config\Annotation\ModuleConfiguration\ExtensionObjectResol
 use Ecotone\Messaging\Config\Configuration;
 use Ecotone\Messaging\Config\ConfigurationException;
 use Ecotone\Messaging\Config\Container\Definition;
+use Ecotone\Messaging\Config\Container\InterfaceToCallReference;
 use Ecotone\Messaging\Config\Container\Reference;
 use Ecotone\Messaging\Config\ModulePackageList;
 use Ecotone\Messaging\Config\ModuleReferenceSearchService;
 use Ecotone\Messaging\Config\ServiceConfiguration;
+use Ecotone\Messaging\Handler\Gateway\GatewayProxyBuilder;
+use Ecotone\Messaging\Handler\Gateway\ParameterToMessageConverter\GatewayHeaderBuilder;
+use Ecotone\Messaging\Handler\Gateway\ParameterToMessageConverter\GatewayHeaderValueBuilder;
 use Ecotone\Messaging\Handler\InterfaceToCallRegistry;
+use Ecotone\Messaging\Handler\Processor\MethodInvoker\Converter\HeaderBuilder;
+use Ecotone\Messaging\Handler\ServiceActivator\ServiceActivatorBuilder;
 use Ecotone\Messaging\Scheduling\Duration;
 use Ecotone\Messaging\Scheduling\EcotoneClockInterface;
+use Ecotone\Messaging\Support\LicensingException;
 use Ecotone\Projecting\Attribute\Partitioned;
 use Ecotone\Projecting\Attribute\ProjectionV2;
 use Ecotone\Projecting\Config\StreamFilterRegistryModule;
 use Ecotone\Projecting\EventStoreAdapter\EventStreamingChannelAdapter;
 use Ecotone\Projecting\PartitionProviderReference;
+use Ecotone\Projecting\ProjectionRegistry;
 use Ecotone\Projecting\ProjectionStateStorageReference;
+use Ecotone\Projecting\ProjectionV2StateHandler;
 use Ecotone\Projecting\StreamFilter;
 use Ecotone\Projecting\StreamFilterRegistry;
 use Ecotone\Projecting\StreamSourceReference;
@@ -50,11 +62,13 @@ class ProophProjectingModule implements AnnotationModule
      * @param string[] $projectionNames
      * @param string[] $partitionedProjectionNames
      * @param string[] $globalStreamProjectionNames
+     * @param array<array{className: string, methodName: string, projectionName: string, partitionKeyParam: ?string}> $v2StateGateways
      */
     public function __construct(
         private array $projectionNames,
         private array $partitionedProjectionNames,
         private array $globalStreamProjectionNames,
+        private array $v2StateGateways = [],
     ) {
     }
 
@@ -70,11 +84,91 @@ class ProophProjectingModule implements AnnotationModule
             $projectionNames[] = $projectionAttribute->name;
         }
 
+        $v2StateGateways = [];
+        foreach ($annotationRegistrationService->findAnnotatedMethods(ProjectionStateGateway::class) as $gatewayAnnotation) {
+            /** @var ProjectionStateGateway $attribute */
+            $attribute = $gatewayAnnotation->getAnnotationForMethod();
+            if (! in_array($attribute->getProjectionName(), $projectionNames, true)) {
+                continue;
+            }
+
+            $interfaceToCall = $interfaceToCallRegistry->getFor(
+                $gatewayAnnotation->getClassName(),
+                $gatewayAnnotation->getMethodName()
+            );
+            $aggregateIdParam = null;
+            foreach ($interfaceToCall->getInterfaceParameters() as $parameter) {
+                $aggregateIdParam = $parameter->getName();
+                break;
+            }
+
+            $streamName = null;
+            $aggregateType = null;
+            if ($aggregateIdParam !== null) {
+                $streamFilter = self::resolveStreamFilterForGateway(
+                    $annotationRegistrationService,
+                    $gatewayAnnotation->getClassName(),
+                    $gatewayAnnotation->getMethodName(),
+                    $attribute->getProjectionName(),
+                    $allStreamFilters,
+                );
+                $streamName = $streamFilter->streamName;
+                $aggregateType = $streamFilter->aggregateType;
+            }
+
+            $v2StateGateways[] = [
+                'className' => $gatewayAnnotation->getClassName(),
+                'methodName' => $gatewayAnnotation->getMethodName(),
+                'projectionName' => $attribute->getProjectionName(),
+                'aggregateIdParam' => $aggregateIdParam,
+                'streamName' => $streamName,
+                'aggregateType' => $aggregateType,
+            ];
+        }
+
         return new self(
             $projectionNames,
             $partitionedProjectionNames,
             $globalStreamProjectionNames,
+            $v2StateGateways,
         );
+    }
+
+    /**
+     * @param array<string, StreamFilter[]> $allStreamFilters
+     */
+    private static function resolveStreamFilterForGateway(
+        AnnotationFinder $annotationFinder,
+        string $gatewayClassName,
+        string $gatewayMethodName,
+        string $projectionName,
+        array $allStreamFilters,
+    ): StreamFilter {
+        $methodAnnotations = $annotationFinder->getAnnotationsForMethod($gatewayClassName, $gatewayMethodName);
+        foreach ($methodAnnotations as $annotation) {
+            if ($annotation instanceof FromAggregateStream) {
+                return StreamFilterRegistryModule::resolveFromAggregateStream($annotationFinder, $annotation, $projectionName);
+            }
+        }
+
+        $streamFilters = $allStreamFilters[$projectionName] ?? [];
+        $partitionedFilters = array_filter($streamFilters, fn (StreamFilter $f) => $f->aggregateType !== null);
+
+        if (count($partitionedFilters) === 0) {
+            throw ConfigurationException::create(
+                "#[ProjectionStateGateway('{$projectionName}')] on {$gatewayClassName}::{$gatewayMethodName}() has a parameter for aggregate identifier, "
+                . "but projection '{$projectionName}' has no streams with aggregate type. Use #[FromStream] with aggregateType or #[FromAggregateStream] on the projection."
+            );
+        }
+
+        if (count($partitionedFilters) > 1) {
+            throw ConfigurationException::create(
+                "#[ProjectionStateGateway('{$projectionName}')] on {$gatewayClassName}::{$gatewayMethodName}() cannot resolve which stream to use for partition key "
+                . "because projection '{$projectionName}' has multiple streams. Add #[FromAggregateStream(AggregateClass::class)] on the gateway method to disambiguate."
+            );
+        }
+
+        return reset($partitionedFilters);
     }
 
     /**
@@ -128,6 +222,11 @@ class ProophProjectingModule implements AnnotationModule
     {
         $dbalConfiguration = ExtensionObjectResolver::resolveUnique(DbalConfiguration::class, $extensionObjects, DbalConfiguration::createWithDefaults());
         $eventSourcingConfiguration = ExtensionObjectResolver::resolveUnique(EventSourcingConfiguration::class, $extensionObjects, EventSourcingConfiguration::createWithDefaults());
+        $multiTenantConfigurations = ExtensionObjectResolver::resolve(MultiTenantConfiguration::class, $extensionObjects);
+
+        if (! empty($multiTenantConfigurations) && ! empty($this->projectionNames) && ! $messagingConfiguration->isRunningForEnterpriseLicence()) {
+            throw LicensingException::create('Using Multi-Tenant connection with ProjectionV2 requires Ecotone Enterprise licence.');
+        }
 
         foreach ($extensionObjects as $extensionObject) {
             if ($extensionObject instanceof EventStreamingChannelAdapter) {
@@ -161,6 +260,8 @@ class ProophProjectingModule implements AnnotationModule
             $this->registerAggregateStreamSource($messagingConfiguration);
             $this->registerDbalProjectionStateStorage($messagingConfiguration);
         }
+
+        $this->registerV2StateGateways($messagingConfiguration);
     }
 
     private function registerDbalProjectionStateStorage(Configuration $messagingConfiguration): void
@@ -215,11 +316,75 @@ class ProophProjectingModule implements AnnotationModule
         );
     }
 
+    private function registerV2StateGateways(Configuration $messagingConfiguration): void
+    {
+        if ($this->v2StateGateways === []) {
+            return;
+        }
+
+        $messagingConfiguration->registerServiceDefinition(
+            ProjectionV2StateHandler::class,
+            new Definition(ProjectionV2StateHandler::class, [
+                new Reference(ProjectionRegistry::class),
+            ])
+        );
+
+        $handlerChannel = 'projection_v2_get_state';
+
+        $messagingConfiguration->registerMessageHandler(
+            ServiceActivatorBuilder::create(
+                ProjectionV2StateHandler::class,
+                InterfaceToCallReference::create(ProjectionV2StateHandler::class, 'getProjectionState')
+            )
+            ->withMethodParameterConverters([
+                HeaderBuilder::create('projectionName', 'ecotone.projectionV2.state.projectionName'),
+                HeaderBuilder::createOptional('aggregateId', 'ecotone.projectionV2.state.aggregateId'),
+                HeaderBuilder::createOptional('streamName', 'ecotone.projectionV2.state.streamName'),
+                HeaderBuilder::createOptional('aggregateType', 'ecotone.projectionV2.state.aggregateType'),
+            ])
+            ->withInputChannelName($handlerChannel)
+        );
+
+        foreach ($this->v2StateGateways as $gateway) {
+            $parameterConverters = [
+                GatewayHeaderValueBuilder::create(
+                    'ecotone.projectionV2.state.projectionName',
+                    $gateway['projectionName']
+                ),
+            ];
+
+            if ($gateway['aggregateIdParam'] !== null) {
+                $parameterConverters[] = GatewayHeaderBuilder::create(
+                    $gateway['aggregateIdParam'],
+                    'ecotone.projectionV2.state.aggregateId'
+                );
+                $parameterConverters[] = GatewayHeaderValueBuilder::create(
+                    'ecotone.projectionV2.state.streamName',
+                    $gateway['streamName']
+                );
+                $parameterConverters[] = GatewayHeaderValueBuilder::create(
+                    'ecotone.projectionV2.state.aggregateType',
+                    $gateway['aggregateType']
+                );
+            }
+
+            $messagingConfiguration->registerGatewayBuilder(
+                GatewayProxyBuilder::create(
+                    $gateway['className'],
+                    $gateway['className'],
+                    $gateway['methodName'],
+                    $handlerChannel
+                )->withParameterConverters($parameterConverters)
+            );
+        }
+    }
+
     public function canHandle($extensionObject): bool
     {
         return $extensionObject instanceof DbalConfiguration
             || $extensionObject instanceof EventSourcingConfiguration
-            || $extensionObject instanceof EventStreamingChannelAdapter;
+            || $extensionObject instanceof EventStreamingChannelAdapter
+            || $extensionObject instanceof MultiTenantConfiguration;
     }
 
     public function getModuleExtensions(ServiceConfiguration $serviceConfiguration, array $serviceExtensions): array

--- a/packages/PdoEventSourcing/src/Database/ProjectionStateTableManager.php
+++ b/packages/PdoEventSourcing/src/Database/ProjectionStateTableManager.php
@@ -15,7 +15,7 @@ use function is_array;
 /**
  * Table manager for the ProjectionV2 state table.
  *
- * licence Enterprise
+ * licence Apache-2.0
  */
 final class ProjectionStateTableManager implements DbalTableManager
 {

--- a/packages/PdoEventSourcing/src/Projecting/PartitionState/DbalProjectionStateStorage.php
+++ b/packages/PdoEventSourcing/src/Projecting/PartitionState/DbalProjectionStateStorage.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * licence Enterprise
+ * licence Apache-2.0
  */
 declare(strict_types=1);
 

--- a/packages/PdoEventSourcing/src/Projecting/PartitionState/DbalTransaction.php
+++ b/packages/PdoEventSourcing/src/Projecting/PartitionState/DbalTransaction.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * licence Enterprise
+ * licence Apache-2.0
  */
 declare(strict_types=1);
 

--- a/packages/PdoEventSourcing/src/Projecting/StreamEvent.php
+++ b/packages/PdoEventSourcing/src/Projecting/StreamEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * licence Enterprise
+ * licence Apache-2.0
  */
 declare(strict_types=1);
 

--- a/packages/PdoEventSourcing/src/Projecting/StreamSource/EventStoreGlobalStreamSource.php
+++ b/packages/PdoEventSourcing/src/Projecting/StreamSource/EventStoreGlobalStreamSource.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * licence Enterprise
+ * licence Apache-2.0
  */
 declare(strict_types=1);
 

--- a/packages/PdoEventSourcing/src/Projecting/StreamSource/GapAwarePosition.php
+++ b/packages/PdoEventSourcing/src/Projecting/StreamSource/GapAwarePosition.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * licence Enterprise
+ * licence Apache-2.0
  */
 declare(strict_types=1);
 

--- a/packages/PdoEventSourcing/tests/Fixture/TicketProjectionState/CounterStateV2Gateway.php
+++ b/packages/PdoEventSourcing/tests/Fixture/TicketProjectionState/CounterStateV2Gateway.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Test\Ecotone\EventSourcing\Fixture\TicketProjectionState;
+
+use Ecotone\EventSourcing\Attribute\ProjectionStateGateway;
+
+interface CounterStateV2Gateway
+{
+    #[ProjectionStateGateway('ticket_counter')]
+    public function fetchState(): CounterState;
+}

--- a/packages/PdoEventSourcing/tests/Fixture/TicketProjectionState/PartitionedCounterStateGateway.php
+++ b/packages/PdoEventSourcing/tests/Fixture/TicketProjectionState/PartitionedCounterStateGateway.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Test\Ecotone\EventSourcing\Fixture\TicketProjectionState;
+
+use Ecotone\EventSourcing\Attribute\ProjectionStateGateway;
+
+interface PartitionedCounterStateGateway
+{
+    #[ProjectionStateGateway('ticket_counter_partitioned')]
+    public function fetchStateForPartition(string $aggregateId): CounterState;
+}

--- a/packages/PdoEventSourcing/tests/Fixture/TicketProjectionState/PartitionedCounterStateWithStreamGateway.php
+++ b/packages/PdoEventSourcing/tests/Fixture/TicketProjectionState/PartitionedCounterStateWithStreamGateway.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Test\Ecotone\EventSourcing\Fixture\TicketProjectionState;
+
+use Ecotone\EventSourcing\Attribute\FromAggregateStream;
+use Ecotone\EventSourcing\Attribute\ProjectionStateGateway;
+use Test\Ecotone\EventSourcing\Fixture\Ticket\Ticket;
+
+interface PartitionedCounterStateWithStreamGateway
+{
+    #[ProjectionStateGateway('ticket_counter_multi_stream')]
+    #[FromAggregateStream(Ticket::class)]
+    public function fetchStateForPartition(string $aggregateId): CounterState;
+}

--- a/packages/PdoEventSourcing/tests/Projecting/Global/EmittingEventsProjectionTest.php
+++ b/packages/PdoEventSourcing/tests/Projecting/Global/EmittingEventsProjectionTest.php
@@ -21,6 +21,7 @@ use Ecotone\Modelling\Attribute\EventHandler;
 use Ecotone\Modelling\Attribute\QueryHandler;
 use Ecotone\Projecting\Attribute\ProjectionDeployment;
 use Ecotone\Projecting\Attribute\ProjectionV2;
+use Ecotone\Projecting\ProjectionRegistry;
 use Ecotone\Test\LicenceTesting;
 use Enqueue\Dbal\DbalConnectionFactory;
 
@@ -197,6 +198,85 @@ final class EmittingEventsProjectionTest extends EventSourcingMessagingTestCase
             $eventStore->hasStream('notifications_stream_non_live'),
             'No events should have been emitted to the stream because projection is not live'
         );
+    }
+
+    public function test_rebuild_should_not_emit_events(): void
+    {
+        $projection = $this->createEmittingProjection();
+        $notificationService = new NotificationService();
+
+        $ecotone = EcotoneLite::bootstrapFlowTestingWithEventStore(
+            classesToResolve: [get_class($projection), NotificationService::class, TicketListUpdatedConverter::class, TicketListUpdated::class],
+            containerOrAvailableServices: [
+                $projection,
+                $notificationService,
+                new TicketEventConverter(),
+                new TicketListUpdatedConverter(),
+                DbalConnectionFactory::class => $this->getConnectionFactory(),
+            ],
+            configuration: ServiceConfiguration::createWithDefaults()
+                ->withSkippedModulePackageNames(ModulePackageList::allPackagesExcept([ModulePackageList::DBAL_PACKAGE, ModulePackageList::EVENT_SOURCING_PACKAGE, ModulePackageList::ASYNCHRONOUS_PACKAGE]))
+                ->withNamespaces([
+                    'Test\Ecotone\EventSourcing\Fixture\Ticket',
+                ]),
+            pathToRootCatalog: __DIR__ . '/../../',
+            runForProductionEventStore: true,
+            licenceKey: LicenceTesting::VALID_LICENCE,
+        );
+
+        $ecotone->sendCommand(new RegisterTicket('123', 'Johnny', 'alert'));
+
+        $eventStore = $ecotone->getGateway(EventStore::class);
+        self::assertCount(1, $eventStore->load('notifications_stream'), 'One event should have been emitted during live run');
+
+        $ecotone->resetProjection('emitting_projection');
+        self::assertEmpty($projection->getTickets(), 'Tickets should be empty before rebuild');
+        $notificationsCountBeforeRebuild = $eventStore->hasStream('notifications_stream') ? count($eventStore->load('notifications_stream')) : 0;
+
+        $ecotone->getGateway(ProjectionRegistry::class)->get('emitting_projection')->prepareRebuild();
+
+        self::assertNotEmpty($projection->getTickets(), 'Projection should have replayed events and rebuilt its state');
+        $notificationsCountAfterRebuild = $eventStore->hasStream('notifications_stream') ? count($eventStore->load('notifications_stream')) : 0;
+        self::assertSame($notificationsCountBeforeRebuild, $notificationsCountAfterRebuild, 'Rebuild should not have re-emitted events');
+    }
+
+    public function test_backfill_should_emit_events(): void
+    {
+        $projection = $this->createEmittingProjection();
+        $notificationService = new NotificationService();
+
+        $ecotone = EcotoneLite::bootstrapFlowTestingWithEventStore(
+            classesToResolve: [get_class($projection), NotificationService::class, TicketListUpdatedConverter::class, TicketListUpdated::class],
+            containerOrAvailableServices: [
+                $projection,
+                $notificationService,
+                new TicketEventConverter(),
+                new TicketListUpdatedConverter(),
+                DbalConnectionFactory::class => $this->getConnectionFactory(),
+            ],
+            configuration: ServiceConfiguration::createWithDefaults()
+                ->withSkippedModulePackageNames(ModulePackageList::allPackagesExcept([ModulePackageList::DBAL_PACKAGE, ModulePackageList::EVENT_SOURCING_PACKAGE, ModulePackageList::ASYNCHRONOUS_PACKAGE]))
+                ->withNamespaces([
+                    'Test\Ecotone\EventSourcing\Fixture\Ticket',
+                ]),
+            pathToRootCatalog: __DIR__ . '/../../',
+            runForProductionEventStore: true,
+            licenceKey: LicenceTesting::VALID_LICENCE,
+        );
+
+        $ecotone->sendCommand(new RegisterTicket('123', 'Johnny', 'alert'));
+
+        $eventStore = $ecotone->getGateway(EventStore::class);
+        self::assertCount(1, $eventStore->load('notifications_stream'), 'One event should have been emitted during live run');
+
+        $ecotone->resetProjection('emitting_projection');
+        self::assertEmpty($projection->getTickets(), 'Tickets should be empty before backfill');
+        self::assertFalse($eventStore->hasStream('notifications_stream'), 'Notifications stream should not exist after reset');
+
+        $ecotone->triggerProjection('emitting_projection');
+
+        self::assertNotEmpty($projection->getTickets(), 'Projection should have replayed events');
+        self::assertCount(1, $eventStore->load('notifications_stream'), 'Backfill should re-emit events to the stream');
     }
 
     private function createEmittingProjection(): object

--- a/packages/PdoEventSourcing/tests/Projecting/Global/MultiTenantProjectionTest.php
+++ b/packages/PdoEventSourcing/tests/Projecting/Global/MultiTenantProjectionTest.php
@@ -22,6 +22,7 @@ use Ecotone\Messaging\Config\ModulePackageList;
 use Ecotone\Messaging\Config\ServiceConfiguration;
 use Ecotone\Messaging\Endpoint\PollingMetadata;
 use Ecotone\Messaging\Support\InvalidArgumentException;
+use Ecotone\Messaging\Support\LicensingException;
 use Ecotone\Modelling\Attribute\EventHandler;
 use Ecotone\Modelling\Attribute\QueryHandler;
 use Ecotone\Projecting\Attribute\Polling;
@@ -239,6 +240,38 @@ final class MultiTenantProjectionTest extends ProjectingTestCase
 
         // Polling projection without tenant context should throw exception
         $ecotone->triggerProjection('polling_multi_tenant_projection');
+    }
+
+    public function test_multi_tenant_connection_with_projection_requires_licence(): void
+    {
+        $projection = new #[ProjectionV2('test'), FromStream('test_stream')] class {
+            #[EventHandler('*')]
+            public function handle(array $event): void
+            {
+            }
+        };
+
+        $this->expectException(LicensingException::class);
+
+        EcotoneLite::bootstrapFlowTesting(
+            [$projection::class],
+            [$projection],
+            configuration: ServiceConfiguration::createWithDefaults()
+                ->withSkippedModulePackageNames(ModulePackageList::allPackagesExcept([
+                    ModulePackageList::EVENT_SOURCING_PACKAGE,
+                    ModulePackageList::DBAL_PACKAGE,
+                ]))
+                ->withExtensionObjects([
+                    EventSourcingConfiguration::createInMemory(),
+                    MultiTenantConfiguration::create(
+                        'tenant',
+                        [
+                            'tenant_a' => 'tenant_a_connection',
+                            'tenant_b' => 'tenant_b_connection',
+                        ]
+                    ),
+                ])
+        );
     }
 
     private function createMultiTenantProjection(): object

--- a/packages/PdoEventSourcing/tests/Projecting/Global/ProjectionStateGatewayTest.php
+++ b/packages/PdoEventSourcing/tests/Projecting/Global/ProjectionStateGatewayTest.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Ecotone\EventSourcing\Projecting\Global;
+
+use Ecotone\EventSourcing\Attribute\FromStream;
+use Ecotone\EventSourcing\Attribute\ProjectionState;
+use Ecotone\Lite\EcotoneLite;
+use Ecotone\Lite\Test\FlowTestSupport;
+use Ecotone\Messaging\Config\ModulePackageList;
+use Ecotone\Messaging\Config\ServiceConfiguration;
+use Ecotone\Modelling\Attribute\EventHandler;
+use Ecotone\Modelling\Attribute\QueryHandler;
+use Ecotone\Projecting\Attribute\ProjectionV2;
+use Ecotone\Test\LicenceTesting;
+use Test\Ecotone\EventSourcing\Fixture\Ticket\Command\CloseTicket;
+use Test\Ecotone\EventSourcing\Fixture\Ticket\Command\RegisterTicket;
+use Test\Ecotone\EventSourcing\Fixture\Ticket\Event\TicketWasClosed;
+use Test\Ecotone\EventSourcing\Fixture\Ticket\Event\TicketWasRegistered;
+use Test\Ecotone\EventSourcing\Fixture\Ticket\Ticket;
+use Test\Ecotone\EventSourcing\Fixture\Ticket\TicketEventConverter;
+use Test\Ecotone\EventSourcing\Fixture\TicketProjectionState\CounterState;
+use Test\Ecotone\EventSourcing\Fixture\TicketProjectionState\CounterStateV2Gateway;
+use Test\Ecotone\EventSourcing\Fixture\TicketProjectionState\StateAndEventConverter;
+use Test\Ecotone\EventSourcing\Projecting\ProjectingTestCase;
+
+/**
+ * licence Enterprise
+ * @internal
+ */
+final class ProjectionStateGatewayTest extends ProjectingTestCase
+{
+    public function test_fetching_global_projection_state_via_gateway(): void
+    {
+        $projection = $this->createCounterProjection();
+
+        $ecotone = $this->bootstrapEcotone([$projection::class, CounterStateV2Gateway::class, StateAndEventConverter::class], [$projection, new StateAndEventConverter()]);
+
+        $ecotone->deleteProjection($projection::NAME)
+            ->initializeProjection($projection::NAME);
+
+        $ecotone->sendCommand(new RegisterTicket('123', 'Johnny', 'alert'));
+        $ecotone->sendCommand(new RegisterTicket('124', 'Johnny', 'alert'));
+        $ecotone->sendCommand(new CloseTicket('124'));
+
+        $gateway = $ecotone->getGateway(CounterStateV2Gateway::class);
+
+        self::assertEquals(
+            new CounterState(ticketCount: 2, closedTicketCount: 1),
+            $gateway->fetchState()
+        );
+    }
+
+    private function createCounterProjection(): object
+    {
+        return new #[ProjectionV2(self::NAME), FromStream(Ticket::class)] class () {
+            public const NAME = 'ticket_counter';
+
+            #[EventHandler]
+            public function onTicketRegistered(TicketWasRegistered $event, #[ProjectionState] array $state = []): array
+            {
+                $state['ticketCount'] = ($state['ticketCount'] ?? 0) + 1;
+                $state['closedTicketCount'] = $state['closedTicketCount'] ?? 0;
+                return $state;
+            }
+
+            #[EventHandler]
+            public function onTicketClosed(TicketWasClosed $event, #[ProjectionState] array $state = []): array
+            {
+                $state['closedTicketCount'] = ($state['closedTicketCount'] ?? 0) + 1;
+                return $state;
+            }
+
+            #[QueryHandler('ticket.getCurrentCount')]
+            public function getCurrentCount(#[ProjectionState] array $state = []): int
+            {
+                return $state['ticketCount'] ?? 0;
+            }
+        };
+    }
+
+    private function bootstrapEcotone(array $classesToResolve, array $services): FlowTestSupport
+    {
+        return EcotoneLite::bootstrapFlowTestingWithEventStore(
+            classesToResolve: array_merge($classesToResolve, [Ticket::class, TicketEventConverter::class]),
+            containerOrAvailableServices: array_merge($services, [new TicketEventConverter(), self::getConnectionFactory()]),
+            configuration: ServiceConfiguration::createWithDefaults()
+                ->withSkippedModulePackageNames(ModulePackageList::allPackagesExcept([
+                    ModulePackageList::DBAL_PACKAGE,
+                    ModulePackageList::EVENT_SOURCING_PACKAGE,
+                    ModulePackageList::ASYNCHRONOUS_PACKAGE,
+                ])),
+            runForProductionEventStore: true,
+            licenceKey: LicenceTesting::VALID_LICENCE,
+        );
+    }
+}

--- a/packages/PdoEventSourcing/tests/Projecting/Partitioned/ProjectionStateGatewayTest.php
+++ b/packages/PdoEventSourcing/tests/Projecting/Partitioned/ProjectionStateGatewayTest.php
@@ -1,0 +1,174 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Ecotone\EventSourcing\Projecting\Partitioned;
+
+use Ecotone\EventSourcing\Attribute\FromAggregateStream;
+use Ecotone\EventSourcing\Attribute\FromStream;
+use Ecotone\EventSourcing\Attribute\ProjectionState;
+use Ecotone\Lite\EcotoneLite;
+use Ecotone\Lite\Test\FlowTestSupport;
+use Ecotone\Messaging\Config\ConfigurationException;
+use Ecotone\Messaging\Config\ModulePackageList;
+use Ecotone\Messaging\Config\ServiceConfiguration;
+use Ecotone\Modelling\Attribute\EventHandler;
+use Ecotone\Projecting\Attribute\Partitioned;
+use Ecotone\Projecting\Attribute\ProjectionV2;
+use Ecotone\Test\LicenceTesting;
+use Test\Ecotone\EventSourcing\Fixture\Basket\Basket;
+use Test\Ecotone\EventSourcing\Fixture\Ticket\Command\CloseTicket;
+use Test\Ecotone\EventSourcing\Fixture\Ticket\Command\RegisterTicket;
+use Test\Ecotone\EventSourcing\Fixture\Ticket\Event\TicketWasClosed;
+use Test\Ecotone\EventSourcing\Fixture\Ticket\Event\TicketWasRegistered;
+use Test\Ecotone\EventSourcing\Fixture\Ticket\Ticket;
+use Test\Ecotone\EventSourcing\Fixture\Ticket\TicketEventConverter;
+use Test\Ecotone\EventSourcing\Fixture\TicketProjectionState\CounterState;
+use Test\Ecotone\EventSourcing\Fixture\TicketProjectionState\PartitionedCounterStateGateway;
+use Test\Ecotone\EventSourcing\Fixture\TicketProjectionState\PartitionedCounterStateWithStreamGateway;
+use Test\Ecotone\EventSourcing\Fixture\TicketProjectionState\StateAndEventConverter;
+use Test\Ecotone\EventSourcing\Projecting\ProjectingTestCase;
+
+/**
+ * licence Enterprise
+ * @internal
+ */
+final class ProjectionStateGatewayTest extends ProjectingTestCase
+{
+    public function test_fetching_partitioned_projection_state_via_gateway_with_aggregate_id(): void
+    {
+        $projection = $this->createCounterProjection();
+
+        $ecotone = $this->bootstrapEcotone(
+            [$projection::class, PartitionedCounterStateGateway::class, StateAndEventConverter::class],
+            [$projection, new StateAndEventConverter()]
+        );
+
+        $ecotone->initializeProjection($projection::NAME);
+        $ecotone->deleteProjection($projection::NAME);
+
+        $ecotone->sendCommand(new RegisterTicket('ticket-1', 'Johnny', 'alert'));
+        $ecotone->sendCommand(new RegisterTicket('ticket-2', 'Marcus', 'info'));
+        $ecotone->sendCommand(new CloseTicket('ticket-1'));
+
+        $gateway = $ecotone->getGateway(PartitionedCounterStateGateway::class);
+
+        self::assertEquals(
+            new CounterState(ticketCount: 1, closedTicketCount: 1),
+            $gateway->fetchStateForPartition('ticket-1')
+        );
+        self::assertEquals(
+            new CounterState(ticketCount: 1, closedTicketCount: 0),
+            $gateway->fetchStateForPartition('ticket-2')
+        );
+    }
+
+    public function test_multiple_streams_without_from_aggregate_stream_on_gateway_throws_exception(): void
+    {
+        $projection = new #[
+            ProjectionV2('ticket_counter_partitioned'),
+            Partitioned,
+            FromStream(stream: Ticket::class, aggregateType: Ticket::class),
+            FromStream(stream: Basket::class, aggregateType: Basket::class),
+        ] class () {
+            public const NAME = 'ticket_counter_partitioned';
+
+            #[EventHandler]
+            public function onTicketRegistered(TicketWasRegistered $event, #[ProjectionState] array $state = []): array
+            {
+                return $state;
+            }
+        };
+
+        $this->expectException(ConfigurationException::class);
+        $this->expectExceptionMessage('multiple streams');
+
+        $this->bootstrapEcotone(
+            [$projection::class, PartitionedCounterStateGateway::class, StateAndEventConverter::class],
+            [$projection, new StateAndEventConverter()]
+        );
+    }
+
+    public function test_from_aggregate_stream_on_gateway_method_disambiguates_multiple_streams(): void
+    {
+        $projection = new #[
+            ProjectionV2('ticket_counter_multi_stream'),
+            Partitioned,
+            FromAggregateStream(Ticket::class),
+            FromAggregateStream(Basket::class),
+        ] class () {
+            public const NAME = 'ticket_counter_multi_stream';
+
+            #[EventHandler]
+            public function onTicketRegistered(TicketWasRegistered $event, #[ProjectionState] array $state = []): array
+            {
+                $state['ticketCount'] = ($state['ticketCount'] ?? 0) + 1;
+                $state['closedTicketCount'] = $state['closedTicketCount'] ?? 0;
+                return $state;
+            }
+
+            #[EventHandler]
+            public function onTicketClosed(TicketWasClosed $event, #[ProjectionState] array $state = []): array
+            {
+                $state['closedTicketCount'] = ($state['closedTicketCount'] ?? 0) + 1;
+                return $state;
+            }
+        };
+
+        $ecotone = $this->bootstrapEcotone(
+            [$projection::class, PartitionedCounterStateWithStreamGateway::class, StateAndEventConverter::class],
+            [$projection, new StateAndEventConverter()]
+        );
+
+        $ecotone->initializeProjection($projection::NAME);
+        $ecotone->deleteProjection($projection::NAME);
+
+        $ecotone->sendCommand(new RegisterTicket('ticket-1', 'Johnny', 'alert'));
+        $ecotone->sendCommand(new CloseTicket('ticket-1'));
+
+        $gateway = $ecotone->getGateway(PartitionedCounterStateWithStreamGateway::class);
+
+        self::assertEquals(
+            new CounterState(ticketCount: 1, closedTicketCount: 1),
+            $gateway->fetchStateForPartition('ticket-1')
+        );
+    }
+
+    private function createCounterProjection(): object
+    {
+        return new #[ProjectionV2(self::NAME), Partitioned, FromStream(stream: Ticket::class, aggregateType: Ticket::class)] class () {
+            public const NAME = 'ticket_counter_partitioned';
+
+            #[EventHandler]
+            public function onTicketRegistered(TicketWasRegistered $event, #[ProjectionState] array $state = []): array
+            {
+                $state['ticketCount'] = ($state['ticketCount'] ?? 0) + 1;
+                $state['closedTicketCount'] = $state['closedTicketCount'] ?? 0;
+                return $state;
+            }
+
+            #[EventHandler]
+            public function onTicketClosed(TicketWasClosed $event, #[ProjectionState] array $state = []): array
+            {
+                $state['closedTicketCount'] = ($state['closedTicketCount'] ?? 0) + 1;
+                return $state;
+            }
+        };
+    }
+
+    private function bootstrapEcotone(array $classesToResolve, array $services): FlowTestSupport
+    {
+        return EcotoneLite::bootstrapFlowTestingWithEventStore(
+            classesToResolve: array_merge($classesToResolve, [Ticket::class, TicketEventConverter::class]),
+            containerOrAvailableServices: array_merge($services, [new TicketEventConverter(), self::getConnectionFactory()]),
+            configuration: ServiceConfiguration::createWithDefaults()
+                ->withSkippedModulePackageNames(ModulePackageList::allPackagesExcept([
+                    ModulePackageList::DBAL_PACKAGE,
+                    ModulePackageList::EVENT_SOURCING_PACKAGE,
+                    ModulePackageList::ASYNCHRONOUS_PACKAGE,
+                ])),
+            runForProductionEventStore: true,
+            licenceKey: LicenceTesting::VALID_LICENCE,
+        );
+    }
+}


### PR DESCRIPTION
# Documentation on new Projecting System

Read the documentation on new Projecting System [here](https://docs.ecotone.tech/modelling/event-sourcing/setting-up-projections)

## Why is this change proposed?

ProjectionV2 is currently entirely gated behind an enterprise licence. Users who want globally-tracked projection that follows event store position cannot use it without purchasing a licence. This change makes the core projection capability available in open-source — giving users production-ready globally-tracked projections — while keeping scaling, operational, and deployment features as enterprise value-adds - to help users as their system grows.

New Projection System is natural replacement for old Prooph based Projection V1 - which was limited in gap detection, scaling abilities, and ability to build new features on top of it.  
This will allow current Ecotone users to migrates from `Projection(v1)` to `ProjectionV2` - which will allow in Ecotone 2.0 for complete removal of old projecting system.

## Description of Changes

### Open-source features (no licence required)

```php
#[ProjectionV2('in_progress_tickets')]
#[FromStream(Ticket::class)]
class InProgressTicketList
{
    #[EventHandler]
    public function onTicketCreated(TicketCreated $event): void
    {
        // Write to read model
    }

    #[ProjectionInitialization]
    public function init(): void { /* CREATE TABLE ... */ }

    #[ProjectionDelete]
    public function delete(): void { /* DROP TABLE ... */ }

    #[ProjectionReset]
    public function reset(): void { /* DELETE FROM ... */ }
}
```

Also supported without licence:
- Async event-driven via `#[Asynchronous('channel')]`
- Multiple `#[FromStream]` / `#[FromAggregateStream]` on same projection
- `#[ProjectionExecution(eventLoadingBatchSize: 500)]`
- `#[ProjectionBackfill]` (sync only, no `asyncChannelName`)
- `#[ProjectionState]` for stateful handlers
- Event emission via `EventStreamEmitter`
- Gap detection, locking, batch loading

### Enterprise-only features (require licence)

```php
// These attributes require enterprise licence:
#[Partitioned]           // Partition-based scaling
#[Streaming('channel')]  // Streaming channel consumption
#[Polling('endpoint')]   // Polling execution mode
#[ProjectionRebuild]     // Rebuild capability
#[ProjectionDeployment(manualKickOff: true, live: false)]  // Blue-green
#[ProjectionBackfill(asyncChannelName: 'backfill')]  // Async backfill
```

Custom implementations of `#[StreamSource]`, `#[StateStorage]`, `#[PartitionProvider]` also require enterprise licence.

### Use case scenarios

1. **Read model projection** — A team building a CQRS app needs a projection that maintains a denormalized read model from event-sourced aggregates. With this change, they can use `#[ProjectionV2]` + `#[FromStream]` out of the box.

2. **Multi-stream aggregation** — A dashboard projection consuming events from multiple aggregate streams (e.g., Orders + Payments) works without licence using multiple `#[FromStream]` attributes.

3. **Scaling to production** — When the team needs partition-based parallel processing, async rebuild, or blue-green deployment, they upgrade to enterprise.

### Feature split diagram

```mermaid
flowchart TD
    PV2["#[ProjectionV2]"] --> OSCheck{Open-source eligible?}
    
    OSCheck -->|Global + sync/async event-driven| OS["Open Source ✓"]
    OSCheck -->|Partitioned / Streaming / Polling| ENT["Enterprise Required"]
    OSCheck -->|ProjectionRebuild / Deployment| ENT
    OSCheck -->|Async backfill| ENT
    OSCheck -->|Custom StreamSource / StateStorage| ENT
    
    OS --> Features["Lifecycle • Multi-stream • Backfill (sync)\nGap detection • Locking • Batch loading\nEvent emission • ProjectionState"]
```

## Pull Request Contribution Terms

- [X] I have read and agree to the contribution terms outlined in [CONTRIBUTING](https://github.com/ecotoneframework/ecotone-dev/blob/main/CONTRIBUTING.md).