### PR TITLE
fix: preserve env placeholders in serialized message attributes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -129,6 +129,8 @@
             "Symfony\\App\\MultiTenant\\": "packages/Symfony/tests/phpunit/MultiTenant/src",
             "Symfony\\App\\SingleTenant\\": "packages/Symfony/tests/phpunit/SingleTenant/src",
             "Symfony\\App\\Licence\\": "packages/Symfony/tests/phpunit/Licence/src",
+            "Symfony\\App\\EnvPlaceholderEndpoint\\": "packages/Symfony/tests/phpunit/EnvPlaceholderEndpoint/src",
+            "Symfony\\App\\EnvPlaceholderKafka\\": "packages/Symfony/tests/phpunit/EnvPlaceholderKafka/src",
             "Tests\\Ecotone\\": "tests"
         }
     },

--- a/packages/Amqp/src/Attribute/RabbitConsumer.php
+++ b/packages/Amqp/src/Attribute/RabbitConsumer.php
@@ -51,6 +51,7 @@ final class RabbitConsumer extends MessageConsumer implements DefinedObject
             [
                 $this->getEndpointId(),
                 $this->queueName,
+                $this->finalFailureStrategy,
                 $this->connectionReference,
             ]
         );

--- a/packages/Ecotone/src/Messaging/Attribute/Asynchronous.php
+++ b/packages/Ecotone/src/Messaging/Attribute/Asynchronous.php
@@ -5,13 +5,15 @@ declare(strict_types=1);
 namespace Ecotone\Messaging\Attribute;
 
 use Attribute;
+use Ecotone\Messaging\Config\Container\DefinedObject;
+use Ecotone\Messaging\Config\Container\Definition;
 use Ecotone\Messaging\Support\Assert;
 
 #[Attribute(Attribute::TARGET_METHOD | Attribute::TARGET_CLASS)]
 /**
  * licence Apache-2.0
  */
-class Asynchronous
+class Asynchronous implements DefinedObject
 {
     private string|array $channelName;
     /** @var AsynchronousEndpointAttribute[] */
@@ -39,5 +41,10 @@ class Asynchronous
     public function getAsynchronousExecution(): array
     {
         return $this->asynchronousExecution;
+    }
+
+    public function getDefinition(): Definition
+    {
+        return new Definition(self::class, [$this->channelName, $this->asynchronousExecution]);
     }
 }

--- a/packages/Ecotone/src/Messaging/Attribute/DelayedRetry.php
+++ b/packages/Ecotone/src/Messaging/Attribute/DelayedRetry.php
@@ -5,13 +5,15 @@ declare(strict_types=1);
 namespace Ecotone\Messaging\Attribute;
 
 use Attribute;
+use Ecotone\Messaging\Config\Container\DefinedObject;
+use Ecotone\Messaging\Config\Container\Definition;
 use Ecotone\Messaging\Support\Assert;
 
 /**
  * licence Enterprise
  */
 #[Attribute(Attribute::TARGET_CLASS | Attribute::TARGET_METHOD)]
-final class DelayedRetry implements AsynchronousEndpointAttribute
+final class DelayedRetry implements AsynchronousEndpointAttribute, DefinedObject
 {
     public function __construct(
         public readonly int     $initialDelayMs,
@@ -24,6 +26,17 @@ final class DelayedRetry implements AsynchronousEndpointAttribute
         Assert::isTrue($multiplier > 0, 'DelayedRetry multiplier must be greater than 0');
         Assert::isTrue($maxAttempts === null || $maxAttempts > 0, 'DelayedRetry maxAttempts must be null (unlimited) or greater than 0');
         Assert::isTrue($deadLetterChannel === null || $deadLetterChannel !== '', 'DelayedRetry deadLetterChannel must be null or a non-empty channel name');
+    }
+
+    public function getDefinition(): Definition
+    {
+        return new Definition(self::class, [
+            $this->initialDelayMs,
+            $this->multiplier,
+            $this->maxDelayMs,
+            $this->maxAttempts,
+            $this->deadLetterChannel,
+        ]);
     }
 
     public static function generateChannelName(string $handlerEndpointId): string

--- a/packages/Ecotone/src/Messaging/Attribute/ErrorChannel.php
+++ b/packages/Ecotone/src/Messaging/Attribute/ErrorChannel.php
@@ -5,13 +5,15 @@ declare(strict_types=1);
 namespace Ecotone\Messaging\Attribute;
 
 use Attribute;
+use Ecotone\Messaging\Config\Container\DefinedObject;
+use Ecotone\Messaging\Config\Container\Definition;
 use Ecotone\Messaging\Support\Assert;
 
 /**
  * licence Enterprise
  */
 #[Attribute(Attribute::TARGET_CLASS | Attribute::TARGET_METHOD)]
-class ErrorChannel implements AsynchronousEndpointAttribute
+class ErrorChannel implements AsynchronousEndpointAttribute, DefinedObject
 {
     /**
      * @param string $errorChannelName Name of the error channel to send Message too
@@ -20,5 +22,10 @@ class ErrorChannel implements AsynchronousEndpointAttribute
         public readonly string   $errorChannelName,
     ) {
         Assert::notNullAndEmpty($errorChannelName, 'Channel name can not be empty string');
+    }
+
+    public function getDefinition(): Definition
+    {
+        return new Definition(self::class, [$this->errorChannelName]);
     }
 }

--- a/packages/Ecotone/src/Messaging/Attribute/WithoutDatabaseTransaction.php
+++ b/packages/Ecotone/src/Messaging/Attribute/WithoutDatabaseTransaction.php
@@ -5,11 +5,17 @@ declare(strict_types=1);
 namespace Ecotone\Messaging\Attribute;
 
 use Attribute;
+use Ecotone\Messaging\Config\Container\DefinedObject;
+use Ecotone\Messaging\Config\Container\Definition;
 
 /**
  * licence Apache-2.0
  */
 #[Attribute]
-class WithoutDatabaseTransaction implements AsynchronousEndpointAttribute
+class WithoutDatabaseTransaction implements AsynchronousEndpointAttribute, DefinedObject
 {
+    public function getDefinition(): Definition
+    {
+        return new Definition(self::class);
+    }
 }

--- a/packages/Ecotone/src/Messaging/Attribute/WithoutMessageCollector.php
+++ b/packages/Ecotone/src/Messaging/Attribute/WithoutMessageCollector.php
@@ -5,11 +5,17 @@ declare(strict_types=1);
 namespace Ecotone\Messaging\Attribute;
 
 use Attribute;
+use Ecotone\Messaging\Config\Container\DefinedObject;
+use Ecotone\Messaging\Config\Container\Definition;
 
 /**
  * licence Enterprise
  */
 #[Attribute]
-class WithoutMessageCollector implements AsynchronousEndpointAttribute
+class WithoutMessageCollector implements AsynchronousEndpointAttribute, DefinedObject
 {
+    public function getDefinition(): Definition
+    {
+        return new Definition(self::class);
+    }
 }

--- a/packages/Ecotone/src/Messaging/Config/Container/DefinitionHelper.php
+++ b/packages/Ecotone/src/Messaging/Config/Container/DefinitionHelper.php
@@ -25,6 +25,16 @@ class DefinitionHelper
 
     public static function buildAttributeDefinitionFromInstance(object $object): AttributeDefinition
     {
+        if ($object instanceof DefinedObject) {
+            $definition = $object->getDefinition();
+
+            return new AttributeDefinition(
+                $definition->getClassName(),
+                $definition->getArguments(),
+                $definition->hasFactory() ? $definition->getFactory() : '',
+            );
+        }
+
         return new AttributeDefinition(get_class($object), [serialize($object)], [self::class, 'unserializeSerializedObject']);
     }
 
@@ -37,7 +47,12 @@ class DefinitionHelper
     {
         $attributeArguments = $attributeDefinition->getArguments();
         if (self::isComplexArgument($attributeArguments)) {
-            return DefinitionHelper::buildDefinitionFromInstance($attributeDefinition->instance());
+            $instance = $attributeDefinition->instance();
+            if ($instance instanceof DefinedObject) {
+                return $instance->getDefinition();
+            }
+
+            return DefinitionHelper::buildDefinitionFromInstance($instance);
         } else {
             return $attributeDefinition;
         }

--- a/packages/Symfony/composer.json
+++ b/packages/Symfony/composer.json
@@ -50,6 +50,8 @@
         "doctrine/doctrine-bundle": "^2.7.2",
         "doctrine/orm": "^2.11|^3.0",
         "ecotone/dbal": "~1.313.2",
+        "ecotone/kafka": "~1.313.2",
+        "ext-rdkafka": "*",
         "monolog/monolog": "^2.9|^3.3.1",
         "phpstan/phpstan": "^1.8",
         "phpunit/phpunit": "^10.5|^11.0",
@@ -81,7 +83,9 @@
             "Ecotone\\SymfonyBundle\\App\\": "App",
             "Symfony\\App\\MultiTenant\\": "tests/phpunit/MultiTenant/src",
             "Symfony\\App\\SingleTenant\\": "tests/phpunit/SingleTenant/src",
-            "Symfony\\App\\Licence\\": "tests/phpunit/Licence/src"
+            "Symfony\\App\\Licence\\": "tests/phpunit/Licence/src",
+            "Symfony\\App\\EnvPlaceholderEndpoint\\": "tests/phpunit/EnvPlaceholderEndpoint/src",
+            "Symfony\\App\\EnvPlaceholderKafka\\": "tests/phpunit/EnvPlaceholderKafka/src"
         }
     },
     "scripts": {

--- a/packages/Symfony/tests/phpunit/EnvPlaceholderEndpoint/EnvPlaceholderEndpointTest.php
+++ b/packages/Symfony/tests/phpunit/EnvPlaceholderEndpoint/EnvPlaceholderEndpointTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\EnvPlaceholderEndpoint;
+
+use Ecotone\Messaging\Config\ConfiguredMessagingSystem;
+use Ecotone\Messaging\Endpoint\ExecutionPollingMetadata;
+use Ecotone\Modelling\CommandBus;
+use Ecotone\SymfonyBundle\DependencyInjection\Compiler\CacheClearer;
+use Ecotone\Test\LicenceTesting;
+use PHPUnit\Framework\TestCase;
+use Symfony\App\EnvPlaceholderEndpoint\Configuration\Kernel;
+
+/**
+ * Reproduces https://github.com/ecotoneframework/ecotone-dev/issues/669
+ *
+ * licence Enterprise
+ * @internal
+ */
+final class EnvPlaceholderEndpointTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        putenv('SYMFONY_LICENCE_KEY=' . LicenceTesting::VALID_LICENCE);
+        putenv('ECOTONE_ERROR_CHANNEL=orders.error');
+    }
+
+    protected function tearDown(): void
+    {
+        putenv('SYMFONY_LICENCE_KEY');
+        putenv('ECOTONE_ERROR_CHANNEL');
+
+        restore_exception_handler();
+    }
+
+    public function test_consuming_async_handler_whose_endpoint_annotation_uses_env_placeholder(): void
+    {
+        $kernel = new Kernel('test', true);
+        $kernel->boot();
+        $container = $kernel->getContainer();
+        $container->get(CacheClearer::class)->clear('');
+
+        $container->get(CommandBus::class)->sendWithRouting('order.place', 'order-1');
+
+        $container->get(ConfiguredMessagingSystem::class)
+            ->run('orders', ExecutionPollingMetadata::createWithTestingSetup());
+
+        $this->expectNotToPerformAssertions();
+    }
+}

--- a/packages/Symfony/tests/phpunit/EnvPlaceholderEndpoint/config/bundles.php
+++ b/packages/Symfony/tests/phpunit/EnvPlaceholderEndpoint/config/bundles.php
@@ -1,0 +1,8 @@
+<?php
+
+use Ecotone\SymfonyBundle\EcotoneSymfonyBundle;
+
+return [
+    Symfony\Bundle\FrameworkBundle\FrameworkBundle::class => ['all' => true],
+    EcotoneSymfonyBundle::class => ['all' => true],
+];

--- a/packages/Symfony/tests/phpunit/EnvPlaceholderEndpoint/config/services.php
+++ b/packages/Symfony/tests/phpunit/EnvPlaceholderEndpoint/config/services.php
@@ -1,0 +1,20 @@
+<?php
+
+use Ecotone\Messaging\Config\ModulePackageList;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $containerConfigurator->extension('ecotone', [
+        'skippedModulePackageNames' => ModulePackageList::allPackagesExcept([
+            ModulePackageList::SYMFONY_PACKAGE,
+            ModulePackageList::ASYNCHRONOUS_PACKAGE,
+        ]),
+        'licenceKey' => '%env(SYMFONY_LICENCE_KEY)%',
+    ]);
+
+    $services = $containerConfigurator->services();
+
+    $services->load('Symfony\\App\\EnvPlaceholderEndpoint\\', '%kernel.project_dir%/src/')
+        ->autowire()
+        ->autoconfigure();
+};

--- a/packages/Symfony/tests/phpunit/EnvPlaceholderEndpoint/src/Configuration/EcotoneConfiguration.php
+++ b/packages/Symfony/tests/phpunit/EnvPlaceholderEndpoint/src/Configuration/EcotoneConfiguration.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symfony\App\EnvPlaceholderEndpoint\Configuration;
+
+use Ecotone\Messaging\Attribute\ServiceContext;
+use Ecotone\Messaging\Channel\SimpleMessageChannelBuilder;
+
+/**
+ * licence Apache-2.0
+ */
+final class EcotoneConfiguration
+{
+    #[ServiceContext]
+    public function ordersChannel(): array
+    {
+        return [
+            SimpleMessageChannelBuilder::createQueueChannel('orders'),
+        ];
+    }
+}

--- a/packages/Symfony/tests/phpunit/EnvPlaceholderEndpoint/src/Configuration/Kernel.php
+++ b/packages/Symfony/tests/phpunit/EnvPlaceholderEndpoint/src/Configuration/Kernel.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Symfony\App\EnvPlaceholderEndpoint\Configuration;
+
+use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;
+
+/**
+ * licence Apache-2.0
+ */
+class Kernel extends \Symfony\Component\HttpKernel\Kernel
+{
+    use MicroKernelTrait;
+
+    public function getProjectDir(): string
+    {
+        return __DIR__ . '/../../';
+    }
+}

--- a/packages/Symfony/tests/phpunit/EnvPlaceholderEndpoint/src/PlaceOrderHandler.php
+++ b/packages/Symfony/tests/phpunit/EnvPlaceholderEndpoint/src/PlaceOrderHandler.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symfony\App\EnvPlaceholderEndpoint;
+
+use Ecotone\Messaging\Attribute\Asynchronous;
+use Ecotone\Messaging\Attribute\ErrorChannel;
+use Ecotone\Modelling\Attribute\CommandHandler;
+
+/**
+ * licence Apache-2.0
+ */
+final class PlaceOrderHandler
+{
+    #[Asynchronous('orders', asynchronousExecution: [new ErrorChannel('errorChannel.%env(ECOTONE_ERROR_CHANNEL)%')])]
+    #[CommandHandler('order.place', endpointId: 'placeOrderEndpoint')]
+    public function placeOrder(string $command): void
+    {
+    }
+}

--- a/packages/Symfony/tests/phpunit/EnvPlaceholderKafka/EnvPlaceholderKafkaConsumerTest.php
+++ b/packages/Symfony/tests/phpunit/EnvPlaceholderKafka/EnvPlaceholderKafkaConsumerTest.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\EnvPlaceholderKafka;
+
+use Ecotone\Messaging\Config\ConfiguredMessagingSystem;
+use Ecotone\Messaging\Endpoint\ExecutionPollingMetadata;
+use Ecotone\Messaging\MessagePublisher;
+use Ecotone\Modelling\QueryBus;
+use Ecotone\Test\LicenceTesting;
+use PHPUnit\Framework\TestCase;
+use Symfony\App\EnvPlaceholderKafka\Configuration\Kernel;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * Reproduces https://github.com/ecotoneframework/ecotone-dev/issues/669
+ *
+ * Path B: the #[KafkaConsumer] attribute is serialized as an endpoint annotation
+ * (AnnotatedMethod::getAllAnnotationDefinitions -> AttributeDefinition::fromObject)
+ * and embedded into the consumer's runtime definition once the DBAL error-handling
+ * path is active. Symfony then rewrites the %env()% placeholder inside the serialized
+ * blob, breaking its length prefix, so the consumer can never be built and the
+ * published Message is never consumed.
+ *
+ * licence Enterprise
+ * @internal
+ */
+final class EnvPlaceholderKafkaConsumerTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        putenv('SYMFONY_LICENCE_KEY=' . LicenceTesting::VALID_LICENCE);
+        putenv('ECOTONE_KAFKA_SUFFIX=it' . substr(Uuid::v4()->toRfc4122(), 0, 8));
+
+        (new Filesystem())->remove([__DIR__ . '/var', '/tmp/ecotone']);
+    }
+
+    protected function tearDown(): void
+    {
+        putenv('SYMFONY_LICENCE_KEY');
+        putenv('ECOTONE_KAFKA_SUFFIX');
+
+        restore_exception_handler();
+    }
+
+    public function test_publishing_and_consuming_from_topic_built_from_env_placeholder(): void
+    {
+        $kernel = new Kernel('test', true);
+        $kernel->boot();
+        $container = $kernel->getContainer();
+
+        $payload = Uuid::v7()->toRfc4122();
+        $container->get(MessagePublisher::class)->send($payload);
+
+        $container->get(ConfiguredMessagingSystem::class)
+            ->run('ordersKafkaConsumer', ExecutionPollingMetadata::createWithTestingSetup(
+                maxExecutionTimeInMilliseconds: 30000,
+            ));
+
+        $this->assertSame(
+            [$payload],
+            $container->get(QueryBus::class)->sendWithRouting('ordersKafka.consumedPayloads'),
+        );
+    }
+}

--- a/packages/Symfony/tests/phpunit/EnvPlaceholderKafka/config/bundles.php
+++ b/packages/Symfony/tests/phpunit/EnvPlaceholderKafka/config/bundles.php
@@ -1,0 +1,8 @@
+<?php
+
+use Ecotone\SymfonyBundle\EcotoneSymfonyBundle;
+
+return [
+    Symfony\Bundle\FrameworkBundle\FrameworkBundle::class => ['all' => true],
+    EcotoneSymfonyBundle::class => ['all' => true],
+];

--- a/packages/Symfony/tests/phpunit/EnvPlaceholderKafka/config/services.php
+++ b/packages/Symfony/tests/phpunit/EnvPlaceholderKafka/config/services.php
@@ -1,0 +1,33 @@
+<?php
+
+use Ecotone\Kafka\Configuration\KafkaBrokerConfiguration;
+use Ecotone\Messaging\Config\ModulePackageList;
+use Enqueue\Dbal\DbalConnectionFactory;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $containerConfigurator->extension('ecotone', [
+        'skippedModulePackageNames' => ModulePackageList::allPackagesExcept([
+            ModulePackageList::SYMFONY_PACKAGE,
+            ModulePackageList::ASYNCHRONOUS_PACKAGE,
+            ModulePackageList::KAFKA_PACKAGE,
+            ModulePackageList::DBAL_PACKAGE,
+        ]),
+        'licenceKey' => '%env(SYMFONY_LICENCE_KEY)%',
+    ]);
+
+    $services = $containerConfigurator->services();
+
+    $services->set(KafkaBrokerConfiguration::class)
+        ->factory([KafkaBrokerConfiguration::class, 'createWithDefaults'])
+        ->args([['%env(KAFKA_DSN)%']])
+        ->public();
+
+    $services->set(DbalConnectionFactory::class)
+        ->args(['%env(DATABASE_DSN)%'])
+        ->public();
+
+    $services->load('Symfony\\App\\EnvPlaceholderKafka\\', '%kernel.project_dir%/src/')
+        ->autowire()
+        ->autoconfigure();
+};

--- a/packages/Symfony/tests/phpunit/EnvPlaceholderKafka/src/Configuration/EcotoneConfiguration.php
+++ b/packages/Symfony/tests/phpunit/EnvPlaceholderKafka/src/Configuration/EcotoneConfiguration.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symfony\App\EnvPlaceholderKafka\Configuration;
+
+use Ecotone\Kafka\Configuration\KafkaPublisherConfiguration;
+use Ecotone\Messaging\Attribute\ServiceContext;
+
+/**
+ * licence Enterprise
+ */
+final class EcotoneConfiguration
+{
+    #[ServiceContext]
+    public function kafkaPublisher(): KafkaPublisherConfiguration
+    {
+        return KafkaPublisherConfiguration::createWithDefaults('orders.topic.' . getenv('ECOTONE_KAFKA_SUFFIX'))
+            ->withHeaderMapper('*');
+    }
+}

--- a/packages/Symfony/tests/phpunit/EnvPlaceholderKafka/src/Configuration/Kernel.php
+++ b/packages/Symfony/tests/phpunit/EnvPlaceholderKafka/src/Configuration/Kernel.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Symfony\App\EnvPlaceholderKafka\Configuration;
+
+use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;
+
+/**
+ * licence Apache-2.0
+ */
+class Kernel extends \Symfony\Component\HttpKernel\Kernel
+{
+    use MicroKernelTrait;
+
+    public function getProjectDir(): string
+    {
+        return __DIR__ . '/../../';
+    }
+}

--- a/packages/Symfony/tests/phpunit/EnvPlaceholderKafka/src/PlaceOrderKafkaConsumer.php
+++ b/packages/Symfony/tests/phpunit/EnvPlaceholderKafka/src/PlaceOrderKafkaConsumer.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symfony\App\EnvPlaceholderKafka;
+
+use Ecotone\Kafka\Attribute\KafkaConsumer;
+use Ecotone\Messaging\Attribute\Parameter\Payload;
+use Ecotone\Modelling\Attribute\QueryHandler;
+
+/**
+ * licence Enterprise
+ */
+final class PlaceOrderKafkaConsumer
+{
+    /** @var string[] */
+    private array $consumedPayloads = [];
+
+    #[KafkaConsumer('ordersKafkaConsumer', 'orders.topic.%env(ECOTONE_KAFKA_SUFFIX)%')]
+    public function handle(#[Payload] string $payload): void
+    {
+        $this->consumedPayloads[] = $payload;
+    }
+
+    /**
+     * @return string[]
+     */
+    #[QueryHandler('ordersKafka.consumedPayloads')]
+    public function consumedPayloads(): array
+    {
+        return $this->consumedPayloads;
+    }
+}


### PR DESCRIPTION
## Why is this change proposed?

Since 1.313.0, consuming messages in a **Symfony** application fails with `DefinitionHelper::unserializeSerializedObject(): Return value must be of type object, false returned` whenever an attribute contains an environment placeholder — e.g. `#[KafkaConsumer(topics: 'orders.%env(SUFFIX)%')]` or `#[Asynchronous(asynchronousExecution: [new ErrorChannel('%env(ERROR_CHANNEL)%')])]`.

Ecotone stored such attributes as PHP-`serialize()`d strings in the container. Symfony then rewrites the `%...%` placeholder inside that string during container compilation, which changes the string's byte length but **not** the serialized length prefix (`s:NN:"…"`), so `unserialize()` returns `false` and the consumer/handler can never be built. It only reproduces under a real Symfony container (Symfony resolves `%...%` in service arguments). Fixes #669.

## Description of Changes

- `DefinitionHelper` now builds attribute container definitions from `DefinedObject::getDefinition()` (a structured class + arguments) instead of `serialize()`, so each placeholder-bearing string is a normal container argument that Symfony resolves correctly — no length-prefix corruption, and the environment value is still applied.
- `#[Asynchronous]`, `#[ErrorChannel]`, `#[DelayedRetry]`, `#[WithoutMessageCollector]`, `#[WithoutDatabaseTransaction]` now implement `DefinedObject` (`#[KafkaConsumer]` already did). All `AsynchronousEndpointAttribute` elements must be `DefinedObject` because `#[Asynchronous]` now exposes `asynchronousExecution` structurally.
- Scoped to the attribute paths only (`buildAttributeDefinitionFromInstance` + `resolvePotentialComplexAttribute`); the generic `buildDefinitionFromInstance` is left as-is to avoid affecting service configurations.
- Added booted-kernel Symfony regression tests for both cases; the Kafka test publishes to and consumes from an env-placeholder topic end-to-end.
- Added `ecotone/kafka` + `ext-rdkafka` to the Symfony package `require-dev`.

### Usage examples

```php
// Kafka consumer with an environment-driven topic name
final class OrderConsumer
{
    #[KafkaConsumer('orders', topics: 'orders.%env(ENV_SUFFIX)%')]
    public function handle(string $payload): void
    {
        // ENV_SUFFIX=production  -> subscribes to "orders.production"
    }
}

// Async command handler with an environment-driven error channel
final class OrderHandler
{
    #[Asynchronous('orders', asynchronousExecution: [new ErrorChannel('errors.%env(ERROR_CHANNEL)%')])]
    #[CommandHandler('order.place')]
    public function place(PlaceOrder $command): void
    {
        // ERROR_CHANNEL=high_priority -> failures route to "errors.high_priority"
    }
}
```

### Use cases

- Per-environment Kafka topic naming (`orders.staging` vs `orders.production`) driven by env vars.
- Configuring an error / dead-letter channel name from the environment.
- Any attribute argument that should be sourced from `%env(...)%` in a Symfony app.

### Flow

```mermaid
sequenceDiagram
    participant App as Symfony container (compile)
    participant Runtime
    Note over App: Before — serialize() blob: s:28:"orders.%env(SUFFIX)%"
    App->>Runtime: %env% resolved inside blob -> s:28:"orders.production" (length mismatch) -> unserialize() = false
    Note over App: After — structured Definition arg: "orders.%env(SUFFIX)%"
    App->>Runtime: %env% resolved as a whole argument -> new KafkaConsumer('orders.production')
```

## Pull Request Contribution Terms

- [X] I have read and agree to the contribution terms outlined in [CONTRIBUTING](https://github.com/ecotoneframework/ecotone-dev/blob/main/CONTRIBUTING.md).