### PR TITLE
fix: support EventStreamEmitter inside #[ProjectionFlush]

### DIFF
--- a/packages/Ecotone/src/Projecting/EcotoneProjectorExecutor.php
+++ b/packages/Ecotone/src/Projecting/EcotoneProjectorExecutor.php
@@ -80,13 +80,29 @@ class EcotoneProjectorExecutor implements ProjectorExecutor
         }
     }
 
-    public function flush(mixed $userState = null): void
+    public function flush(mixed $userState = null, bool $isRebuilding = false): void
     {
-        if ($this->flushChannel) {
-            $this->messagingEntrypoint->sendWithHeaders([], $this->withProjectionName([
-                ProjectingHeaders::PROJECTION_STATE => $userState,
-            ]), $this->flushChannel);
+        if (! $this->flushChannel) {
+            return;
         }
+
+        $headers = $this->withProjectionName([
+            ProjectingHeaders::PROJECTION_STATE => $userState,
+            ProjectingHeaders::PROJECTION_LIVE => $this->isLive && ! $isRebuilding,
+            MessageHeaders::STREAM_BASED_SOURCED => true,
+        ]);
+
+        $requestMessage = MessageBuilder::withPayload([])
+            ->setMultipleHeaders($headers)
+            ->build();
+
+        $flushChannel = $this->flushChannel;
+        $this->messageHeadersPropagatorInterceptor->storeHeaders(
+            function () use ($headers, $flushChannel): void {
+                $this->messagingEntrypoint->sendWithHeaders([], $headers, $flushChannel);
+            },
+            $requestMessage
+        );
     }
 
     public function reset(?string $partitionKey = null): void

--- a/packages/Ecotone/src/Projecting/EcotoneProjectorExecutor.php
+++ b/packages/Ecotone/src/Projecting/EcotoneProjectorExecutor.php
@@ -80,7 +80,7 @@ class EcotoneProjectorExecutor implements ProjectorExecutor
         }
     }
 
-    public function flush(mixed $userState = null, bool $isRebuilding = false): void
+    public function flush(mixed $userState, bool $isRebuilding): void
     {
         if (! $this->flushChannel) {
             return;

--- a/packages/Ecotone/src/Projecting/EventStoreAdapter/EventStoreChannelAdapterProjection.php
+++ b/packages/Ecotone/src/Projecting/EventStoreAdapter/EventStoreChannelAdapterProjection.php
@@ -73,7 +73,7 @@ class EventStoreChannelAdapterProjection implements ProjectorExecutor
         // No deletion needed
     }
 
-    public function flush(mixed $userState = null, bool $isRebuilding = false): void
+    public function flush(mixed $userState, bool $isRebuilding): void
     {
         // No flushing needed
     }

--- a/packages/Ecotone/src/Projecting/EventStoreAdapter/EventStoreChannelAdapterProjection.php
+++ b/packages/Ecotone/src/Projecting/EventStoreAdapter/EventStoreChannelAdapterProjection.php
@@ -73,7 +73,7 @@ class EventStoreChannelAdapterProjection implements ProjectorExecutor
         // No deletion needed
     }
 
-    public function flush(mixed $userState = null): void
+    public function flush(mixed $userState = null, bool $isRebuilding = false): void
     {
         // No flushing needed
     }

--- a/packages/Ecotone/src/Projecting/InMemory/InMemoryProjector.php
+++ b/packages/Ecotone/src/Projecting/InMemory/InMemoryProjector.php
@@ -40,7 +40,7 @@ class InMemoryProjector implements ProjectorExecutor, Countable
         $this->projectedEvents = [];
     }
 
-    public function flush(mixed $userState = null): void
+    public function flush(mixed $userState = null, bool $isRebuilding = false): void
     {
     }
 

--- a/packages/Ecotone/src/Projecting/InMemory/InMemoryProjector.php
+++ b/packages/Ecotone/src/Projecting/InMemory/InMemoryProjector.php
@@ -40,7 +40,7 @@ class InMemoryProjector implements ProjectorExecutor, Countable
         $this->projectedEvents = [];
     }
 
-    public function flush(mixed $userState = null, bool $isRebuilding = false): void
+    public function flush(mixed $userState, bool $isRebuilding): void
     {
     }
 

--- a/packages/Ecotone/src/Projecting/ProjectingManager.php
+++ b/packages/Ecotone/src/Projecting/ProjectingManager.php
@@ -102,7 +102,7 @@ class ProjectingManager
                     $batchProcessedEvents++;
                 }
                 if ($batchProcessedEvents > 0) {
-                    $this->projectorExecutor->flush($userState);
+                    $this->projectorExecutor->flush($userState, $shouldReset);
                 }
 
                 $totalProcessedEvents += $batchProcessedEvents;

--- a/packages/Ecotone/src/Projecting/ProjectorExecutor.php
+++ b/packages/Ecotone/src/Projecting/ProjectorExecutor.php
@@ -18,6 +18,6 @@ interface ProjectorExecutor
     public function project(Event $event, mixed $userState = null, bool $isRebuilding = false): mixed;
     public function init(): void;
     public function delete(): void;
-    public function flush(mixed $userState = null, bool $isRebuilding = false): void;
+    public function flush(mixed $userState, bool $isRebuilding): void;
     public function reset(?string $partitionKey = null): void;
 }

--- a/packages/Ecotone/src/Projecting/ProjectorExecutor.php
+++ b/packages/Ecotone/src/Projecting/ProjectorExecutor.php
@@ -18,6 +18,6 @@ interface ProjectorExecutor
     public function project(Event $event, mixed $userState = null, bool $isRebuilding = false): mixed;
     public function init(): void;
     public function delete(): void;
-    public function flush(mixed $userState = null): void;
+    public function flush(mixed $userState = null, bool $isRebuilding = false): void;
     public function reset(?string $partitionKey = null): void;
 }

--- a/packages/PdoEventSourcing/tests/Projecting/Partitioned/EmittingEventsProjectionTest.php
+++ b/packages/PdoEventSourcing/tests/Projecting/Partitioned/EmittingEventsProjectionTest.php
@@ -7,21 +7,26 @@ declare(strict_types=1);
 
 namespace Test\Ecotone\EventSourcing\Projecting\Partitioned;
 
+use Ecotone\EventSourcing\Attribute\FromAggregateStream;
 use Ecotone\EventSourcing\Attribute\FromStream;
 use Ecotone\EventSourcing\Attribute\ProjectionDelete;
 use Ecotone\EventSourcing\Attribute\ProjectionInitialization;
 use Ecotone\EventSourcing\Attribute\ProjectionReset;
+use Ecotone\EventSourcing\Attribute\ProjectionState;
 use Ecotone\EventSourcing\EventStore;
 use Ecotone\EventSourcing\EventStreamEmitter;
 use Ecotone\Lite\EcotoneLite;
 use Ecotone\Messaging\Attribute\Parameter\Reference;
 use Ecotone\Messaging\Config\ModulePackageList;
 use Ecotone\Messaging\Config\ServiceConfiguration;
+use Ecotone\Messaging\Support\LicensingException;
 use Ecotone\Modelling\Attribute\EventHandler;
 use Ecotone\Modelling\Attribute\QueryHandler;
 use Ecotone\Projecting\Attribute\Partitioned;
 use Ecotone\Projecting\Attribute\ProjectionDeployment;
+use Ecotone\Projecting\Attribute\ProjectionFlush;
 use Ecotone\Projecting\Attribute\ProjectionV2;
+use Ecotone\Projecting\ProjectionRegistry;
 use Ecotone\Test\LicenceTesting;
 use Enqueue\Dbal\DbalConnectionFactory;
 
@@ -355,6 +360,206 @@ final class EmittingEventsProjectionTest extends EventSourcingMessagingTestCase
                 $this->tickets = [];
                 if ($eventStore->hasStream(self::STREAM_NAME)) {
                     $eventStore->delete(self::STREAM_NAME);
+                }
+            }
+        };
+    }
+
+    public function test_partitioned_projection_flush_emits_events_using_event_stream_emitter(): void
+    {
+        $projection = $this->createFlushEmittingProjection();
+
+        $ecotone = EcotoneLite::bootstrapFlowTestingWithEventStore(
+            classesToResolve: [get_class($projection), TicketListUpdatedConverter::class, TicketListUpdated::class],
+            containerOrAvailableServices: [
+                $projection,
+                new TicketEventConverter(),
+                new TicketListUpdatedConverter(),
+                DbalConnectionFactory::class => $this->getConnectionFactory(),
+            ],
+            configuration: ServiceConfiguration::createWithDefaults()
+                ->withSkippedModulePackageNames(ModulePackageList::allPackagesExcept([ModulePackageList::DBAL_PACKAGE, ModulePackageList::EVENT_SOURCING_PACKAGE, ModulePackageList::ASYNCHRONOUS_PACKAGE]))
+                ->withNamespaces([
+                    'Test\Ecotone\EventSourcing\Fixture\Ticket',
+                ]),
+            pathToRootCatalog: __DIR__ . '/../../',
+            runForProductionEventStore: true,
+            licenceKey: LicenceTesting::VALID_LICENCE,
+        );
+
+        $ecotone
+            ->sendCommand(new RegisterTicket('1', 'Johnny', 'alert'))
+            ->sendCommand(new RegisterTicket('2', 'Jane', 'info'));
+
+        $eventStore = $ecotone->getGateway(EventStore::class);
+        $emittedEvents = $eventStore->load('projection_flush_emitting_projection');
+
+        self::assertCount(2, $emittedEvents);
+    }
+
+    public function test_rebuild_should_not_emit_events_from_flush_method(): void
+    {
+        $projection = $this->createFlushEmittingProjection();
+
+        $ecotone = EcotoneLite::bootstrapFlowTestingWithEventStore(
+            classesToResolve: [get_class($projection), TicketListUpdatedConverter::class, TicketListUpdated::class],
+            containerOrAvailableServices: [
+                $projection,
+                new TicketEventConverter(),
+                new TicketListUpdatedConverter(),
+                DbalConnectionFactory::class => $this->getConnectionFactory(),
+            ],
+            configuration: ServiceConfiguration::createWithDefaults()
+                ->withSkippedModulePackageNames(ModulePackageList::allPackagesExcept([ModulePackageList::DBAL_PACKAGE, ModulePackageList::EVENT_SOURCING_PACKAGE, ModulePackageList::ASYNCHRONOUS_PACKAGE]))
+                ->withNamespaces([
+                    'Test\Ecotone\EventSourcing\Fixture\Ticket',
+                ]),
+            pathToRootCatalog: __DIR__ . '/../../',
+            runForProductionEventStore: true,
+            licenceKey: LicenceTesting::VALID_LICENCE,
+        );
+
+        $ecotone
+            ->sendCommand(new RegisterTicket('1', 'Johnny', 'alert'))
+            ->sendCommand(new RegisterTicket('2', 'Jane', 'info'));
+
+        $eventStore = $ecotone->getGateway(EventStore::class);
+        self::assertCount(2, $eventStore->load('projection_flush_emitting_projection'));
+
+        $ecotone->resetProjection('flush_emitting_projection');
+        self::assertEmpty($projection->getTickets());
+        $emittedCountBeforeRebuild = $eventStore->hasStream('projection_flush_emitting_projection')
+            ? count($eventStore->load('projection_flush_emitting_projection'))
+            : 0;
+
+        $ecotone->getGateway(ProjectionRegistry::class)->get('flush_emitting_projection')->prepareRebuild();
+
+        self::assertNotEmpty($projection->getTickets());
+        $emittedCountAfterRebuild = $eventStore->hasStream('projection_flush_emitting_projection')
+            ? count($eventStore->load('projection_flush_emitting_projection'))
+            : 0;
+        self::assertSame($emittedCountBeforeRebuild, $emittedCountAfterRebuild);
+    }
+
+    public function test_global_flush_with_projection_state_requires_enterprise_licence(): void
+    {
+        $projection = new #[ProjectionV2('global_flush_state_projection'), \Ecotone\EventSourcing\Attribute\FromStream(Ticket::class)] class () {
+            #[EventHandler(endpointId: 'globalFlushStateProjection.addTicket')]
+            public function addTicket(TicketWasRegistered $event, #[ProjectionState] array $ticket = []): array
+            {
+                $ticket['ticketId'] = $event->getTicketId();
+                return $ticket;
+            }
+
+            #[ProjectionFlush]
+            public function flush(#[ProjectionState] array $ticket, EventStreamEmitter $emitter): void
+            {
+                if (! isset($ticket['ticketId'])) {
+                    return;
+                }
+                $emitter->emit([new TicketListUpdated($ticket['ticketId'])]);
+            }
+        };
+
+        $this->expectException(LicensingException::class);
+        $this->expectExceptionMessage('Using #[ProjectionState] in #[ProjectionFlush] methods requires Ecotone Enterprise licence.');
+
+        EcotoneLite::bootstrapFlowTestingWithEventStore(
+            classesToResolve: [get_class($projection), TicketListUpdatedConverter::class, TicketListUpdated::class],
+            containerOrAvailableServices: [
+                $projection,
+                new TicketEventConverter(),
+                new TicketListUpdatedConverter(),
+                DbalConnectionFactory::class => $this->getConnectionFactory(),
+            ],
+            configuration: ServiceConfiguration::createWithDefaults()
+                ->withSkippedModulePackageNames(ModulePackageList::allPackagesExcept([ModulePackageList::DBAL_PACKAGE, ModulePackageList::EVENT_SOURCING_PACKAGE, ModulePackageList::ASYNCHRONOUS_PACKAGE]))
+                ->withNamespaces([
+                    'Test\Ecotone\EventSourcing\Fixture\Ticket',
+                ]),
+            pathToRootCatalog: __DIR__ . '/../../',
+            runForProductionEventStore: true,
+        );
+    }
+
+    public function test_partitioned_flush_emitter_pattern_requires_enterprise_licence(): void
+    {
+        $projection = $this->createFlushEmittingProjection();
+
+        $this->expectException(LicensingException::class);
+        $this->expectExceptionMessageMatches('/Enterprise licence/');
+
+        EcotoneLite::bootstrapFlowTestingWithEventStore(
+            classesToResolve: [get_class($projection), TicketListUpdatedConverter::class, TicketListUpdated::class],
+            containerOrAvailableServices: [
+                $projection,
+                new TicketEventConverter(),
+                new TicketListUpdatedConverter(),
+                DbalConnectionFactory::class => $this->getConnectionFactory(),
+            ],
+            configuration: ServiceConfiguration::createWithDefaults()
+                ->withSkippedModulePackageNames(ModulePackageList::allPackagesExcept([ModulePackageList::DBAL_PACKAGE, ModulePackageList::EVENT_SOURCING_PACKAGE, ModulePackageList::ASYNCHRONOUS_PACKAGE]))
+                ->withNamespaces([
+                    'Test\Ecotone\EventSourcing\Fixture\Ticket',
+                ]),
+            pathToRootCatalog: __DIR__ . '/../../',
+            runForProductionEventStore: true,
+        );
+    }
+
+    private function createFlushEmittingProjection(): object
+    {
+        return new #[ProjectionV2('flush_emitting_projection'), Partitioned, FromAggregateStream(Ticket::class)] class () {
+            public array $tickets = [];
+
+            #[EventHandler(endpointId: 'flushEmittingProjection.addTicket')]
+            public function addTicket(TicketWasRegistered $event, #[ProjectionState] array $ticket = []): array
+            {
+                $ticket['ticketId'] = $event->getTicketId();
+                $ticket['status'] = 'open';
+                $this->tickets[$event->getTicketId()] = $ticket;
+                return $ticket;
+            }
+
+            #[EventHandler(endpointId: 'flushEmittingProjection.closeTicket')]
+            public function closeTicket(TicketWasClosed $event, #[ProjectionState] array $ticket): array
+            {
+                $ticket['status'] = 'closed';
+                $this->tickets[$event->getTicketId()] = $ticket;
+                return $ticket;
+            }
+
+            #[ProjectionFlush]
+            public function flush(#[ProjectionState] array $ticket, EventStreamEmitter $emitter): void
+            {
+                if (! isset($ticket['ticketId'])) {
+                    return;
+                }
+
+                $emitter->emit([new TicketListUpdated($ticket['ticketId'])]);
+            }
+
+            #[QueryHandler('getFlushEmittingProjectionTickets')]
+            public function getTickets(): array
+            {
+                return $this->tickets;
+            }
+
+            #[ProjectionReset]
+            public function reset(#[Reference] EventStore $eventStore): void
+            {
+                $this->tickets = [];
+                if ($eventStore->hasStream('projection_flush_emitting_projection')) {
+                    $eventStore->delete('projection_flush_emitting_projection');
+                }
+            }
+
+            #[ProjectionDelete]
+            public function delete(#[Reference] EventStore $eventStore): void
+            {
+                $this->tickets = [];
+                if ($eventStore->hasStream('projection_flush_emitting_projection')) {
+                    $eventStore->delete('projection_flush_emitting_projection');
                 }
             }
         };


### PR DESCRIPTION
## Why is this change proposed?

Calling `EventStreamEmitter::emit(...)` (or `linkTo(...)`) from a `#[ProjectionFlush]` method threw `MessageHeaderDoesNotExistsException: Header projection.name does not exists` from `StreamNameMapper`. The flush dispatch in `EcotoneProjectorExecutor` skipped the header context that the event-handler dispatch (`project()`) sets up — `projection.name`, `projection.live`, `streamBasedSourced` — and never wrapped the dispatch in `MessageHeadersPropagatorInterceptor::storeHeaders`, so propagation to outbound gateways from inside flush was broken.

This blocks a common pattern: building per-batch state across event handlers, then in flush persisting the state and emitting a single derived event (e.g. "wallet balance changed", "ticket list updated") — exactly the use case the API was designed for.

## Description of Changes

- `EcotoneProjectorExecutor::flush()` now mirrors the header context of `project()`: sets `PROJECTION_LIVE` (false during rebuild), `STREAM_BASED_SOURCED`, and `PROJECTION_NAME` (still **enterprise-gated** via `withProjectionName()` — open-core flushes don't get it, matching `project()` behaviour). The dispatch is wrapped in `messageHeadersPropagatorInterceptor->storeHeaders()` so `EventStreamEmitter`'s `PropagateHeaders` gateway can merge those headers into outbound emit/linkTo calls.
- `ProjectorExecutor::flush()` interface gains `bool $isRebuilding = false`; `ProjectingManager::executePartitionBatch` passes `$shouldReset` so rebuild-time emits are correctly suppressed by the `PROJECTION_LIVE` filter. Existing `InMemoryProjector` / `EventStoreChannelAdapterProjection` updated for the signature.
- New tests in `packages/PdoEventSourcing/tests/Projecting/Partitioned/EmittingEventsProjectionTest.php`:
  - emit-from-flush works once per batch (Partitioned + `FromAggregateStream`)
  - rebuild does **not** re-emit events from flush
  - non-enterprise bootstrap shows a clear `LicensingException` ("Using #[ProjectionState] in #[ProjectionFlush] methods requires Ecotone Enterprise licence.")

### Usage

```php
#[Partitioned]
#[ProjectionV2('wallet_balance')]
#[FromAggregateStream(Wallet::class)]
class WalletBalanceProjection
{
    #[EventHandler]
    public function whenWalletInitialized(
        WalletWasInitialized $event,
        #[ProjectionState] array $wallet = []
    ): array {
        return ['walletId' => $event->walletId, 'balance' => 0];
    }

    #[EventHandler]
    public function whenMoneyWasAdded(
        MoneyWasAddedToWallet $event,
        #[ProjectionState] array $wallet
    ): array {
        $wallet['balance'] += $event->amount;
        return $wallet;
    }

    #[ProjectionFlush]
    public function flush(
        #[ProjectionState] array $wallet,
        EventStreamEmitter $emitter,
    ): void {
        $this->saveWallet($wallet);
        $emitter->emit([new WalletBalanceWasChanged($wallet['walletId'], $wallet['balance'])]);
    }
}
```

### Use cases

1. **Per-batch derived events** — collapse N inbound events into a single outbound event per partition flush (e.g. one `WalletBalanceWasChanged` per batch instead of one per `MoneyWasAdded`), reducing downstream consumer pressure.
2. **Atomic persist + publish** — a `#[ProjectionFlush]` runs inside the projection transaction; persisting projection state and emitting the derived event in the same flush keeps both within one boundary.
3. **Safe rebuilds** — when a projection is rebuilt via `ProjectionRegistry::prepareRebuild()`, flush still runs (state is reconstructed) but emits are suppressed via the `projection.live` filter, so downstream consumers don't see duplicate "balance changed" events.

### Flow

```mermaid
sequenceDiagram
    participant PM as ProjectingManager
    participant Exec as EcotoneProjectorExecutor
    participant Interceptor as HeadersPropagator
    participant Flush as #[ProjectionFlush] handler
    participant Emitter as EventStreamEmitter
    participant Store as EventStore

    PM->>Exec: flush(state, isRebuilding)
    Exec->>Interceptor: storeHeaders(projection.name, projection.live, ...)
    Interceptor->>Flush: invoke flush method
    Flush->>Emitter: emit([DerivedEvent])
    Emitter->>Interceptor: propagateHeaders()
    Interceptor-->>Emitter: + projection.name, projection.live
    alt projection.live = true
        Emitter->>Store: append to projection_<name>
    else projection.live = false (rebuild)
        Emitter--xStore: filtered out
    end
```

## Pull Request Contribution Terms

- [X] I have read and agree to the contribution terms outlined in [CONTRIBUTING](https://github.com/ecotoneframework/ecotone-dev/blob/main/CONTRIBUTING.md).