### PR TITLE
Fix deduplication cleanup under multi-tenant with no default connection (#667)

### DIFF
--- a/packages/Dbal/tests/Integration/MultiTenant/DeduplicationCleanupMultiTenantTest.php
+++ b/packages/Dbal/tests/Integration/MultiTenant/DeduplicationCleanupMultiTenantTest.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Ecotone\Dbal\Integration\MultiTenant;
+
+use Ecotone\Dbal\Configuration\DbalConfiguration;
+use Ecotone\Dbal\MultiTenant\MultiTenantConfiguration;
+use Ecotone\Lite\EcotoneLite;
+use Ecotone\Lite\Test\FlowTestSupport;
+use Ecotone\Messaging\Config\ModulePackageList;
+use Ecotone\Messaging\Config\ServiceConfiguration;
+use Ecotone\Messaging\Support\InvalidArgumentException;
+use Test\Ecotone\Dbal\DbalMessagingTestCase;
+use Test\Ecotone\Dbal\Fixture\DeduplicationCommandHandler\EmailCommandHandler;
+
+/**
+ * @internal
+ *
+ * Reproduces and verifies the fix path for issue #667:
+ * deduplication cleanup under multi-tenant connections with no default connection.
+ */
+/**
+ * licence Apache-2.0
+ * @internal
+ */
+final class DeduplicationCleanupMultiTenantTest extends DbalMessagingTestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        foreach ([$this->connectionForTenantA(), $this->connectionForTenantB()] as $connectionFactory) {
+            $connectionFactory->createContext()->getDbalConnection()
+                ->executeStatement('DROP TABLE IF EXISTS ecotone_deduplication');
+        }
+    }
+
+    public function test_reproduces_667_cleanup_without_tenant_header_throws_when_no_default_connection(): void
+    {
+        $ecotoneLite = $this->bootstrapEcotone();
+
+        $this->expectException(InvalidArgumentException::class);
+
+        $ecotoneLite->runConsoleCommand('ecotone:deduplication:remove-expired-messages', []);
+    }
+
+    public function test_cleanup_with_tenant_header_routes_to_correct_tenant_connection(): void
+    {
+        $ecotoneLite = $this->bootstrapEcotone();
+
+        $ecotoneLite->sendCommandWithRoutingKey(
+            'email_event_handler.handle_with_custom_deduplication_header',
+            metadata: ['tenant' => 'tenant_a', 'emailId' => 'a-1']
+        );
+        $ecotoneLite->sendCommandWithRoutingKey(
+            'email_event_handler.handle_with_custom_deduplication_header',
+            metadata: ['tenant' => 'tenant_b', 'emailId' => 'b-1']
+        );
+
+        $this->assertSame(1, $this->countDeduplicationRows($this->connectionForTenantA()), 'tenant_a should have one tracked message before cleanup');
+        $this->assertSame(1, $this->countDeduplicationRows($this->connectionForTenantB()), 'tenant_b should have one tracked message before cleanup');
+
+        $ecotoneLite->runConsoleCommand('ecotone:deduplication:remove-expired-messages', ['header' => ['tenant:tenant_a']]);
+
+        $this->assertSame(0, $this->countDeduplicationRows($this->connectionForTenantA()), 'tenant_a expired message should be removed');
+        $this->assertSame(1, $this->countDeduplicationRows($this->connectionForTenantB()), 'tenant_b must be untouched - cleanup routed to tenant_a only');
+    }
+
+    private function countDeduplicationRows(object $connectionFactory): int
+    {
+        return (int) $connectionFactory->createContext()->getDbalConnection()
+            ->executeQuery('SELECT COUNT(*) FROM ecotone_deduplication')
+            ->fetchOne();
+    }
+
+    private function bootstrapEcotone(): FlowTestSupport
+    {
+        return EcotoneLite::bootstrapFlowTesting(
+            [EmailCommandHandler::class],
+            [
+                new EmailCommandHandler(),
+                'tenant_a_connection' => $this->connectionForTenantA(),
+                'tenant_b_connection' => $this->connectionForTenantB(),
+            ],
+            ServiceConfiguration::createWithDefaults()
+                ->withSkippedModulePackageNames(ModulePackageList::allPackagesExcept([ModulePackageList::DBAL_PACKAGE]))
+                ->withExtensionObjects([
+                    MultiTenantConfiguration::create(
+                        tenantHeaderName: 'tenant',
+                        tenantToConnectionMapping: [
+                            'tenant_a' => 'tenant_a_connection',
+                            'tenant_b' => 'tenant_b_connection',
+                        ],
+                    ),
+                    DbalConfiguration::createWithDefaults()
+                        ->withDeduplication(true, expirationTime: 1),
+                ]),
+        );
+    }
+}

--- a/packages/Ecotone/src/Messaging/Config/ConsoleCommandRunner.php
+++ b/packages/Ecotone/src/Messaging/Config/ConsoleCommandRunner.php
@@ -54,7 +54,7 @@ class ConsoleCommandRunner
             }
         }
 
-        return $this->entrypoint->sendWithHeaders([], $arguments, $this->commandConfiguration->getChannelName());
+        return $this->entrypoint->sendWithHeadersPropagation([], $arguments, $this->commandConfiguration->getChannelName());
     }
 
     private function hasParameterWithGivenName(int|string $argumentName): bool


### PR DESCRIPTION
## Why is this change proposed?

Fixes #667 — `ecotone:deduplication:remove-expired-messages` fails under a multi-tenant
connection setup that has no default connection.

With `MultiTenantConfiguration` and no default connection, running the cleanup command throws:

```
Lack of context about tenant in Message Headers. Please add `tenantId` header metadata to your message.
  at HeaderBasedMultiTenantConnectionFactory.php:105
```

## Description of Changes

  ```bash
  # Symfony
  bin/console ecotone:deduplication:remove-expired-messages --header tenantId:tenant_a
  # Laravel
  php artisan ecotone:deduplication:remove-expired-messages --header=tenantId:tenant_a
  ```

  Run once per tenant (e.g. from the scheduler) to clean each tenant's `ecotone_deduplication` table.

## Pull Request Contribution Terms

- [X] I have read and agree to the contribution terms outlined in [CONTRIBUTING](https://github.com/ecotoneframework/ecotone-dev/blob/main/CONTRIBUTING.md).
