### PR TITLE
feat(tempest): add ecotone/tempest framework integration package

### DIFF
--- a/.github/workflows/benchmark-pr.yml
+++ b/.github/workflows/benchmark-pr.yml
@@ -98,6 +98,9 @@ jobs:
         run: |
           git clean -fxd -e .phpbench -e vendor
 
+      - name: Remove tempest/framework (requires PHP 8.5+, not run in benchmark)
+        run: composer remove --dev --no-update tempest/framework
+
       - name: Install dependencies
         run: composer update --${{ matrix.stability }} --prefer-dist --no-interaction
 

--- a/.github/workflows/benchmark-pr.yml
+++ b/.github/workflows/benchmark-pr.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: true # Fail the entire workflow if any job fails
       matrix:
         operating-system: [ ubuntu-latest ]
-        php-versions: [ 8.3 ]
+        php-versions: [ 8.5 ]
         stability: [prefer-stable]
     services:
       rabbitmq:
@@ -74,7 +74,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-versions }}
-          extensions: grpc, rdkafka
+          extensions: rdkafka
           coverage: none
 
       - uses: actions/checkout@v3
@@ -82,7 +82,7 @@ jobs:
           ref: main
 
       - name: Install dependencies
-        run: composer update --${{ matrix.stability }} --prefer-dist --no-interaction
+        run: composer update --${{ matrix.stability }} --prefer-dist --no-interaction --ignore-platform-reqs
 
       - name: Benchmark main as baseline
         id: baseline
@@ -98,11 +98,8 @@ jobs:
         run: |
           git clean -fxd -e .phpbench -e vendor
 
-      - name: Remove tempest/framework (requires PHP 8.5+, not run in benchmark)
-        run: composer remove --dev --no-update tempest/framework
-
       - name: Install dependencies
-        run: composer update --${{ matrix.stability }} --prefer-dist --no-interaction
+        run: composer update --${{ matrix.stability }} --prefer-dist --no-interaction --ignore-platform-reqs
 
       - name: Benchmark PR
         shell: bash

--- a/.github/workflows/file-licence.yml
+++ b/.github/workflows/file-licence.yml
@@ -24,6 +24,9 @@ jobs:
         with:
           php-version: 8.2
 
+      - name: Remove tempest/framework (requires PHP 8.5+; its function files fail to parse on 8.2)
+        run: composer remove --dev --no-update tempest/framework
+
       - name: Install dependencies
         run: composer update --prefer-dist --no-interaction --ignore-platform-reqs
 

--- a/.github/workflows/file-licence.yml
+++ b/.github/workflows/file-licence.yml
@@ -22,10 +22,7 @@ jobs:
       - name: Set Up PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.2
-
-      - name: Remove tempest/framework (requires PHP 8.5+; its function files fail to parse on 8.2)
-        run: composer remove --dev --no-update tempest/framework
+          php-version: 8.5
 
       - name: Install dependencies
         run: composer update --prefer-dist --no-interaction --ignore-platform-reqs

--- a/.github/workflows/split-testing.yml
+++ b/.github/workflows/split-testing.yml
@@ -134,10 +134,10 @@ jobs:
       - name: Run tests
         run: |
           COMPONENTS=$(find packages -maxdepth 2 -type f -name phpunit.xml.dist | xargs -I{} dirname {})
-          # ecotone/tempest depends on tempest/framework which requires PHP 8.5+; skip it on lower PHP versions
-          if [ "${{ matrix.php-version }}" != "8.5" ]; then
-            COMPONENTS=$(echo "$COMPONENTS" | grep -v 'packages/Tempest')
-          fi
+          # ecotone/tempest needs PHP 8.5+ (tempest/framework) and its integration tests use a
+          # kernel-boot harness tied to the monorepo layout; it is covered by the unified Monorepo
+          # job, so exclude it from the isolated per-package Split Testing matrix.
+          COMPONENTS=$(echo "$COMPONENTS" | grep -v 'packages/Tempest')
           RUN_TESTS="composer tests:ci"
 
           if [ "${{ matrix.stability }}" = "prefer-lowest" ]; then

--- a/.github/workflows/split-testing.yml
+++ b/.github/workflows/split-testing.yml
@@ -134,6 +134,10 @@ jobs:
       - name: Run tests
         run: |
           COMPONENTS=$(find packages -maxdepth 2 -type f -name phpunit.xml.dist | xargs -I{} dirname {})
+          # ecotone/tempest depends on tempest/framework which requires PHP 8.5+; skip it on lower PHP versions
+          if [ "${{ matrix.php-version }}" != "8.5" ]; then
+            COMPONENTS=$(echo "$COMPONENTS" | grep -v 'packages/Tempest')
+          fi
           RUN_TESTS="composer tests:ci"
 
           if [ "${{ matrix.stability }}" = "prefer-lowest" ]; then
@@ -210,8 +214,9 @@ jobs:
                 overall_exit_code=1
               fi
 
-              # Run SQLite pass (skip for PdoEventSourcing and DataProtection - SQLite event store not supported)
-              if [[ ! "$dir" =~ (PdoEventSourcing|DataProtection) ]]; then
+              # Run SQLite pass (skip for PdoEventSourcing and DataProtection - SQLite event store not supported;
+              # skip Tempest - its multi-tenant tests need two distinct Postgres/MySQL engines)
+              if [[ ! "$dir" =~ (PdoEventSourcing|DataProtection|Tempest) ]]; then
                 local sqlite_db="/tmp/ecotone_${slug}_test.db"
                 local sqlite_db_secondary="/tmp/ecotone_${slug}_test_b.db"
                 # Use 4 slashes for absolute paths: sqlite:// + / + /path = sqlite:////path

--- a/composer.json
+++ b/composer.json
@@ -126,6 +126,7 @@
             ],
             "Test\\Ecotone\\Laravel\\": "packages/Laravel/tests",
             "Test\\Ecotone\\Tempest\\": "packages/Tempest/tests",
+            "App\\Tempest\\": "packages/Tempest/tests/app/src",
             "App\\MultiTenant\\": "packages/Laravel/tests/MultiTenant/app",
             "App\\Licence\\Laravel\\": "packages/Laravel/tests/Licence/app",
             "Symfony\\App\\MultiTenant\\": "packages/Symfony/tests/phpunit/MultiTenant/src",

--- a/composer.json
+++ b/composer.json
@@ -64,6 +64,7 @@
             "Ecotone\\Redis\\": "packages/Redis/src",
             "Ecotone\\Sqs\\": "packages/Sqs/src",
             "Ecotone\\Laravel\\": "packages/Laravel/src",
+            "Ecotone\\Tempest\\": "packages/Tempest/src",
             "Ecotone\\Lite\\": [
                 "packages/Ecotone/src/Lite/",
                 "packages/LiteApplication/src"
@@ -124,6 +125,7 @@
                 "packages/Kafka/tests"
             ],
             "Test\\Ecotone\\Laravel\\": "packages/Laravel/tests",
+            "Test\\Ecotone\\Tempest\\": "packages/Tempest/tests",
             "App\\MultiTenant\\": "packages/Laravel/tests/MultiTenant/app",
             "App\\Licence\\Laravel\\": "packages/Laravel/tests/Licence/app",
             "Symfony\\App\\MultiTenant\\": "packages/Symfony/tests/phpunit/MultiTenant/src",
@@ -171,7 +173,7 @@
         "guzzlehttp/psr7": "^2.0",
         "orchestra/testbench": "^8.0|^9.0|^10.0|^11.0",
         "php-coveralls/php-coveralls": "^2.5",
-        "phpstan/phpstan": "^1.8",
+        "phpstan/phpstan": "^1.8|^2.0",
         "phpunit/phpunit": "^11.0",
         "predis/predis": "^1.1.10",
         "symfony/expression-language": "^6.4|^7.0|^8.0",
@@ -193,7 +195,8 @@
         "kwn/php-rdkafka-stubs": "^2.2",
         "symfony/var-exporter": "^6.4|^7.0|^8.0",
         "enqueue/dsn": "^0.10.27",
-        "yoast/phpunit-polyfills": "^4.0.0"
+        "yoast/phpunit-polyfills": "^4.0.0",
+        "tempest/framework": "^3.11"
     },
     "suggest": {
         "ext-simplexml": "Required if application/xml is used as serialization media type"
@@ -226,6 +229,7 @@
         "ecotone/enqueue": "1.82.0",
         "ecotone/jms-converter": "1.82.0",
         "ecotone/laravel": "1.82.0",
+        "ecotone/tempest": "1.82.0",
         "ecotone/pdo-event-sourcing": "1.82.0",
         "ecotone/symfony-bundle": "1.82.0"
     },

--- a/packages/Ecotone/src/Messaging/Config/ModuleClassList.php
+++ b/packages/Ecotone/src/Messaging/Config/ModuleClassList.php
@@ -81,6 +81,7 @@ use Ecotone\Sqs\Configuration\SqsMessageConsumerModule;
 use Ecotone\Sqs\Configuration\SqsMessagePublisherModule;
 use Ecotone\Sqs\Configuration\SqsModule;
 use Ecotone\SymfonyBundle\Config\SymfonyConnectionModule;
+use Ecotone\Tempest\Config\TempestConnectionModule;
 
 /**
  * licence Apache-2.0
@@ -200,6 +201,10 @@ class ModuleClassList
 
     public const SYMFONY_MODULES = [
         SymfonyConnectionModule::class,
+    ];
+
+    public const TEMPEST_MODULES = [
+        TempestConnectionModule::class,
     ];
 
     public const KAFKA_MODULES = [

--- a/packages/Ecotone/src/Messaging/Config/ModulePackageList.php
+++ b/packages/Ecotone/src/Messaging/Config/ModulePackageList.php
@@ -25,6 +25,7 @@ final class ModulePackageList
     public const TRACING_PACKAGE = 'tracing';
     public const LARAVEL_PACKAGE = 'laravel';
     public const SYMFONY_PACKAGE = 'symfony';
+    public const TEMPEST_PACKAGE = 'tempest';
     public const TEST_PACKAGE = 'test';
 
     public static function getModuleClassesForPackage(string $packageName): array
@@ -43,6 +44,7 @@ final class ModulePackageList
             ModulePackageList::TEST_PACKAGE => ModuleClassList::TEST_MODULES,
             ModulePackageList::LARAVEL_PACKAGE => ModuleClassList::LARAVEL_MODULES,
             ModulePackageList::SYMFONY_PACKAGE => ModuleClassList::SYMFONY_MODULES,
+            ModulePackageList::TEMPEST_PACKAGE => ModuleClassList::TEMPEST_MODULES,
             ModulePackageList::DATA_PROTECTION_PACKAGE => ModuleClassList::DATA_PROTECTION_MODULES,
             default => throw ConfigurationException::create(sprintf('Given unknown package name %s. Available packages name are: %s', $packageName, implode(',', self::allPackages())))
         };
@@ -66,6 +68,7 @@ final class ModulePackageList
             self::TRACING_PACKAGE,
             self::LARAVEL_PACKAGE,
             self::SYMFONY_PACKAGE,
+            self::TEMPEST_PACKAGE,
             self::DATA_PROTECTION_PACKAGE,
         ];
     }

--- a/packages/Ecotone/src/Messaging/MessageHeaders.php
+++ b/packages/Ecotone/src/Messaging/MessageHeaders.php
@@ -283,11 +283,8 @@ final class MessageHeaders
     {
         unset(
             $metadata[MessageBusChannel::COMMAND_CHANNEL_NAME_BY_NAME],
-            $metadata[MessageBusChannel::COMMAND_CHANNEL_NAME_BY_OBJECT],
             $metadata[MessageBusChannel::EVENT_CHANNEL_NAME_BY_NAME],
-            $metadata[MessageBusChannel::EVENT_CHANNEL_NAME_BY_OBJECT],
-            $metadata[MessageBusChannel::QUERY_CHANNEL_NAME_BY_NAME],
-            $metadata[MessageBusChannel::QUERY_CHANNEL_NAME_BY_OBJECT]
+            $metadata[MessageBusChannel::QUERY_CHANNEL_NAME_BY_NAME]
         );
 
         return $metadata;

--- a/packages/Tempest/.gitattributes
+++ b/packages/Tempest/.gitattributes
@@ -1,0 +1,7 @@
+tests/          export-ignore
+.coveralls.yml  export-ignore
+.gitattributes  export-ignore
+.gitignore      export-ignore
+behat.yaml      export-ignore
+phpstan.neon    export-ignore
+phpunit.xml     export-ignore

--- a/packages/Tempest/.github/FUNDING.yml
+++ b/packages/Tempest/.github/FUNDING.yml
@@ -1,0 +1,12 @@
+# These are supported funding model platforms
+
+github: [dgafka]
+patreon: # Replace with a single Open Collective username
+open_collective: # Replace with a single Open Collective username
+ko_fi: # Replace with a single Ko-fi username
+tidelift: # Replace with a single Tidelift platform-name/package-name e.g., npm/babel
+community_bridge: # Replace with a single Community Bridge project-name e.g., cloud-foundry
+liberapay: # Replace with a single Liberapay username
+issuehunt: # Replace with a single IssueHunt username
+otechie: # Replace with a single Otechie username
+custom: # Replace with up to 4 custom sponsorship URLs e.g., ['link1', 'link2']

--- a/packages/Tempest/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/packages/Tempest/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,10 @@
+---
+name: This is Read-Only repository
+about: Report at ecotoneframework/ecotone-dev
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+Report issue at [ecotone-dev](ecotoneframework/ecotone-dev)

--- a/packages/Tempest/.gitignore
+++ b/packages/Tempest/.gitignore
@@ -1,0 +1,9 @@
+.idea/
+vendor/
+bin/
+tests/coverage
+!tests/coverage/.gitkeep
+file
+.phpunit.result.cache
+composer.lock
+phpunit.xml

--- a/packages/Tempest/LICENSE
+++ b/packages/Tempest/LICENSE
@@ -1,0 +1,21 @@
+Copyright (c) 2025 Dariusz Gafka <support@simplycodedsoftware.com>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+**Scope of the License**
+
+Apache-2.0 Licence applies to non Enterprise Functionalities of the Ecotone Framework.
+Functionalities of the Ecotone Framework referred to as Enterprise functionalities, are not covered under the Apache-2.0 license. These functionalities are provided under a separate Enterprise License.
+For details on the Enterprise License, please refer to the [LICENSE-ENTERPRISE](./LICENSE-ENTERPRISE) file.

--- a/packages/Tempest/LICENSE-ENTERPRISE
+++ b/packages/Tempest/LICENSE-ENTERPRISE
@@ -1,0 +1,3 @@
+Copyright (c) 2025 Dariusz Gafka <support@simplycodedsoftware.com>
+
+Licence is available at [ecotone.tech/documents/ecotone_enterprise_licence.pdf](https://ecotone.tech/documents/ecotone_enterprise_licence.pdf)

--- a/packages/Tempest/README.md
+++ b/packages/Tempest/README.md
@@ -6,34 +6,298 @@ To contribute make use of [Ecotone-Dev repository](https://github.com/ecotonefra
 </a></p>
 
 ![Github Actions](https://github.com/ecotoneFramework/ecotone-dev/actions/workflows/split-testing.yml/badge.svg)
-[![Latest Stable Version](https://poser.pugx.org/ecotone/ecotone/v/stable)](https://packagist.org/packages/ecotone/ecotone)
-[![License](https://poser.pugx.org/ecotone/ecotone/license)](https://packagist.org/packages/ecotone/ecotone)
-[![Total Downloads](https://img.shields.io/packagist/dt/ecotone/ecotone)](https://packagist.org/packages/ecotone/ecotone)
-[![PHP Version Require](https://img.shields.io/packagist/dependency-v/ecotone/ecotone/php.svg)](https://packagist.org/packages/ecotone/ecotone)
+[![Latest Stable Version](https://poser.pugx.org/ecotone/tempest/v/stable)](https://packagist.org/packages/ecotone/tempest)
+[![License](https://poser.pugx.org/ecotone/tempest/license)](https://packagist.org/packages/ecotone/tempest)
+[![Total Downloads](https://img.shields.io/packagist/dt/ecotone/tempest)](https://packagist.org/packages/ecotone/tempest)
+[![PHP Version Require](https://img.shields.io/packagist/dependency-v/ecotone/tempest/php.svg)](https://packagist.org/packages/ecotone/tempest)
 
 **Ecotone is the PHP architecture layer that grows with your system — without rewrites.**
 
 From `#[CommandHandler]` on day one, to event sourcing, sagas, outbox, and distributed messaging at scale — one package, same codebase, no forced migrations between growth stages. Declarative PHP 8 attributes on the classes you already have.
 
-## {{Package name}}
+## ecotone/tempest
 
-{{One-paragraph description of what this package adds to Ecotone and the primary use case.}}
+Ecotone for [Tempest](https://tempestphp.com) — CQRS, Event Sourcing, Sagas, Durable Workflows, and Outbox via PHP attributes. Zero-config auto-discovery derives your application namespaces from your `composer.json` PSR-4 roots. Handlers, aggregates, sagas, and projections are found automatically without any registration boilerplate.
 
-- {{Key capability 1}}
-- {{Key capability 2}}
-- {{Key capability 3}}
+- Zero-config auto-discovery of handlers from your app's PSR-4 namespaces
+- CQRS — `CommandBus`, `QueryBus`, `EventBus` available via dependency injection
+- Database integration via `ecotone/dbal` with Tempest's `DatabaseConfig`
+- Multi-tenant connections with per-tenant database switching
+- Async messaging, sagas, outbox, event sourcing (with appropriate modules)
+- Console commands: `ecotone:list`, `ecotone:run`, `ecotone:cache:clear`
 
 Visit [ecotone.tech](https://ecotone.tech) to learn more.
 
-> Works with [Symfony](https://docs.ecotone.tech/modules/symfony-ddd-cqrs-event-sourcing), [Laravel](https://docs.ecotone.tech/modules/laravel-ddd-cqrs-event-sourcing), or any PSR-11 framework via [Ecotone Lite](https://docs.ecotone.tech/install-php-service-bus#install-ecotone-lite-no-framework).
+## Installation
 
-## Getting started
+```bash
+composer require ecotone/tempest
+```
 
-See the [quickstart guide](https://docs.ecotone.tech/quick-start) and [reference documentation](https://docs.ecotone.tech). Read more on the [Ecotone Blog](https://blog.ecotone.tech).
+Ecotone auto-discovery is enabled via Tempest's package discovery system. No service provider registration is needed.
 
-## AI-Ready documentation
+## Getting Started
 
-Ecotone ships with MCP server, Agentic Skills, and LLMs.txt for any coding agent. See the [AI Integration Guide](https://docs.ecotone.tech/other/ai-integration).
+### Zero-Config Handler Discovery
+
+Ecotone derives your application namespaces from the PSR-4 roots declared in your `composer.json`. Any class with an Ecotone attribute (`#[CommandHandler]`, `#[QueryHandler]`, `#[EventHandler]`, etc.) in those namespaces is discovered automatically.
+
+```php
+// src/Order/PlaceOrderHandler.php
+namespace App\Order;
+
+use Ecotone\Modelling\Attribute\CommandHandler;
+use Ecotone\Modelling\Attribute\QueryHandler;
+
+final class PlaceOrderHandler
+{
+    private array $orders = [];
+
+    #[CommandHandler('order.place')]
+    public function place(string $orderId): void
+    {
+        $this->orders[] = $orderId;
+    }
+
+    #[QueryHandler('order.all')]
+    public function all(): array
+    {
+        return $this->orders;
+    }
+}
+```
+
+That is all that is needed. No configuration file, no registration — Ecotone discovers it from your namespace.
+
+### Using the Buses
+
+`CommandBus`, `QueryBus`, and `EventBus` are automatically registered in the Tempest container and can be injected anywhere:
+
+```php
+use Ecotone\Modelling\CommandBus;
+use Ecotone\Modelling\QueryBus;
+
+final class OrderController
+{
+    public function __construct(
+        private CommandBus $commandBus,
+        private QueryBus $queryBus,
+    ) {}
+
+    public function place(string $orderId): array
+    {
+        $this->commandBus->sendWithRouting('order.place', $orderId);
+
+        return $this->queryBus->sendWithRouting('order.all');
+    }
+}
+```
+
+## Optional Configuration
+
+Create a class that provides `EcotoneConfig` to the Tempest container to customise behaviour:
+
+```php
+// src/Configuration/EcotoneConfiguration.php
+namespace App\Configuration;
+
+use Ecotone\Tempest\EcotoneConfig;
+use Tempest\Container\Singleton;
+
+#[Singleton]
+final class EcotoneConfiguration
+{
+    public function ecotoneConfig(): EcotoneConfig
+    {
+        return new EcotoneConfig(
+            serviceName: 'my-service',
+            licenceKey: getenv('ECOTONE_LICENCE_KEY') ?: '',
+            cacheConfiguration: true,
+        );
+    }
+}
+```
+
+Or simply bind `EcotoneConfig` in a Tempest config file:
+
+```php
+// config/ecotone.php  (or any #[ServiceContext] provider)
+use Ecotone\Tempest\EcotoneConfig;
+
+return new EcotoneConfig(
+    serviceName: 'my-service',
+    licenceKey: getenv('ECOTONE_LICENCE_KEY') ?: '',
+);
+```
+
+### `EcotoneConfig` Reference
+
+| Property | Type | Default | Description |
+|---|---|---|---|
+| `serviceName` | `string` | `''` (from `ECOTONE_SERVICE_NAME` env) | Identifies this service in distributed tracing and logs |
+| `namespaces` | `array` | `[]` | Explicit namespaces to scan. When empty and `loadAppNamespaces` is true, derived from `composer.json` |
+| `loadAppNamespaces` | `bool` | `true` | Auto-derive scan namespaces from your app's PSR-4 roots |
+| `cacheConfiguration` | `bool` | `false` (from `ECOTONE_CACHE_CONFIGURATION` env) | Cache the messaging system definition for production |
+| `defaultSerializationMediaType` | `string` | `''` | Override the default message serialization format |
+| `defaultErrorChannel` | `string` | `''` | Channel name for unhandled async exceptions |
+| `skippedModulePackageNames` | `array` | `[]` | Module packages to skip loading (useful for testing) |
+| `licenceKey` | `string` | `''` | Enterprise licence key |
+
+## Console Commands
+
+Ecotone registers Tempest console commands automatically:
+
+```bash
+# List all registered consumers and handlers
+./tempest ecotone:list
+
+# Run an asynchronous consumer (requires ecotone/dbal or another async transport)
+./tempest ecotone:run notifications
+
+# Clear the Ecotone configuration cache
+./tempest ecotone:cache:clear
+```
+
+The `ecotone:cache:clear` command removes the cached messaging system definition from `sys_get_temp_dir()/ecotone_tempest/`. Use it after deploying changes when `cacheConfiguration` is enabled.
+
+## Database Integration (requires `ecotone/dbal`)
+
+Install the DBAL module:
+
+```bash
+composer require ecotone/dbal
+```
+
+### Single-Tenant Connection
+
+Register a `TempestConnectionReference` via `#[ServiceContext]` to bridge Tempest's `DatabaseConfig` to Ecotone's DBAL module:
+
+```php
+use Ecotone\Messaging\Attribute\ServiceContext;
+use Ecotone\Tempest\Config\TempestConnectionReference;
+
+final class EcotoneConfiguration
+{
+    #[ServiceContext]
+    public function dbalConnection(): TempestConnectionReference
+    {
+        return TempestConnectionReference::defaultConnection();
+    }
+}
+```
+
+`TempestConnectionReference::defaultConnection()` resolves Tempest's default `DatabaseConfig` from the container at runtime.
+
+To use a specific config:
+
+```php
+use Tempest\Database\Config\PostgresConfig;
+
+#[ServiceContext]
+public function dbalConnection(): TempestConnectionReference
+{
+    return TempestConnectionReference::create('myConnection', new PostgresConfig(
+        host: getenv('DB_HOST') ?: 'localhost',
+        port: getenv('DB_PORT') ?: '5432',
+        username: getenv('DB_USER') ?: 'app',
+        password: getenv('DB_PASSWORD') ?: '',
+        database: getenv('DB_NAME') ?: 'app',
+    ));
+}
+```
+
+### Multi-Tenant Connection
+
+Use `MultiTenantConfiguration` together with per-tenant `TempestConnectionReference` instances. A `tenant` header on each message selects the correct database:
+
+```php
+use Ecotone\Dbal\MultiTenant\MultiTenantConfiguration;
+use Ecotone\Messaging\Attribute\ServiceContext;
+use Ecotone\Tempest\Config\TempestConnectionReference;
+use Tempest\Database\Config\MysqlConfig;
+use Tempest\Database\Config\PostgresConfig;
+
+final class EcotoneConfiguration
+{
+    #[ServiceContext]
+    public function multiTenantConfiguration(): MultiTenantConfiguration
+    {
+        return MultiTenantConfiguration::create(
+            tenantHeaderName: 'tenant',
+            tenantToConnectionMapping: [
+                'tenant_a' => TempestConnectionReference::create('tenant_a', new PostgresConfig(
+                    host: getenv('TENANT_A_DB_HOST'),
+                    username: getenv('TENANT_A_DB_USER'),
+                    password: getenv('TENANT_A_DB_PASSWORD'),
+                    database: getenv('TENANT_A_DB_NAME'),
+                )),
+                'tenant_b' => TempestConnectionReference::create('tenant_b', new MysqlConfig(
+                    host: getenv('TENANT_B_DB_HOST'),
+                    username: getenv('TENANT_B_DB_USER'),
+                    password: getenv('TENANT_B_DB_PASSWORD'),
+                    database: getenv('TENANT_B_DB_NAME'),
+                )),
+            ],
+        );
+    }
+}
+```
+
+Route commands to the correct tenant by setting the header:
+
+```php
+$commandBus->sendWithRouting('order.place', $order, metadata: ['tenant' => 'tenant_a']);
+```
+
+> **Security note:** When `cacheConfiguration` is enabled, the `DatabaseConfig` for each
+> `TempestConnectionReference::create(name, config)` call is serialized into the on-disk cache
+> file. This means database credentials (username, password, DSN) are written to disk in
+> base64-encoded serialized form. Keep the cache directory (`sys_get_temp_dir()/ecotone_tempest/`)
+> non-world-readable and rotate credentials if the cache file is exposed. Use
+> `./tempest ecotone:cache:clear` after credential rotation.
+
+## Production Caching
+
+Enable the configuration cache for production to avoid re-scanning annotations on every request:
+
+```php
+new EcotoneConfig(
+    cacheConfiguration: true,
+);
+```
+
+Or set the `ECOTONE_CACHE_CONFIGURATION=1` environment variable. The cache is stored in `sys_get_temp_dir()/ecotone_tempest/`. Clear it after deployment:
+
+```bash
+./tempest ecotone:cache:clear
+```
+
+When `APP_ENV=prod` or `APP_ENV=production`, the production cache path is used automatically regardless of the `cacheConfiguration` setting.
+
+## Expression Language
+
+Ecotone supports Symfony Expression Language in `#[Payload]` and `#[Header]` attributes. The `parameter()` function reads from environment variables via `TempestConfigurationVariableService`:
+
+```php
+use Ecotone\Messaging\Attribute\Parameter\Payload;
+use Ecotone\Modelling\Attribute\CommandHandler;
+
+final class CalculatorHandler
+{
+    #[CommandHandler('calculator.multiply')]
+    public function multiply(
+        #[Payload("parameter('APP_MULTIPLIER') * payload['value']")] int $result
+    ): void {
+        // $result = APP_MULTIPLIER * payload['value']
+    }
+}
+```
+
+Requires `symfony/expression-language`:
+
+```bash
+composer require symfony/expression-language
+```
 
 ## Feature requests and issue reporting
 
@@ -57,4 +321,4 @@ If you want to help building and improving Ecotone consider becoming a sponsor:
 
 ## Tags
 
-PHP, Ecotone, {{package-specific tags}}
+PHP, Ecotone, Tempest, CQRS, Event Sourcing, Sagas, Durable Workflows, Outbox, Messaging, EIP, DDD

--- a/packages/Tempest/README.md
+++ b/packages/Tempest/README.md
@@ -1,0 +1,60 @@
+# This is Read Only Repository
+To contribute make use of [Ecotone-Dev repository](https://github.com/ecotoneframework/ecotone-dev).
+
+<p align="left"><a href="https://ecotone.tech" target="_blank">
+    <img src="https://github.com/ecotoneframework/ecotone-dev/blob/main/ecotone_small.png?raw=true">
+</a></p>
+
+![Github Actions](https://github.com/ecotoneFramework/ecotone-dev/actions/workflows/split-testing.yml/badge.svg)
+[![Latest Stable Version](https://poser.pugx.org/ecotone/ecotone/v/stable)](https://packagist.org/packages/ecotone/ecotone)
+[![License](https://poser.pugx.org/ecotone/ecotone/license)](https://packagist.org/packages/ecotone/ecotone)
+[![Total Downloads](https://img.shields.io/packagist/dt/ecotone/ecotone)](https://packagist.org/packages/ecotone/ecotone)
+[![PHP Version Require](https://img.shields.io/packagist/dependency-v/ecotone/ecotone/php.svg)](https://packagist.org/packages/ecotone/ecotone)
+
+**Ecotone is the PHP architecture layer that grows with your system — without rewrites.**
+
+From `#[CommandHandler]` on day one, to event sourcing, sagas, outbox, and distributed messaging at scale — one package, same codebase, no forced migrations between growth stages. Declarative PHP 8 attributes on the classes you already have.
+
+## {{Package name}}
+
+{{One-paragraph description of what this package adds to Ecotone and the primary use case.}}
+
+- {{Key capability 1}}
+- {{Key capability 2}}
+- {{Key capability 3}}
+
+Visit [ecotone.tech](https://ecotone.tech) to learn more.
+
+> Works with [Symfony](https://docs.ecotone.tech/modules/symfony-ddd-cqrs-event-sourcing), [Laravel](https://docs.ecotone.tech/modules/laravel-ddd-cqrs-event-sourcing), or any PSR-11 framework via [Ecotone Lite](https://docs.ecotone.tech/install-php-service-bus#install-ecotone-lite-no-framework).
+
+## Getting started
+
+See the [quickstart guide](https://docs.ecotone.tech/quick-start) and [reference documentation](https://docs.ecotone.tech). Read more on the [Ecotone Blog](https://blog.ecotone.tech).
+
+## AI-Ready documentation
+
+Ecotone ships with MCP server, Agentic Skills, and LLMs.txt for any coding agent. See the [AI Integration Guide](https://docs.ecotone.tech/other/ai-integration).
+
+## Feature requests and issue reporting
+
+Use [issue tracking system](https://github.com/ecotoneframework/ecotone-dev/issues) for new feature request and bugs.
+Please verify that it's not already reported by someone else.
+
+## Contact
+
+If you want to talk or ask questions about Ecotone
+
+- [**Twitter**](https://twitter.com/EcotonePHP)
+- **support@simplycodedsoftware.com**
+- [**Community Channel**](https://discord.gg/GwM2BSuXeg)
+
+## Support Ecotone
+
+If you want to help building and improving Ecotone consider becoming a sponsor:
+
+- [Sponsor Ecotone](https://github.com/sponsors/dgafka)
+- [Contribute to Ecotone](https://github.com/ecotoneframework/ecotone-dev).
+
+## Tags
+
+PHP, Ecotone, {{package-specific tags}}

--- a/packages/Tempest/composer.json
+++ b/packages/Tempest/composer.json
@@ -45,7 +45,8 @@
     },
     "autoload-dev": {
         "psr-4": {
-            "Test\\Ecotone\\Tempest\\": "tests"
+            "Test\\Ecotone\\Tempest\\": "tests",
+            "App\\Tempest\\": "tests/app/src"
         }
     },
     "require": {
@@ -60,7 +61,9 @@
     "require-dev": {
         "phpunit/phpunit": "^11.0",
         "phpstan/phpstan": "^1.8|^2.0",
-        "symfony/expression-language": "^6.4|^7.0|^8.0"
+        "symfony/expression-language": "^6.4|^7.0|^8.0",
+        "ecotone/dbal": "~1.315.0",
+        "doctrine/dbal": "^4.0"
     },
     "scripts": {
         "tests:phpstan": "vendor/bin/phpstan",

--- a/packages/Tempest/composer.json
+++ b/packages/Tempest/composer.json
@@ -50,7 +50,7 @@
     },
     "require": {
         "php": "^8.4",
-        "ecotone/ecotone": "~1.314.0",
+        "ecotone/ecotone": "~1.315.0",
         "tempest/framework": "^3.11"
     },
     "suggest": {
@@ -59,7 +59,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^11.0",
-        "phpstan/phpstan": "^1.8",
+        "phpstan/phpstan": "^1.8|^2.0",
         "symfony/expression-language": "^6.4|^7.0|^8.0"
     },
     "scripts": {
@@ -74,7 +74,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-main": "1.314.0-dev"
+            "dev-main": "1.315.0-dev"
         },
         "ecotone": {
             "repository": "tempest"

--- a/packages/Tempest/composer.json
+++ b/packages/Tempest/composer.json
@@ -53,6 +53,10 @@
         "ecotone/ecotone": "~1.314.0",
         "tempest/framework": "^3.11"
     },
+    "suggest": {
+        "ecotone/dbal": "Enables DBAL integration, database repositories, multi-tenant connections via TempestConnectionReference, and the DbalModule for transactional outbox, sagas, and event sourcing backed by relational databases.",
+        "enqueue/dbal": "DBAL-backed message queue transport; required if you want durable async messaging over a relational database using ecotone/dbal."
+    },
     "require-dev": {
         "phpunit/phpunit": "^11.0",
         "phpstan/phpstan": "^1.8",

--- a/packages/Tempest/composer.json
+++ b/packages/Tempest/composer.json
@@ -1,0 +1,93 @@
+{
+    "name": "ecotone/tempest",
+    "license": [
+        "Apache-2.0",
+        "proprietary"
+    ],
+    "homepage": "https://docs.ecotone.tech/",
+    "forum": "https://discord.gg/GwM2BSuXeg",
+    "type": "library",
+    "minimum-stability": "dev",
+    "prefer-stable": true,
+    "authors": [
+        {
+            "name": "Dariusz Gafka",
+            "email": "support@simplycodedsoftware.com"
+        }
+    ],
+    "keywords": [
+        "ddd",
+        "cqrs",
+        "tempest",
+        "event-sourcing",
+        "sagas",
+        "durable-workflows",
+        "workflow",
+        "outbox",
+        "ecotone",
+        "messaging",
+        "eip"
+    ],
+    "description": "Ecotone for Tempest — CQRS, Event Sourcing, Sagas, Durable Workflows, and Outbox via PHP attributes.",
+    "repositories": [
+        {
+            "type": "path",
+            "url": "../*",
+            "options": {
+                "symlink": true
+            }
+        }
+    ],
+    "autoload": {
+        "psr-4": {
+            "Ecotone\\Tempest\\": "src"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Test\\Ecotone\\Tempest\\": "tests"
+        }
+    },
+    "require": {
+        "php": "^8.4",
+        "ecotone/ecotone": "~1.314.0",
+        "tempest/framework": "^3.11"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^11.0",
+        "phpstan/phpstan": "^1.8",
+        "symfony/expression-language": "^6.4|^7.0|^8.0"
+    },
+    "scripts": {
+        "tests:phpstan": "vendor/bin/phpstan",
+        "tests:phpunit": [
+            "vendor/bin/phpunit --no-coverage"
+        ],
+        "tests:ci": [
+            "@tests:phpstan",
+            "@tests:phpunit"
+        ]
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-main": "1.314.0-dev"
+        },
+        "ecotone": {
+            "repository": "tempest"
+        },
+        "tempest": {
+            "can-discover": true
+        },
+        "license-info": {
+            "Apache-2.0": {
+                "name": "Apache License 2.0",
+                "url": "https://github.com/ecotoneframework/ecotone-dev/blob/main/LICENSE",
+                "description": "Allows to use non Enterprise features of Ecotone. For more information please write to support@simplycodedsoftware.com"
+            },
+            "proprietary": {
+                "name": "Enterprise License",
+                "description": "Allows to use Enterprise features of Ecotone. For more information please write to support@simplycodedsoftware.com"
+            }
+        }
+    }
+}

--- a/packages/Tempest/phpstan.neon
+++ b/packages/Tempest/phpstan.neon
@@ -1,0 +1,4 @@
+parameters:
+	level: 1
+	paths:
+		- src

--- a/packages/Tempest/phpunit.xml.dist
+++ b/packages/Tempest/phpunit.xml.dist
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.5/phpunit.xsd"
+        colors="true"
+        bootstrap="../../vendor/autoload.php"
+        displayDetailsOnTestsThatTriggerWarnings="true"
+        displayDetailsOnTestsThatTriggerDeprecations="true"
+        displayDetailsOnTestsThatTriggerErrors="true"
+>
+    <source>
+        <include>
+            <directory suffix=".php">./src</directory>
+        </include>
+    </source>
+    <coverage>
+        <report>
+            <text outputFile="php://stdout" showOnlySummary="true" />
+        </report>
+    </coverage>
+    <testsuites>
+        <testsuite name="Tempest Tests">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/packages/Tempest/phpunit.xml.dist
+++ b/packages/Tempest/phpunit.xml.dist
@@ -3,7 +3,7 @@
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.5/phpunit.xsd"
         colors="true"
-        bootstrap="../../vendor/autoload.php"
+        bootstrap="vendor/autoload.php"
         displayDetailsOnTestsThatTriggerWarnings="true"
         displayDetailsOnTestsThatTriggerDeprecations="true"
         displayDetailsOnTestsThatTriggerErrors="true"

--- a/packages/Tempest/src/Config/PDO/Connection.php
+++ b/packages/Tempest/src/Config/PDO/Connection.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ecotone\Tempest\Config\PDO;
+
+use function assert;
+
+use Doctrine\DBAL\Driver\Connection as DriverConnection;
+use Doctrine\DBAL\Driver\PDO\Exception;
+use Doctrine\DBAL\Driver\PDO\Result;
+use Doctrine\DBAL\Driver\PDO\Statement;
+use Doctrine\DBAL\Driver\Result as ResultInterface;
+use Doctrine\DBAL\Driver\Statement as StatementInterface;
+use Doctrine\DBAL\ServerVersionProvider;
+use PDO;
+use PDOException;
+use PDOStatement;
+
+/**
+ * licence Apache-2.0
+ */
+final class Connection implements DriverConnection, ServerVersionProvider
+{
+    public function __construct(private PDO $pdo)
+    {
+    }
+
+    public function exec(string $statement): int
+    {
+        try {
+            $result = $this->pdo->exec($statement);
+            assert($result !== false);
+
+            return $result;
+        } catch (PDOException $e) {
+            throw Exception::new($e);
+        }
+    }
+
+    public function prepare(string $sql): StatementInterface
+    {
+        try {
+            return new Statement($this->pdo->prepare($sql));
+        } catch (PDOException $e) {
+            throw Exception::new($e);
+        }
+    }
+
+    public function query(string $sql): ResultInterface
+    {
+        try {
+            $stmt = $this->pdo->query($sql);
+            assert($stmt instanceof PDOStatement);
+
+            return new Result($stmt);
+        } catch (PDOException $e) {
+            throw Exception::new($e);
+        }
+    }
+
+    public function lastInsertId(): string|int
+    {
+        try {
+            return $this->pdo->lastInsertId();
+        } catch (PDOException $e) {
+            throw Exception::new($e);
+        }
+    }
+
+    public function beginTransaction(): void
+    {
+        $this->pdo->beginTransaction();
+    }
+
+    public function commit(): void
+    {
+        $this->pdo->commit();
+    }
+
+    public function rollBack(): void
+    {
+        $this->pdo->rollBack();
+    }
+
+    public function quote(string $value): string
+    {
+        return $this->pdo->quote($value);
+    }
+
+    public function getServerVersion(): string
+    {
+        return $this->pdo->getAttribute(PDO::ATTR_SERVER_VERSION);
+    }
+
+    public function getNativeConnection(): PDO
+    {
+        return $this->pdo;
+    }
+}

--- a/packages/Tempest/src/Config/PDO/MySqlDriver.php
+++ b/packages/Tempest/src/Config/PDO/MySqlDriver.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ecotone\Tempest\Config\PDO;
+
+use Doctrine\DBAL\Driver\AbstractMySQLDriver;
+
+/**
+ * licence Apache-2.0
+ */
+final class MySqlDriver extends AbstractMySQLDriver
+{
+    public function connect(array $params): Connection
+    {
+        return new Connection($params['pdo']);
+    }
+}

--- a/packages/Tempest/src/Config/PDO/PostgresDriver.php
+++ b/packages/Tempest/src/Config/PDO/PostgresDriver.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ecotone\Tempest\Config\PDO;
+
+use Doctrine\DBAL\Driver\AbstractPostgreSQLDriver;
+
+/**
+ * licence Apache-2.0
+ */
+final class PostgresDriver extends AbstractPostgreSQLDriver
+{
+    public function connect(array $params): Connection
+    {
+        return new Connection($params['pdo']);
+    }
+}

--- a/packages/Tempest/src/Config/PDO/SQLiteDriver.php
+++ b/packages/Tempest/src/Config/PDO/SQLiteDriver.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ecotone\Tempest\Config\PDO;
+
+use Doctrine\DBAL\Driver\AbstractSQLiteDriver;
+
+/**
+ * licence Apache-2.0
+ */
+final class SQLiteDriver extends AbstractSQLiteDriver
+{
+    public function connect(array $params): Connection
+    {
+        return new Connection($params['pdo']);
+    }
+}

--- a/packages/Tempest/src/Config/PDO/TempestDynamicDriver.php
+++ b/packages/Tempest/src/Config/PDO/TempestDynamicDriver.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ecotone\Tempest\Config\PDO;
+
+use Doctrine\DBAL\Driver\AbstractPostgreSQLDriver;
+use Doctrine\DBAL\Driver\Connection as DriverConnection;
+
+/**
+ * A Doctrine driver whose connect() returns TempestDynamicDriverConnection.
+ * Combined with closing the Doctrine Connection on tenant switch, this makes the
+ * DbalTransactionInterceptor re-resolve the current Tempest Connection singleton
+ * on every message so transactions follow the active tenant.
+ *
+ * licence Apache-2.0
+ */
+final class TempestDynamicDriver extends AbstractPostgreSQLDriver
+{
+    public function connect(array $params): DriverConnection
+    {
+        return new TempestDynamicDriverConnection();
+    }
+}

--- a/packages/Tempest/src/Config/PDO/TempestDynamicDriverConnection.php
+++ b/packages/Tempest/src/Config/PDO/TempestDynamicDriverConnection.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ecotone\Tempest\Config\PDO;
+
+use Doctrine\DBAL\Driver\Connection as DriverConnection;
+use Doctrine\DBAL\Driver\PDO\Result;
+use Doctrine\DBAL\Driver\PDO\Statement;
+use Doctrine\DBAL\Driver\Result as ResultInterface;
+use Doctrine\DBAL\Driver\Statement as StatementInterface;
+use PDO;
+use Tempest\Container\GenericContainer;
+use Tempest\Database\Connection\Connection;
+
+/**
+ * A Doctrine DriverConnection that re-resolves Tempest's default Connection singleton
+ * on every DBAL call. This allows the DbalTransactionInterceptor to transparently follow
+ * whichever PDO TempestTenantDatabaseSwitcher has promoted as the current default,
+ * so Ecotone transactions wrap Tempest ORM writes even when the active connection changes
+ * between messages (multi-tenant switching).
+ *
+ * licence Apache-2.0
+ */
+final class TempestDynamicDriverConnection implements DriverConnection
+{
+    private function pdo(): PDO
+    {
+        $connection = GenericContainer::instance()->get(Connection::class);
+        $property = new \ReflectionProperty($connection, 'pdo');
+        return $property->getValue($connection);
+    }
+
+    public function prepare(string $sql): StatementInterface
+    {
+        return new Statement($this->pdo()->prepare($sql));
+    }
+
+    public function query(string $sql): ResultInterface
+    {
+        return new Result($this->pdo()->query($sql));
+    }
+
+    public function quote(string $value): string
+    {
+        return $this->pdo()->quote($value);
+    }
+
+    public function exec(string $sql): int|string
+    {
+        $result = $this->pdo()->exec($sql);
+        return $result === false ? 0 : $result;
+    }
+
+    public function lastInsertId(): int|string
+    {
+        return $this->pdo()->lastInsertId();
+    }
+
+    public function beginTransaction(): void
+    {
+        $this->pdo()->beginTransaction();
+    }
+
+    public function commit(): void
+    {
+        $this->pdo()->commit();
+    }
+
+    public function rollBack(): void
+    {
+        $this->pdo()->rollBack();
+    }
+
+    public function getNativeConnection(): PDO
+    {
+        return $this->pdo();
+    }
+
+    public function getServerVersion(): string
+    {
+        return $this->pdo()->getAttribute(PDO::ATTR_SERVER_VERSION);
+    }
+}

--- a/packages/Tempest/src/Config/TempestConnectionModule.php
+++ b/packages/Tempest/src/Config/TempestConnectionModule.php
@@ -5,18 +5,19 @@ declare(strict_types=1);
 namespace Ecotone\Tempest\Config;
 
 use Ecotone\AnnotationFinder\AnnotationFinder;
+use Ecotone\Dbal\MultiTenant\HeaderBasedMultiTenantConnectionFactory;
+use Ecotone\Dbal\MultiTenant\MultiTenantConfiguration;
 use Ecotone\Messaging\Attribute\ModuleAnnotation;
 use Ecotone\Messaging\Config\Annotation\AnnotationModule;
 use Ecotone\Messaging\Config\Annotation\ModuleConfiguration\ExtensionObjectResolver;
 use Ecotone\Messaging\Config\Annotation\ModuleConfiguration\NoExternalConfigurationModule;
 use Ecotone\Messaging\Config\Configuration;
 use Ecotone\Messaging\Config\Container\Definition;
-use Ecotone\Messaging\Config\Container\Reference;
 use Ecotone\Messaging\Config\ModulePackageList;
 use Ecotone\Messaging\Config\ModuleReferenceSearchService;
 use Ecotone\Messaging\Handler\InterfaceToCallRegistry;
+use Ecotone\Messaging\Handler\ServiceActivator\ServiceActivatorBuilder;
 use Interop\Queue\ConnectionFactory;
-use Tempest\Database\Config\DatabaseConfig;
 
 #[ModuleAnnotation]
 /**
@@ -36,28 +37,82 @@ final class TempestConnectionModule extends NoExternalConfigurationModule implem
         foreach ($tempestConnections as $connection) {
             $messagingConfiguration->registerServiceDefinition(
                 $connection->getReferenceName(),
-                new Definition(
-                    ConnectionFactory::class,
-                    [
-                        $connection,
-                        new Reference(DatabaseConfig::class),
-                    ],
-                    [
-                        TempestConnectionResolver::class,
-                        'resolve',
-                    ]
-                )
+                $this->buildConnectionFactoryDefinition($connection)
             );
         }
+
+        if (! class_exists(HeaderBasedMultiTenantConnectionFactory::class)) {
+            return;
+        }
+
+        $multiTenantConfigurations = ExtensionObjectResolver::resolve(MultiTenantConfiguration::class, $extensionObjects);
+
+        $tempestRelatedMultiTenantConfigurations = [];
+
+        foreach ($multiTenantConfigurations as $multiTenantConfiguration) {
+            foreach ($multiTenantConfiguration->getTenantToConnectionMapping() as $connectionReference) {
+                if (! ($connectionReference instanceof TempestConnectionReference)) {
+                    continue;
+                }
+
+                $tempestRelatedMultiTenantConfigurations[$multiTenantConfiguration->getReferenceName()] = $multiTenantConfiguration;
+
+                $messagingConfiguration->registerServiceDefinition(
+                    $connectionReference->getReferenceName(),
+                    $this->buildConnectionFactoryDefinition($connectionReference)
+                );
+            }
+        }
+
+        if ($tempestRelatedMultiTenantConfigurations === []) {
+            return;
+        }
+
+        $messagingConfiguration->registerServiceDefinition(
+            TempestTenantDatabaseSwitcher::class,
+            new Definition(
+                TempestTenantDatabaseSwitcher::class,
+                [],
+                [
+                    TempestTenantDatabaseSwitcher::class,
+                    'create',
+                ]
+            )
+        );
+
+        $messagingConfiguration->registerMessageHandler(
+            ServiceActivatorBuilder::create(TempestTenantDatabaseSwitcher::class, 'switchOn')
+                ->withInputChannelName(HeaderBasedMultiTenantConnectionFactory::TENANT_ACTIVATED_CHANNEL_NAME)
+        );
+
+        $messagingConfiguration->registerMessageHandler(
+            ServiceActivatorBuilder::create(TempestTenantDatabaseSwitcher::class, 'switchOff')
+                ->withInputChannelName(HeaderBasedMultiTenantConnectionFactory::TENANT_DEACTIVATED_CHANNEL_NAME)
+        );
     }
 
     public function canHandle($extensionObject): bool
     {
-        return $extensionObject instanceof TempestConnectionReference;
+        return $extensionObject instanceof TempestConnectionReference
+            || $extensionObject instanceof MultiTenantConfiguration;
     }
 
     public function getModulePackageName(): string
     {
         return ModulePackageList::TEMPEST_PACKAGE;
+    }
+
+    private function buildConnectionFactoryDefinition(TempestConnectionReference $connection): Definition
+    {
+        return new Definition(
+            ConnectionFactory::class,
+            [
+                $connection,
+            ],
+            [
+                TempestConnectionResolver::class,
+                'resolve',
+            ]
+        );
     }
 }

--- a/packages/Tempest/src/Config/TempestConnectionModule.php
+++ b/packages/Tempest/src/Config/TempestConnectionModule.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ecotone\Tempest\Config;
+
+use Ecotone\AnnotationFinder\AnnotationFinder;
+use Ecotone\Messaging\Attribute\ModuleAnnotation;
+use Ecotone\Messaging\Config\Annotation\AnnotationModule;
+use Ecotone\Messaging\Config\Annotation\ModuleConfiguration\ExtensionObjectResolver;
+use Ecotone\Messaging\Config\Annotation\ModuleConfiguration\NoExternalConfigurationModule;
+use Ecotone\Messaging\Config\Configuration;
+use Ecotone\Messaging\Config\Container\Definition;
+use Ecotone\Messaging\Config\Container\Reference;
+use Ecotone\Messaging\Config\ModulePackageList;
+use Ecotone\Messaging\Config\ModuleReferenceSearchService;
+use Ecotone\Messaging\Handler\InterfaceToCallRegistry;
+use Interop\Queue\ConnectionFactory;
+use Tempest\Database\Config\DatabaseConfig;
+
+#[ModuleAnnotation]
+/**
+ * licence Apache-2.0
+ */
+final class TempestConnectionModule extends NoExternalConfigurationModule implements AnnotationModule
+{
+    public static function create(AnnotationFinder $annotationRegistrationService, InterfaceToCallRegistry $interfaceToCallRegistry): static
+    {
+        return new self();
+    }
+
+    public function prepare(Configuration $messagingConfiguration, array $extensionObjects, ModuleReferenceSearchService $moduleReferenceSearchService, InterfaceToCallRegistry $interfaceToCallRegistry): void
+    {
+        $tempestConnections = ExtensionObjectResolver::resolve(TempestConnectionReference::class, $extensionObjects);
+
+        foreach ($tempestConnections as $connection) {
+            $messagingConfiguration->registerServiceDefinition(
+                $connection->getReferenceName(),
+                new Definition(
+                    ConnectionFactory::class,
+                    [
+                        $connection,
+                        new Reference(DatabaseConfig::class),
+                    ],
+                    [
+                        TempestConnectionResolver::class,
+                        'resolve',
+                    ]
+                )
+            );
+        }
+    }
+
+    public function canHandle($extensionObject): bool
+    {
+        return $extensionObject instanceof TempestConnectionReference;
+    }
+
+    public function getModulePackageName(): string
+    {
+        return ModulePackageList::TEMPEST_PACKAGE;
+    }
+}

--- a/packages/Tempest/src/Config/TempestConnectionReference.php
+++ b/packages/Tempest/src/Config/TempestConnectionReference.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ecotone\Tempest\Config;
+
+use Ecotone\Messaging\Config\ConnectionReference;
+use Ecotone\Messaging\Config\Container\DefinedObject;
+use Ecotone\Messaging\Config\Container\Definition;
+use Enqueue\Dbal\DbalConnectionFactory;
+
+/**
+ * licence Apache-2.0
+ */
+final class TempestConnectionReference extends ConnectionReference implements DefinedObject
+{
+    private function __construct(
+        string $referenceName,
+    ) {
+        parent::__construct($referenceName, null);
+    }
+
+    public static function create(string $referenceName): self
+    {
+        return new self($referenceName);
+    }
+
+    public static function defaultConnection(): self
+    {
+        return new self(DbalConnectionFactory::class);
+    }
+
+    public function getDefinition(): Definition
+    {
+        return new Definition(
+            TempestConnectionReference::class,
+            [
+                $this->getReferenceName(),
+            ],
+            [
+                self::class,
+                'create',
+            ]
+        );
+    }
+}

--- a/packages/Tempest/src/Config/TempestConnectionReference.php
+++ b/packages/Tempest/src/Config/TempestConnectionReference.php
@@ -8,7 +8,6 @@ use Ecotone\Messaging\Config\ConnectionReference;
 use Ecotone\Messaging\Config\Container\DefinedObject;
 use Ecotone\Messaging\Config\Container\Definition;
 use Enqueue\Dbal\DbalConnectionFactory;
-use Tempest\Database\Config\DatabaseConfig;
 
 /**
  * licence Apache-2.0
@@ -17,28 +16,37 @@ final class TempestConnectionReference extends ConnectionReference implements De
 {
     private function __construct(
         string $referenceName,
-        private readonly ?DatabaseConfig $databaseConfig = null,
+        private readonly ?string $configTag = null,
     ) {
         parent::__construct($referenceName, $referenceName);
     }
 
-    public static function create(string $referenceName, ?DatabaseConfig $databaseConfig = null): self
+    /**
+     * Reference resolved from a tagged Tempest DatabaseConfig in the container.
+     * No credentials are stored here or in Ecotone's compiled cache — the config
+     * is looked up at runtime from Tempest's container by tag.
+     *
+     * Register the matching config in a Tempest *.config.php:
+     *   return new PostgresConfig(host: '...', tag: 'tenant_a');
+     */
+    public static function create(string $configTag, ?string $referenceName = null): self
     {
-        return new self($referenceName, $databaseConfig);
+        return new self($referenceName ?? $configTag, $configTag);
     }
 
+    /**
+     * Reference to the default (untagged) Tempest Connection singleton.
+     * Shares the same PDO that Tempest's IsDatabaseModel / Database use,
+     * so Ecotone's DBAL transactions wrap Tempest ORM writes on the same connection.
+     */
     public static function defaultConnection(): self
     {
-        return new self(DbalConnectionFactory::class);
+        return new self(DbalConnectionFactory::class, null);
     }
 
-    public static function clearRegistry(): void
+    public function getConfigTag(): ?string
     {
-    }
-
-    public function getDatabaseConfig(): ?DatabaseConfig
-    {
-        return $this->databaseConfig;
+        return $this->configTag;
     }
 
     public function getDefinition(): Definition
@@ -47,19 +55,17 @@ final class TempestConnectionReference extends ConnectionReference implements De
             TempestConnectionReference::class,
             [
                 $this->getReferenceName(),
-                $this->databaseConfig !== null ? base64_encode(serialize($this->databaseConfig)) : null,
+                $this->configTag,
             ],
             [
                 self::class,
-                'createFromSerializedConfig',
+                'fromTagAndReferenceName',
             ]
         );
     }
 
-    public static function createFromSerializedConfig(string $referenceName, ?string $serializedConfig = null): self
+    public static function fromTagAndReferenceName(string $referenceName, ?string $configTag = null): self
     {
-        $config = $serializedConfig !== null ? unserialize(base64_decode($serializedConfig)) : null;
-
-        return new self($referenceName, $config);
+        return new self($referenceName, $configTag);
     }
 }

--- a/packages/Tempest/src/Config/TempestConnectionReference.php
+++ b/packages/Tempest/src/Config/TempestConnectionReference.php
@@ -8,6 +8,7 @@ use Ecotone\Messaging\Config\ConnectionReference;
 use Ecotone\Messaging\Config\Container\DefinedObject;
 use Ecotone\Messaging\Config\Container\Definition;
 use Enqueue\Dbal\DbalConnectionFactory;
+use Tempest\Database\Config\DatabaseConfig;
 
 /**
  * licence Apache-2.0
@@ -16,18 +17,28 @@ final class TempestConnectionReference extends ConnectionReference implements De
 {
     private function __construct(
         string $referenceName,
+        private readonly ?DatabaseConfig $databaseConfig = null,
     ) {
-        parent::__construct($referenceName, null);
+        parent::__construct($referenceName, $referenceName);
     }
 
-    public static function create(string $referenceName): self
+    public static function create(string $referenceName, ?DatabaseConfig $databaseConfig = null): self
     {
-        return new self($referenceName);
+        return new self($referenceName, $databaseConfig);
     }
 
     public static function defaultConnection(): self
     {
         return new self(DbalConnectionFactory::class);
+    }
+
+    public static function clearRegistry(): void
+    {
+    }
+
+    public function getDatabaseConfig(): ?DatabaseConfig
+    {
+        return $this->databaseConfig;
     }
 
     public function getDefinition(): Definition
@@ -36,11 +47,19 @@ final class TempestConnectionReference extends ConnectionReference implements De
             TempestConnectionReference::class,
             [
                 $this->getReferenceName(),
+                $this->databaseConfig !== null ? base64_encode(serialize($this->databaseConfig)) : null,
             ],
             [
                 self::class,
-                'create',
+                'createFromSerializedConfig',
             ]
         );
+    }
+
+    public static function createFromSerializedConfig(string $referenceName, ?string $serializedConfig = null): self
+    {
+        $config = $serializedConfig !== null ? unserialize(base64_decode($serializedConfig)) : null;
+
+        return new self($referenceName, $config);
     }
 }

--- a/packages/Tempest/src/Config/TempestConnectionResolver.php
+++ b/packages/Tempest/src/Config/TempestConnectionResolver.php
@@ -13,6 +13,7 @@ use Ecotone\Tempest\Config\PDO\PostgresDriver;
 use Ecotone\Tempest\Config\PDO\SQLiteDriver;
 use Interop\Queue\ConnectionFactory;
 use PDO;
+use Tempest\Container\GenericContainer;
 use Tempest\Database\Config\DatabaseConfig;
 use Tempest\Database\Config\DatabaseDialect;
 
@@ -21,11 +22,13 @@ use Tempest\Database\Config\DatabaseDialect;
  */
 final class TempestConnectionResolver
 {
-    public static function resolve(TempestConnectionReference $reference, DatabaseConfig $databaseConfig): ConnectionFactory
+    public static function resolve(TempestConnectionReference $reference): ConnectionFactory
     {
         if (! class_exists(DbalConnection::class)) {
             throw new InvalidArgumentException('Dbal Module is not installed. Please install it first to make use of Database capabilities.');
         }
+
+        $databaseConfig = $reference->getDatabaseConfig() ?? self::resolveDefaultDatabaseConfig();
 
         $pdo = new PDO(
             $databaseConfig->dsn,
@@ -42,6 +45,13 @@ final class TempestConnectionResolver
         );
 
         return DbalConnection::create($doctrineConnection);
+    }
+
+    private static function resolveDefaultDatabaseConfig(): DatabaseConfig
+    {
+        $container = GenericContainer::instance();
+
+        return $container->get(DatabaseConfig::class);
     }
 
     private static function driverForDialect(DatabaseDialect $dialect): Driver

--- a/packages/Tempest/src/Config/TempestConnectionResolver.php
+++ b/packages/Tempest/src/Config/TempestConnectionResolver.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ecotone\Tempest\Config;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Driver;
+use Ecotone\Dbal\DbalConnection;
+use Ecotone\Messaging\Support\InvalidArgumentException;
+use Ecotone\Tempest\Config\PDO\MySqlDriver;
+use Ecotone\Tempest\Config\PDO\PostgresDriver;
+use Ecotone\Tempest\Config\PDO\SQLiteDriver;
+use Interop\Queue\ConnectionFactory;
+use PDO;
+use Tempest\Database\Config\DatabaseConfig;
+use Tempest\Database\Config\DatabaseDialect;
+
+/**
+ * licence Apache-2.0
+ */
+final class TempestConnectionResolver
+{
+    public static function resolve(TempestConnectionReference $reference, DatabaseConfig $databaseConfig): ConnectionFactory
+    {
+        if (! class_exists(DbalConnection::class)) {
+            throw new InvalidArgumentException('Dbal Module is not installed. Please install it first to make use of Database capabilities.');
+        }
+
+        $pdo = new PDO(
+            $databaseConfig->dsn,
+            $databaseConfig->username,
+            $databaseConfig->password,
+            $databaseConfig->options,
+        );
+
+        $driver = self::driverForDialect($databaseConfig->dialect);
+
+        $doctrineConnection = new Connection(
+            ['pdo' => $pdo],
+            $driver,
+        );
+
+        return DbalConnection::create($doctrineConnection);
+    }
+
+    private static function driverForDialect(DatabaseDialect $dialect): Driver
+    {
+        return match ($dialect) {
+            DatabaseDialect::POSTGRESQL => new PostgresDriver(),
+            DatabaseDialect::MYSQL => new MySqlDriver(),
+            DatabaseDialect::SQLITE => new SQLiteDriver(),
+        };
+    }
+}

--- a/packages/Tempest/src/Config/TempestConnectionResolver.php
+++ b/packages/Tempest/src/Config/TempestConnectionResolver.php
@@ -13,9 +13,11 @@ use Ecotone\Tempest\Config\PDO\PostgresDriver;
 use Ecotone\Tempest\Config\PDO\SQLiteDriver;
 use Interop\Queue\ConnectionFactory;
 use PDO;
+use ReflectionProperty;
 use Tempest\Container\GenericContainer;
 use Tempest\Database\Config\DatabaseConfig;
 use Tempest\Database\Config\DatabaseDialect;
+use Tempest\Database\Connection\Connection as TempestConnection;
 
 /**
  * licence Apache-2.0
@@ -28,7 +30,11 @@ final class TempestConnectionResolver
             throw new InvalidArgumentException('Dbal Module is not installed. Please install it first to make use of Database capabilities.');
         }
 
-        $databaseConfig = $reference->getDatabaseConfig() ?? self::resolveDefaultDatabaseConfig();
+        $databaseConfig = $reference->getDatabaseConfig();
+
+        if ($databaseConfig === null) {
+            return self::resolveFromTempestConnection();
+        }
 
         $pdo = new PDO(
             $databaseConfig->dsn,
@@ -47,11 +53,20 @@ final class TempestConnectionResolver
         return DbalConnection::create($doctrineConnection);
     }
 
-    private static function resolveDefaultDatabaseConfig(): DatabaseConfig
+    private static function resolveFromTempestConnection(): ConnectionFactory
     {
         $container = GenericContainer::instance();
+        $tempestConnection = $container->get(TempestConnection::class);
+        $databaseConfig = $container->get(DatabaseConfig::class);
 
-        return $container->get(DatabaseConfig::class);
+        $pdoProperty = new ReflectionProperty($tempestConnection, 'pdo');
+        $sharedPdo = $pdoProperty->getValue($tempestConnection);
+
+        $driver = self::driverForDialect($databaseConfig->dialect);
+
+        $doctrineConnection = new Connection(['pdo' => $sharedPdo], $driver);
+
+        return DbalConnection::create($doctrineConnection);
     }
 
     private static function driverForDialect(DatabaseDialect $dialect): Driver

--- a/packages/Tempest/src/Config/TempestConnectionResolver.php
+++ b/packages/Tempest/src/Config/TempestConnectionResolver.php
@@ -11,13 +11,14 @@ use Ecotone\Messaging\Support\InvalidArgumentException;
 use Ecotone\Tempest\Config\PDO\MySqlDriver;
 use Ecotone\Tempest\Config\PDO\PostgresDriver;
 use Ecotone\Tempest\Config\PDO\SQLiteDriver;
+use Ecotone\Tempest\Config\PDO\TempestDynamicDriver;
 use Interop\Queue\ConnectionFactory;
-use PDO;
 use ReflectionProperty;
 use Tempest\Container\GenericContainer;
 use Tempest\Database\Config\DatabaseConfig;
 use Tempest\Database\Config\DatabaseDialect;
 use Tempest\Database\Connection\Connection as TempestConnection;
+use Tempest\Database\Connection\PDOConnection;
 
 /**
  * licence Apache-2.0
@@ -30,35 +31,51 @@ final class TempestConnectionResolver
             throw new InvalidArgumentException('Dbal Module is not installed. Please install it first to make use of Database capabilities.');
         }
 
-        $databaseConfig = $reference->getDatabaseConfig();
+        $configTag = $reference->getConfigTag();
 
-        if ($databaseConfig === null) {
+        if ($configTag === null) {
             return self::resolveFromTempestConnection();
         }
 
-        $pdo = new PDO(
-            $databaseConfig->dsn,
-            $databaseConfig->username,
-            $databaseConfig->password,
-            $databaseConfig->options,
+        return self::resolveFromTaggedConfig($configTag);
+    }
+
+    private static function resolveFromTaggedConfig(string $configTag): ConnectionFactory
+    {
+        $container = GenericContainer::instance();
+
+        if (! $container->has(TempestConnection::class, tag: $configTag)) {
+            $databaseConfig = $container->get(DatabaseConfig::class, tag: $configTag);
+            $connection = new PDOConnection($databaseConfig);
+            $connection->connect();
+            $container->singleton(TempestConnection::class, $connection, tag: $configTag);
+        }
+
+        return self::doctrineConnectionFromTempestConnection(
+            $container->get(TempestConnection::class, tag: $configTag),
+            $container->get(DatabaseConfig::class, tag: $configTag),
         );
-
-        $driver = self::driverForDialect($databaseConfig->dialect);
-
-        $doctrineConnection = new Connection(
-            ['pdo' => $pdo],
-            $driver,
-        );
-
-        return DbalConnection::create($doctrineConnection);
     }
 
     private static function resolveFromTempestConnection(): ConnectionFactory
     {
         $container = GenericContainer::instance();
-        $tempestConnection = $container->get(TempestConnection::class);
         $databaseConfig = $container->get(DatabaseConfig::class);
+        $driver = self::driverForDialect($databaseConfig->dialect);
 
+        // TempestDynamicDriver returns a TempestDynamicDriverConnection that re-resolves
+        // Tempest's default Connection singleton on each DBAL call. Combined with
+        // TempestTenantDatabaseSwitcher closing the Doctrine connection on switch,
+        // the DbalTransactionInterceptor transparently follows tenant connection promotions.
+        $doctrineConnection = new Connection([], new TempestDynamicDriver());
+
+        return DbalConnection::create($doctrineConnection);
+    }
+
+    private static function doctrineConnectionFromTempestConnection(
+        TempestConnection $tempestConnection,
+        DatabaseConfig $databaseConfig,
+    ): ConnectionFactory {
         $pdoProperty = new ReflectionProperty($tempestConnection, 'pdo');
         $sharedPdo = $pdoProperty->getValue($tempestConnection);
 

--- a/packages/Tempest/src/Config/TempestTenantDatabaseSwitcher.php
+++ b/packages/Tempest/src/Config/TempestTenantDatabaseSwitcher.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ecotone\Tempest\Config;
+
+use Ecotone\Messaging\Config\ConnectionReference;
+use Tempest\Container\GenericContainer;
+use Tempest\Database\Config\DatabaseConfig;
+use Tempest\Database\Connection\Connection;
+use Tempest\Database\Database;
+
+/**
+ * licence Apache-2.0
+ */
+final class TempestTenantDatabaseSwitcher
+{
+    public function __construct(
+        private readonly DatabaseConfig $defaultDatabaseConfig,
+    ) {}
+
+    public static function create(): self
+    {
+        $container = GenericContainer::instance();
+        $defaultConfig = $container->get(DatabaseConfig::class);
+
+        return new self($defaultConfig);
+    }
+
+    public function switchOn(string|ConnectionReference $activatedConnection): void
+    {
+        if (! ($activatedConnection instanceof TempestConnectionReference)) {
+            return;
+        }
+
+        $tenantConfig = $activatedConnection->getDatabaseConfig();
+
+        if ($tenantConfig === null) {
+            return;
+        }
+
+        $container = GenericContainer::instance();
+        $container->singleton(DatabaseConfig::class, $tenantConfig);
+        $container->unregister(Connection::class);
+        $container->unregister(Database::class);
+    }
+
+    public function switchOff(): void
+    {
+        $container = GenericContainer::instance();
+        $container->singleton(DatabaseConfig::class, $this->defaultDatabaseConfig);
+        $container->unregister(Connection::class);
+        $container->unregister(Database::class);
+    }
+}

--- a/packages/Tempest/src/Config/TempestTenantDatabaseSwitcher.php
+++ b/packages/Tempest/src/Config/TempestTenantDatabaseSwitcher.php
@@ -5,9 +5,11 @@ declare(strict_types=1);
 namespace Ecotone\Tempest\Config;
 
 use Ecotone\Messaging\Config\ConnectionReference;
+use Enqueue\Dbal\DbalConnectionFactory;
 use Tempest\Container\GenericContainer;
 use Tempest\Database\Config\DatabaseConfig;
 use Tempest\Database\Connection\Connection;
+use Tempest\Database\Connection\PDOConnection;
 use Tempest\Database\Database;
 
 /**
@@ -33,16 +35,32 @@ final class TempestTenantDatabaseSwitcher
             return;
         }
 
-        $tenantConfig = $activatedConnection->getDatabaseConfig();
+        $configTag = $activatedConnection->getConfigTag();
 
-        if ($tenantConfig === null) {
+        if ($configTag === null) {
             return;
         }
 
         $container = GenericContainer::instance();
+        $tenantConfig = $container->get(DatabaseConfig::class, tag: $configTag);
+
+        // Ensure the tagged Connection singleton is built so TempestConnectionResolver shares its PDO
+        if (! $container->has(Connection::class, tag: $configTag)) {
+            $connection = new PDOConnection($tenantConfig);
+            $connection->connect();
+            $container->singleton(Connection::class, $connection, tag: $configTag);
+        }
+
+        // Register the tenant's already-built Connection as the default so IsDatabaseModel
+        // and Ecotone's DBAL share one PDO — enabling transaction rollback across both
+        $tenantConnection = $container->get(Connection::class, tag: $configTag);
         $container->singleton(DatabaseConfig::class, $tenantConfig);
-        $container->unregister(Connection::class);
+        $container->singleton(Connection::class, $tenantConnection);
         $container->unregister(Database::class);
+
+        // Close the Doctrine Connection so TempestDynamicDriver reconnects on next use,
+        // picking up the now-promoted default Connection's PDO
+        $this->closeDoctrineDefaultConnection($container);
     }
 
     public function switchOff(): void
@@ -51,5 +69,21 @@ final class TempestTenantDatabaseSwitcher
         $container->singleton(DatabaseConfig::class, $this->defaultDatabaseConfig);
         $container->unregister(Connection::class);
         $container->unregister(Database::class);
+
+        $this->closeDoctrineDefaultConnection($container);
+    }
+
+    private function closeDoctrineDefaultConnection(GenericContainer $container): void
+    {
+        if (! $container->has(DbalConnectionFactory::class)) {
+            return;
+        }
+
+        try {
+            $factory = $container->get(DbalConnectionFactory::class);
+            $doctrineConnection = $factory->createContext()->getDbalConnection();
+            $doctrineConnection->close();
+        } catch (\Throwable) {
+        }
     }
 }

--- a/packages/Tempest/src/ConsoleCommandProxyGenerator.php
+++ b/packages/Tempest/src/ConsoleCommandProxyGenerator.php
@@ -98,7 +98,9 @@ final class ConsoleCommandProxyGenerator
             namespace Ecotone\Tempest\Generated;
 
             use Ecotone\Messaging\Config\ConfiguredMessagingSystem;
+            use Ecotone\Messaging\Config\ConsoleCommandResultSet;
             use Ecotone\Messaging\Gateway\ConsoleCommandRunner;
+            use Tempest\Console\Console;
             use Tempest\Console\ConsoleCommand;
             use Tempest\Console\ExitCode;
             use Tempest\Console\Input\ConsoleArgumentBag;
@@ -115,6 +117,9 @@ final class ConsoleCommandProxyGenerator
                 #[Inject]
                 private readonly ConsoleArgumentBag \$argumentBag;
 
+                #[Inject]
+                private readonly Console \$console;
+
                 #[ConsoleCommand(name: '{$escapedCommandName}', allowDynamicArguments: true)]
                 public function __invoke(): ExitCode
                 {
@@ -124,6 +129,12 @@ final class ConsoleCommandProxyGenerator
                         \$allArgs[\$arg->name !== null ? \$arg->name : ''] = \$arg->value;
                     }
                     \$result = \$runner->execute('{$escapedCommandName}', \$allArgs);
+                    if (\$result instanceof ConsoleCommandResultSet) {
+                        \$this->console->writeln(implode(' | ', \$result->getColumnHeaders()));
+                        foreach (\$result->getRows() as \$row) {
+                            \$this->console->writeln(implode(' | ', \$row));
+                        }
+                    }
                     return ExitCode::SUCCESS;
                 }
             }

--- a/packages/Tempest/src/ConsoleCommandProxyGenerator.php
+++ b/packages/Tempest/src/ConsoleCommandProxyGenerator.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ecotone\Tempest;
+
+use const DIRECTORY_SEPARATOR;
+
+use Ecotone\Messaging\Config\ConsoleCommandConfiguration;
+
+/**
+ * licence Apache-2.0
+ */
+final class ConsoleCommandProxyGenerator
+{
+    /**
+     * @param ConsoleCommandConfiguration[] $commandConfigurations
+     * @return string[] absolute paths to the generated proxy files
+     */
+    public function generate(array $commandConfigurations, string $outputDirectory): array
+    {
+        if (! is_dir($outputDirectory)) {
+            mkdir($outputDirectory, 0777, true);
+        }
+
+        $generatedFiles = [];
+
+        foreach ($commandConfigurations as $configuration) {
+            $generatedFiles[] = $this->writeProxyFile($configuration, $outputDirectory);
+        }
+
+        return $generatedFiles;
+    }
+
+    private function writeProxyFile(ConsoleCommandConfiguration $configuration, string $outputDirectory): string
+    {
+        $commandName = $configuration->getName();
+        $className = $this->buildClassName($commandName);
+        $filePath = $outputDirectory . DIRECTORY_SEPARATOR . $className . '.php';
+
+        file_put_contents($filePath, $this->buildProxyClassCode($className, $commandName));
+
+        return $filePath;
+    }
+
+    private function buildProxyClassCode(string $className, string $commandName): string
+    {
+        $escapedCommandName = addslashes($commandName);
+
+        return <<<PHP
+            <?php
+
+            declare(strict_types=1);
+
+            namespace Ecotone\Tempest\Generated;
+
+            use Ecotone\Messaging\Config\ConfiguredMessagingSystem;
+            use Ecotone\Messaging\Gateway\ConsoleCommandRunner;
+            use Tempest\Console\ConsoleCommand;
+            use Tempest\Console\ExitCode;
+            use Tempest\Console\Input\ConsoleArgumentBag;
+            use Tempest\Container\Inject;
+
+            /**
+             * licence Apache-2.0
+             */
+            final class {$className}
+            {
+                #[Inject]
+                private readonly ConfiguredMessagingSystem \$messagingSystem;
+
+                #[Inject]
+                private readonly ConsoleArgumentBag \$argumentBag;
+
+                #[ConsoleCommand(name: '{$escapedCommandName}', allowDynamicArguments: true)]
+                public function __invoke(): ExitCode
+                {
+                    \$runner = \$this->messagingSystem->getGatewayByName(ConsoleCommandRunner::class);
+                    \$allArgs = [];
+                    foreach (\$this->argumentBag->all() as \$arg) {
+                        \$allArgs[\$arg->name !== null ? \$arg->name : ''] = \$arg->value;
+                    }
+                    \$result = \$runner->execute('{$escapedCommandName}', \$allArgs);
+                    return ExitCode::SUCCESS;
+                }
+            }
+            PHP;
+    }
+
+    private function buildClassName(string $commandName): string
+    {
+        return 'EcotoneConsoleCommand_' . preg_replace('/[^a-zA-Z0-9_]/', '_', $commandName);
+    }
+}

--- a/packages/Tempest/src/ConsoleCommandProxyGenerator.php
+++ b/packages/Tempest/src/ConsoleCommandProxyGenerator.php
@@ -13,14 +13,22 @@ use Ecotone\Messaging\Config\ConsoleCommandConfiguration;
  */
 final class ConsoleCommandProxyGenerator
 {
+    private const HASH_MARKER_FILE = '.ecotone_hash';
+
     /**
      * @param ConsoleCommandConfiguration[] $commandConfigurations
      * @return string[] absolute paths to the generated proxy files
      */
-    public function generate(array $commandConfigurations, string $outputDirectory): array
+    public function generate(array $commandConfigurations, string $outputDirectory, ?string $configHash = null): array
     {
         if (! is_dir($outputDirectory)) {
             mkdir($outputDirectory, 0777, true);
+        }
+
+        $generatedFiles = $this->resolveExpectedFilePaths($commandConfigurations, $outputDirectory);
+
+        if ($configHash !== null && $this->isHashUnchanged($outputDirectory, $configHash, $generatedFiles)) {
+            return $generatedFiles;
         }
 
         $generatedFiles = [];
@@ -29,7 +37,42 @@ final class ConsoleCommandProxyGenerator
             $generatedFiles[] = $this->writeProxyFile($configuration, $outputDirectory);
         }
 
+        if ($configHash !== null) {
+            file_put_contents($outputDirectory . DIRECTORY_SEPARATOR . self::HASH_MARKER_FILE, $configHash);
+        }
+
         return $generatedFiles;
+    }
+
+    private function resolveExpectedFilePaths(array $commandConfigurations, string $outputDirectory): array
+    {
+        $files = [];
+        foreach ($commandConfigurations as $configuration) {
+            $className = $this->buildClassName($configuration->getName());
+            $files[] = $outputDirectory . DIRECTORY_SEPARATOR . $className . '.php';
+        }
+        return $files;
+    }
+
+    private function isHashUnchanged(string $outputDirectory, string $configHash, array $expectedFiles): bool
+    {
+        $markerFile = $outputDirectory . DIRECTORY_SEPARATOR . self::HASH_MARKER_FILE;
+
+        if (! file_exists($markerFile)) {
+            return false;
+        }
+
+        if (file_get_contents($markerFile) !== $configHash) {
+            return false;
+        }
+
+        foreach ($expectedFiles as $file) {
+            if (! file_exists($file)) {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     private function writeProxyFile(ConsoleCommandConfiguration $configuration, string $outputDirectory): string

--- a/packages/Tempest/src/EcotoneCacheClearCommand.php
+++ b/packages/Tempest/src/EcotoneCacheClearCommand.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ecotone\Tempest;
+
+use const DIRECTORY_SEPARATOR;
+
+use Tempest\Console\Console;
+use Tempest\Console\ConsoleCommand;
+
+/**
+ * licence Apache-2.0
+ */
+final class EcotoneCacheClearCommand
+{
+    public function __construct(private readonly Console $console)
+    {
+    }
+
+    #[ConsoleCommand(name: 'ecotone:cache:clear')]
+    public function __invoke(): void
+    {
+        $cacheDirectory = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'ecotone_tempest';
+
+        $this->removeCacheDirectory($cacheDirectory);
+
+        $this->console->writeln('Ecotone cache cleared.');
+    }
+
+    private function removeCacheDirectory(string $directory): void
+    {
+        if (! is_dir($directory)) {
+            return;
+        }
+
+        foreach (glob($directory . DIRECTORY_SEPARATOR . '*') ?: [] as $item) {
+            if (is_dir($item)) {
+                $this->removeCacheDirectory($item);
+            } else {
+                @unlink($item);
+            }
+        }
+
+        @rmdir($directory);
+    }
+}

--- a/packages/Tempest/src/EcotoneConfig.php
+++ b/packages/Tempest/src/EcotoneConfig.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ecotone\Tempest;
+
+use function Tempest\env;
+
+/**
+ * licence Apache-2.0
+ */
+final class EcotoneConfig
+{
+    public function __construct(
+        public string $serviceName = '',
+        public array $namespaces = [],
+        public bool $loadAppNamespaces = true,
+        public bool $cacheConfiguration = false,
+        public string $defaultSerializationMediaType = '',
+        public string $defaultErrorChannel = '',
+        public array $skippedModulePackageNames = [],
+        public bool $test = false,
+        public string $licenceKey = '',
+    ) {
+        if ($this->serviceName === '') {
+            $this->serviceName = (string) env('ECOTONE_SERVICE_NAME', '');
+        }
+        if (! $this->cacheConfiguration) {
+            $this->cacheConfiguration = (bool) env('ECOTONE_CACHE_CONFIGURATION', false);
+        }
+    }
+}

--- a/packages/Tempest/src/EcotoneConsoleCommandDiscovery.php
+++ b/packages/Tempest/src/EcotoneConsoleCommandDiscovery.php
@@ -56,7 +56,7 @@ final class EcotoneConsoleCommandDiscovery implements Discovery
         $outputDirectory = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'ecotone_tempest_console_proxies';
 
         $generator = new ConsoleCommandProxyGenerator();
-        $generatedFiles = $generator->generate($commands, $outputDirectory);
+        $generatedFiles = $generator->generate($commands, $outputDirectory, MessagingSystemInitializer::getConfigHash());
 
         foreach ($generatedFiles as $file) {
             require_once $file;

--- a/packages/Tempest/src/EcotoneConsoleCommandDiscovery.php
+++ b/packages/Tempest/src/EcotoneConsoleCommandDiscovery.php
@@ -33,11 +33,11 @@ final class EcotoneConsoleCommandDiscovery implements Discovery
 
     public function apply(): void
     {
-        if (! $this->container->has(EcotoneConfig::class)) {
-            return;
-        }
-
         if (MessagingSystemInitializer::getDefinitionHolder() === null) {
+            if (! $this->container->has(EcotoneConfig::class)) {
+                return;
+            }
+
             (new MessagingSystemInitializer())->initialize($this->container);
         }
 

--- a/packages/Tempest/src/EcotoneConsoleCommandDiscovery.php
+++ b/packages/Tempest/src/EcotoneConsoleCommandDiscovery.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ecotone\Tempest;
+
+use const DIRECTORY_SEPARATOR;
+
+use Tempest\Console\ConsoleCommand;
+use Tempest\Console\ConsoleConfig;
+use Tempest\Container\Container;
+use Tempest\Discovery\Discovery;
+use Tempest\Discovery\DiscoveryLocation;
+use Tempest\Discovery\IsDiscovery;
+use Tempest\Reflection\ClassReflector;
+
+/**
+ * licence Apache-2.0
+ */
+final class EcotoneConsoleCommandDiscovery implements Discovery
+{
+    use IsDiscovery;
+
+    public function __construct(
+        private readonly Container $container,
+        private readonly ConsoleConfig $consoleConfig,
+    ) {
+    }
+
+    public function discover(DiscoveryLocation $location, ClassReflector $class): void
+    {
+    }
+
+    public function apply(): void
+    {
+        if (! $this->container->has(EcotoneConfig::class)) {
+            return;
+        }
+
+        if (MessagingSystemInitializer::getDefinitionHolder() === null) {
+            (new MessagingSystemInitializer())->initialize($this->container);
+        }
+
+        $definitionHolder = MessagingSystemInitializer::getDefinitionHolder();
+
+        if ($definitionHolder === null) {
+            return;
+        }
+
+        $commands = $definitionHolder->getRegisteredCommands();
+
+        if ($commands === []) {
+            return;
+        }
+
+        $outputDirectory = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'ecotone_tempest_console_proxies';
+
+        $generator = new ConsoleCommandProxyGenerator();
+        $generatedFiles = $generator->generate($commands, $outputDirectory);
+
+        foreach ($generatedFiles as $file) {
+            require_once $file;
+        }
+
+        foreach ($commands as $commandConfiguration) {
+            $className = 'Ecotone\\Tempest\\Generated\\' . $this->buildClassName($commandConfiguration->getName());
+
+            if (! class_exists($className)) {
+                continue;
+            }
+
+            $classReflector = new ClassReflector($className);
+
+            foreach ($classReflector->getPublicMethods() as $method) {
+                $consoleCommand = $method->getAttribute(ConsoleCommand::class);
+
+                if ($consoleCommand === null) {
+                    continue;
+                }
+
+                $this->consoleConfig->addCommand($method, $consoleCommand);
+            }
+        }
+    }
+
+    private function buildClassName(string $commandName): string
+    {
+        return 'EcotoneConsoleCommand_' . preg_replace('/[^a-zA-Z0-9_]/', '_', $commandName);
+    }
+}

--- a/packages/Tempest/src/EcotoneConsoleCommandDiscovery.php
+++ b/packages/Tempest/src/EcotoneConsoleCommandDiscovery.php
@@ -53,7 +53,8 @@ final class EcotoneConsoleCommandDiscovery implements Discovery
             return;
         }
 
-        $outputDirectory = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'ecotone_tempest_console_proxies';
+        $outputDirectory = MessagingSystemInitializer::getProxyDirectory()
+            ?? sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'ecotone_tempest_console_proxies';
 
         $generator = new ConsoleCommandProxyGenerator();
         $generatedFiles = $generator->generate($commands, $outputDirectory, MessagingSystemInitializer::getConfigHash());

--- a/packages/Tempest/src/EcotoneServiceInitializer.php
+++ b/packages/Tempest/src/EcotoneServiceInitializer.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ecotone\Tempest;
+
+use Ecotone\Messaging\Config\ConfiguredMessagingSystem;
+use Ecotone\Modelling\CommandBus;
+use Ecotone\Modelling\EventBus;
+use Ecotone\Modelling\QueryBus;
+use Tempest\Container\Container;
+use Tempest\Container\DynamicInitializer;
+use Tempest\Reflection\ClassReflector;
+use UnitEnum;
+
+/**
+ * licence Apache-2.0
+ */
+final class EcotoneServiceInitializer implements DynamicInitializer
+{
+    private static ?array $compiledServiceIds = null;
+
+    public static function clearCache(): void
+    {
+        self::$compiledServiceIds = null;
+    }
+
+    public static function markCompiled(array $serviceIds): void
+    {
+        self::$compiledServiceIds = array_flip($serviceIds);
+    }
+
+    public function canInitialize(ClassReflector $class, null|string|UnitEnum $tag): bool
+    {
+        if (self::$compiledServiceIds !== null) {
+            return isset(self::$compiledServiceIds[$class->getName()]);
+        }
+
+        return $this->isKnownEcotoneGateway($class->getName());
+    }
+
+    public function initialize(ClassReflector $class, null|string|UnitEnum $tag, Container $container): object
+    {
+        $configuredMessagingSystem = $container->get(ConfiguredMessagingSystem::class);
+
+        return $configuredMessagingSystem->getGatewayByName($class->getName());
+    }
+
+    private function isKnownEcotoneGateway(string $className): bool
+    {
+        return in_array($className, [
+            CommandBus::class,
+            QueryBus::class,
+            EventBus::class,
+        ], true);
+    }
+}

--- a/packages/Tempest/src/EcotoneServiceInitializer.php
+++ b/packages/Tempest/src/EcotoneServiceInitializer.php
@@ -43,7 +43,7 @@ final class EcotoneServiceInitializer implements DynamicInitializer
 
         $container = GenericContainer::instance();
 
-        if ($container === null || ! $container->has(EcotoneConfig::class)) {
+        if ($container === null) {
             return false;
         }
 

--- a/packages/Tempest/src/EcotoneServiceInitializer.php
+++ b/packages/Tempest/src/EcotoneServiceInitializer.php
@@ -5,11 +5,9 @@ declare(strict_types=1);
 namespace Ecotone\Tempest;
 
 use Ecotone\Messaging\Config\ConfiguredMessagingSystem;
-use Ecotone\Modelling\CommandBus;
-use Ecotone\Modelling\EventBus;
-use Ecotone\Modelling\QueryBus;
 use Tempest\Container\Container;
 use Tempest\Container\DynamicInitializer;
+use Tempest\Container\GenericContainer;
 use Tempest\Reflection\ClassReflector;
 use UnitEnum;
 
@@ -20,9 +18,12 @@ final class EcotoneServiceInitializer implements DynamicInitializer
 {
     private static ?array $compiledServiceIds = null;
 
+    private static bool $compiling = false;
+
     public static function clearCache(): void
     {
         self::$compiledServiceIds = null;
+        self::$compiling = false;
     }
 
     public static function markCompiled(array $serviceIds): void
@@ -36,7 +37,21 @@ final class EcotoneServiceInitializer implements DynamicInitializer
             return isset(self::$compiledServiceIds[$class->getName()]);
         }
 
-        return $this->isKnownEcotoneGateway($class->getName());
+        if (self::$compiling) {
+            return false;
+        }
+
+        $container = GenericContainer::instance();
+
+        if ($container === null || ! $container->has(EcotoneConfig::class)) {
+            return false;
+        }
+
+        self::$compiling = true;
+        $container->get(ConfiguredMessagingSystem::class);
+        self::$compiling = false;
+
+        return isset(self::$compiledServiceIds[$class->getName()]);
     }
 
     public function initialize(ClassReflector $class, null|string|UnitEnum $tag, Container $container): object
@@ -44,14 +59,5 @@ final class EcotoneServiceInitializer implements DynamicInitializer
         $configuredMessagingSystem = $container->get(ConfiguredMessagingSystem::class);
 
         return $configuredMessagingSystem->getGatewayByName($class->getName());
-    }
-
-    private function isKnownEcotoneGateway(string $className): bool
-    {
-        return in_array($className, [
-            CommandBus::class,
-            QueryBus::class,
-            EventBus::class,
-        ], true);
     }
 }

--- a/packages/Tempest/src/MessagingSystemInitializer.php
+++ b/packages/Tempest/src/MessagingSystemInitializer.php
@@ -28,6 +28,18 @@ final class MessagingSystemInitializer implements Initializer
 {
     public const MESSAGING_SYSTEM_FILE_NAME = 'messaging_system';
 
+    private static ?ContainerDefinitionsHolder $definitionHolder = null;
+
+    public static function getDefinitionHolder(): ?ContainerDefinitionsHolder
+    {
+        return self::$definitionHolder;
+    }
+
+    public static function clearDefinitionHolder(): void
+    {
+        self::$definitionHolder = null;
+    }
+
     public function initialize(Container $container): ConfiguredMessagingSystem
     {
         $config = $this->resolveEcotoneConfig($container);
@@ -45,6 +57,8 @@ final class MessagingSystemInitializer implements Initializer
             $config->test,
             $cacheDirectory,
         );
+
+        self::$definitionHolder = $definitionHolder;
 
         $ecotoneContainer = new LazyInMemoryContainer(
             $definitionHolder->getDefinitions(),

--- a/packages/Tempest/src/MessagingSystemInitializer.php
+++ b/packages/Tempest/src/MessagingSystemInitializer.php
@@ -119,8 +119,11 @@ final class MessagingSystemInitializer implements Initializer
 
     private function wireLogger(Container $container, LazyInMemoryContainer $ecotoneContainer): void
     {
-        if ($container->has(LoggerInterface::class)) {
-            $ecotoneContainer->set(LoggerInterface::class, $container->get(LoggerInterface::class));
+        try {
+            $logger = $container->get(LoggerInterface::class);
+            $ecotoneContainer->set('logger', $logger);
+            $ecotoneContainer->set(LoggerInterface::class, $logger);
+        } catch (\Throwable) {
         }
     }
 

--- a/packages/Tempest/src/MessagingSystemInitializer.php
+++ b/packages/Tempest/src/MessagingSystemInitializer.php
@@ -19,6 +19,7 @@ use Psr\Log\LoggerInterface;
 use Tempest\Container\Container;
 use Tempest\Container\Initializer;
 use Tempest\Container\Singleton;
+use Tempest\Discovery\Composer;
 
 /**
  * licence Apache-2.0
@@ -56,7 +57,7 @@ final class MessagingSystemInitializer implements Initializer
         $environment = getenv('APP_ENV') ?: 'production';
         $useProductionCache = in_array($environment, ['prod', 'production'], true) ? true : $config->cacheConfiguration;
 
-        $applicationConfiguration = $this->buildServiceConfiguration($config, $environment, $cacheDirectory);
+        $applicationConfiguration = $this->buildServiceConfiguration($config, $environment, $cacheDirectory, $container);
 
         [$serviceCacheConfiguration, $definitionHolder, $configHash] = $this->prepareFromCache(
             $useProductionCache,
@@ -100,6 +101,22 @@ final class MessagingSystemInitializer implements Initializer
         return new EcotoneConfig();
     }
 
+    private function deriveNamespacesFromComposer(Container $container): array
+    {
+        try {
+            $composer = $container->get(Composer::class);
+        } catch (\Throwable) {
+            return [];
+        }
+
+        $namespaces = [];
+        foreach ($composer->namespaces as $psr4Namespace) {
+            $namespaces[] = $psr4Namespace->namespace;
+        }
+
+        return $namespaces;
+    }
+
     private function wireLogger(Container $container, LazyInMemoryContainer $ecotoneContainer): void
     {
         if ($container->has(LoggerInterface::class)) {
@@ -111,12 +128,19 @@ final class MessagingSystemInitializer implements Initializer
         EcotoneConfig $config,
         string $environment,
         string $cacheDirectory,
+        Container $container,
     ): ServiceConfiguration {
+        $namespaces = $config->namespaces;
+
+        if ($namespaces === [] && $config->loadAppNamespaces) {
+            $namespaces = $this->deriveNamespacesFromComposer($container);
+        }
+
         $applicationConfiguration = ServiceConfiguration::createWithDefaults()
             ->withEnvironment($environment)
             ->withLoadCatalog('')
             ->withFailFast(false)
-            ->withNamespaces($config->namespaces)
+            ->withNamespaces($namespaces)
             ->withSkippedModulePackageNames($config->skippedModulePackageNames)
             ->withCacheDirectoryPath($cacheDirectory);
 

--- a/packages/Tempest/src/MessagingSystemInitializer.php
+++ b/packages/Tempest/src/MessagingSystemInitializer.php
@@ -29,9 +29,13 @@ final class MessagingSystemInitializer implements Initializer
 {
     public const MESSAGING_SYSTEM_FILE_NAME = 'messaging_system';
 
+    private const CONFIG_HASH_FILE_NAME = 'messaging_system_hash';
+
     private static ?ContainerDefinitionsHolder $definitionHolder = null;
 
     private static ?string $configHash = null;
+
+    private static ?string $proxyDirectory = null;
 
     public static function getDefinitionHolder(): ?ContainerDefinitionsHolder
     {
@@ -43,10 +47,16 @@ final class MessagingSystemInitializer implements Initializer
         return self::$configHash;
     }
 
+    public static function getProxyDirectory(): ?string
+    {
+        return self::$proxyDirectory;
+    }
+
     public static function clearDefinitionHolder(): void
     {
         self::$definitionHolder = null;
         self::$configHash = null;
+        self::$proxyDirectory = null;
     }
 
     public function initialize(Container $container): ConfiguredMessagingSystem
@@ -69,6 +79,7 @@ final class MessagingSystemInitializer implements Initializer
 
         self::$definitionHolder = $definitionHolder;
         self::$configHash = $configHash;
+        self::$proxyDirectory = $cacheDirectory . DIRECTORY_SEPARATOR . 'console_proxies';
 
         $ecotoneContainer = new LazyInMemoryContainer(
             $definitionHolder->getDefinitions(),
@@ -182,7 +193,9 @@ final class MessagingSystemInitializer implements Initializer
                 $definitionHolder = unserialize(file_get_contents($messagingFile));
 
                 if ($definitionHolder instanceof ContainerDefinitionsHolder) {
-                    return [new ServiceCacheConfiguration($cacheDirectory, true), $definitionHolder, null];
+                    $persistedHash = $this->readPersistedConfigHash($cacheDirectory);
+
+                    return [new ServiceCacheConfiguration($cacheDirectory, true), $definitionHolder, $persistedHash];
                 }
             }
         }
@@ -227,9 +240,32 @@ final class MessagingSystemInitializer implements Initializer
             if ($serviceCacheConfiguration->shouldUseCache()) {
                 MessagingSystemConfiguration::prepareCacheDirectory($serviceCacheConfiguration);
                 file_put_contents($messagingSystemCachePath, serialize($definitionHolder));
+
+                if ($useProductionCache && $cacheHash !== null) {
+                    $this->persistConfigHash($cacheDirectory, $cacheHash);
+                }
             }
         }
 
         return [$serviceCacheConfiguration, $definitionHolder, $cacheHash];
+    }
+
+    private function persistConfigHash(string $cacheDirectory, string $configHash): void
+    {
+        $hashFile = $cacheDirectory . DIRECTORY_SEPARATOR . self::CONFIG_HASH_FILE_NAME;
+        file_put_contents($hashFile, $configHash);
+    }
+
+    private function readPersistedConfigHash(string $cacheDirectory): ?string
+    {
+        $hashFile = $cacheDirectory . DIRECTORY_SEPARATOR . self::CONFIG_HASH_FILE_NAME;
+
+        if (! file_exists($hashFile)) {
+            return null;
+        }
+
+        $hash = file_get_contents($hashFile);
+
+        return $hash !== false && $hash !== '' ? $hash : null;
     }
 }

--- a/packages/Tempest/src/MessagingSystemInitializer.php
+++ b/packages/Tempest/src/MessagingSystemInitializer.php
@@ -30,14 +30,22 @@ final class MessagingSystemInitializer implements Initializer
 
     private static ?ContainerDefinitionsHolder $definitionHolder = null;
 
+    private static ?string $configHash = null;
+
     public static function getDefinitionHolder(): ?ContainerDefinitionsHolder
     {
         return self::$definitionHolder;
     }
 
+    public static function getConfigHash(): ?string
+    {
+        return self::$configHash;
+    }
+
     public static function clearDefinitionHolder(): void
     {
         self::$definitionHolder = null;
+        self::$configHash = null;
     }
 
     public function initialize(Container $container): ConfiguredMessagingSystem
@@ -50,7 +58,7 @@ final class MessagingSystemInitializer implements Initializer
 
         $applicationConfiguration = $this->buildServiceConfiguration($config, $environment, $cacheDirectory);
 
-        [$serviceCacheConfiguration, $definitionHolder] = $this->prepareFromCache(
+        [$serviceCacheConfiguration, $definitionHolder, $configHash] = $this->prepareFromCache(
             $useProductionCache,
             $rootPath,
             $applicationConfiguration,
@@ -59,6 +67,7 @@ final class MessagingSystemInitializer implements Initializer
         );
 
         self::$definitionHolder = $definitionHolder;
+        self::$configHash = $configHash;
 
         $ecotoneContainer = new LazyInMemoryContainer(
             $definitionHolder->getDefinitions(),
@@ -144,7 +153,7 @@ final class MessagingSystemInitializer implements Initializer
                 $definitionHolder = unserialize(file_get_contents($messagingFile));
 
                 if ($definitionHolder instanceof ContainerDefinitionsHolder) {
-                    return [new ServiceCacheConfiguration($cacheDirectory, true), $definitionHolder];
+                    return [new ServiceCacheConfiguration($cacheDirectory, true), $definitionHolder, null];
                 }
             }
         }
@@ -192,6 +201,6 @@ final class MessagingSystemInitializer implements Initializer
             }
         }
 
-        return [$serviceCacheConfiguration, $definitionHolder];
+        return [$serviceCacheConfiguration, $definitionHolder, $cacheHash];
     }
 }

--- a/packages/Tempest/src/MessagingSystemInitializer.php
+++ b/packages/Tempest/src/MessagingSystemInitializer.php
@@ -136,6 +136,8 @@ final class MessagingSystemInitializer implements Initializer
             $applicationConfiguration = $applicationConfiguration->withLicenceKey($config->licenceKey);
         }
 
+        $applicationConfiguration = $applicationConfiguration->withExtensionObjects([new TempestRepositoryBuilder()]);
+
         return MessagingSystemConfiguration::addCorePackage($applicationConfiguration, $config->test);
     }
 

--- a/packages/Tempest/src/MessagingSystemInitializer.php
+++ b/packages/Tempest/src/MessagingSystemInitializer.php
@@ -1,0 +1,183 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ecotone\Tempest;
+
+use const DIRECTORY_SEPARATOR;
+
+use Ecotone\AnnotationFinder\AnnotationFinderFactory;
+use Ecotone\Lite\LazyInMemoryContainer;
+use Ecotone\Messaging\Config\ConfiguredMessagingSystem;
+use Ecotone\Messaging\Config\Container\Compiler\ContainerDefinitionsHolder;
+use Ecotone\Messaging\Config\Container\ContainerConfig;
+use Ecotone\Messaging\Config\MessagingSystemConfiguration;
+use Ecotone\Messaging\Config\ServiceCacheConfiguration;
+use Ecotone\Messaging\Config\ServiceConfiguration;
+use Ecotone\Messaging\ConfigurationVariableService;
+use Psr\Log\LoggerInterface;
+use Tempest\Container\Container;
+use Tempest\Container\Initializer;
+use Tempest\Container\Singleton;
+
+/**
+ * licence Apache-2.0
+ */
+#[Singleton]
+final class MessagingSystemInitializer implements Initializer
+{
+    public const MESSAGING_SYSTEM_FILE_NAME = 'messaging_system';
+
+    public function initialize(Container $container): ConfiguredMessagingSystem
+    {
+        $config = $this->resolveEcotoneConfig($container);
+        $rootPath = getcwd();
+        $cacheDirectory = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'ecotone_tempest';
+        $environment = getenv('APP_ENV') ?: 'production';
+        $useProductionCache = in_array($environment, ['prod', 'production'], true) ? true : $config->cacheConfiguration;
+
+        $applicationConfiguration = $this->buildServiceConfiguration($config, $environment, $cacheDirectory);
+
+        [$serviceCacheConfiguration, $definitionHolder] = $this->prepareFromCache(
+            $useProductionCache,
+            $rootPath,
+            $applicationConfiguration,
+            $config->test,
+            $cacheDirectory,
+        );
+
+        $ecotoneContainer = new LazyInMemoryContainer(
+            $definitionHolder->getDefinitions(),
+            new TempestPsrContainerAdapter($container),
+        );
+
+        $ecotoneContainer->set(
+            ConfigurationVariableService::REFERENCE_NAME,
+            new TempestConfigurationVariableService(),
+        );
+
+        $ecotoneContainer->set(
+            ServiceCacheConfiguration::REFERENCE_NAME,
+            $serviceCacheConfiguration,
+        );
+
+        $this->wireLogger($container, $ecotoneContainer);
+
+        EcotoneServiceInitializer::markCompiled(array_keys($definitionHolder->getDefinitions()));
+
+        return $ecotoneContainer->get(ConfiguredMessagingSystem::class);
+    }
+
+    private function resolveEcotoneConfig(Container $container): EcotoneConfig
+    {
+        if ($container->has(EcotoneConfig::class)) {
+            return $container->get(EcotoneConfig::class);
+        }
+
+        return new EcotoneConfig();
+    }
+
+    private function wireLogger(Container $container, LazyInMemoryContainer $ecotoneContainer): void
+    {
+        if ($container->has(LoggerInterface::class)) {
+            $ecotoneContainer->set(LoggerInterface::class, $container->get(LoggerInterface::class));
+        }
+    }
+
+    private function buildServiceConfiguration(
+        EcotoneConfig $config,
+        string $environment,
+        string $cacheDirectory,
+    ): ServiceConfiguration {
+        $applicationConfiguration = ServiceConfiguration::createWithDefaults()
+            ->withEnvironment($environment)
+            ->withLoadCatalog('')
+            ->withFailFast(false)
+            ->withNamespaces($config->namespaces)
+            ->withSkippedModulePackageNames($config->skippedModulePackageNames)
+            ->withCacheDirectoryPath($cacheDirectory);
+
+        if ($config->serviceName !== '') {
+            $applicationConfiguration = $applicationConfiguration->withServiceName($config->serviceName);
+        }
+
+        if ($config->defaultSerializationMediaType !== '') {
+            $applicationConfiguration = $applicationConfiguration->withDefaultSerializationMediaType($config->defaultSerializationMediaType);
+        }
+
+        if ($config->defaultErrorChannel !== '') {
+            $applicationConfiguration = $applicationConfiguration->withDefaultErrorChannel($config->defaultErrorChannel);
+        }
+
+        if ($config->licenceKey !== '') {
+            $applicationConfiguration = $applicationConfiguration->withLicenceKey($config->licenceKey);
+        }
+
+        return MessagingSystemConfiguration::addCorePackage($applicationConfiguration, $config->test);
+    }
+
+    private function prepareFromCache(
+        bool $useProductionCache,
+        string $rootCatalog,
+        ServiceConfiguration $applicationConfiguration,
+        bool $enableTesting,
+        string $cacheDirectory,
+    ): array {
+        if ($useProductionCache && $cacheDirectory) {
+            $messagingFile = $cacheDirectory . DIRECTORY_SEPARATOR . self::MESSAGING_SYSTEM_FILE_NAME;
+
+            if (file_exists($messagingFile)) {
+                $definitionHolder = unserialize(file_get_contents($messagingFile));
+
+                if ($definitionHolder instanceof ContainerDefinitionsHolder) {
+                    return [new ServiceCacheConfiguration($cacheDirectory, true), $definitionHolder];
+                }
+            }
+        }
+
+        $annotationFinder = AnnotationFinderFactory::createForAttributes(
+            realpath($rootCatalog) ?: $rootCatalog,
+            $applicationConfiguration->getNamespaces(),
+            $applicationConfiguration->getEnvironment(),
+            $applicationConfiguration->getLoadedCatalog() ?? '',
+            MessagingSystemConfiguration::getModuleClassesFor($applicationConfiguration),
+            isRunningForTesting: $enableTesting,
+        );
+
+        $cacheHash = $annotationFinder->getCacheMessagingFileNameBasedOnConfig(
+            realpath($rootCatalog) ?: $rootCatalog,
+            $applicationConfiguration,
+            [],
+            $enableTesting,
+        );
+
+        $serviceCacheConfiguration = new ServiceCacheConfiguration(
+            $useProductionCache ? $cacheDirectory : ($cacheDirectory . DIRECTORY_SEPARATOR . $cacheHash),
+            true,
+        );
+
+        $definitionHolder = null;
+        $messagingSystemCachePath = $serviceCacheConfiguration->getPath() . DIRECTORY_SEPARATOR . self::MESSAGING_SYSTEM_FILE_NAME;
+
+        if ($serviceCacheConfiguration->shouldUseCache() && file_exists($messagingSystemCachePath)) {
+            $definitionHolder = unserialize(file_get_contents($messagingSystemCachePath));
+        }
+
+        if (! $definitionHolder instanceof ContainerDefinitionsHolder) {
+            $configuration = MessagingSystemConfiguration::prepareWithAnnotationFinder(
+                $annotationFinder,
+                new TempestConfigurationVariableService(),
+                $applicationConfiguration,
+                enableTestPackage: $enableTesting,
+            );
+            $definitionHolder = ContainerConfig::buildDefinitionHolder($configuration);
+
+            if ($serviceCacheConfiguration->shouldUseCache()) {
+                MessagingSystemConfiguration::prepareCacheDirectory($serviceCacheConfiguration);
+                file_put_contents($messagingSystemCachePath, serialize($definitionHolder));
+            }
+        }
+
+        return [$serviceCacheConfiguration, $definitionHolder];
+    }
+}

--- a/packages/Tempest/src/TempestConfigurationVariableService.php
+++ b/packages/Tempest/src/TempestConfigurationVariableService.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ecotone\Tempest;
+
+use Ecotone\Messaging\ConfigurationVariableService;
+
+use function Tempest\env;
+
+/**
+ * licence Apache-2.0
+ */
+final class TempestConfigurationVariableService implements ConfigurationVariableService
+{
+    public function getByName(string $name): mixed
+    {
+        return env($name);
+    }
+
+    public function hasName(string $name): bool
+    {
+        return getenv($name) !== false;
+    }
+}

--- a/packages/Tempest/src/TempestPsrContainerAdapter.php
+++ b/packages/Tempest/src/TempestPsrContainerAdapter.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ecotone\Tempest;
+
+use Psr\Container\ContainerInterface;
+use ReflectionClass;
+use ReflectionException;
+use Tempest\Container\Container;
+
+/**
+ * licence Apache-2.0
+ */
+final class TempestPsrContainerAdapter implements ContainerInterface
+{
+    public function __construct(private Container $container)
+    {
+    }
+
+    public function get(string $id): mixed
+    {
+        return $this->container->get($id);
+    }
+
+    public function has(string $id): bool
+    {
+        if ($this->container->has($id)) {
+            return true;
+        }
+
+        if (! class_exists($id) && ! interface_exists($id)) {
+            return false;
+        }
+
+        try {
+            $reflection = new ReflectionClass($id);
+            return $reflection->isInstantiable();
+        } catch (ReflectionException) {
+            return false;
+        }
+    }
+}

--- a/packages/Tempest/src/TempestRepository.php
+++ b/packages/Tempest/src/TempestRepository.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ecotone\Tempest;
+
+use Ecotone\Modelling\StandardRepository;
+use Tempest\Database\IsDatabaseModel;
+
+/**
+ * licence Apache-2.0
+ */
+final class TempestRepository implements StandardRepository
+{
+    public function canHandle(string $aggregateClassName): bool
+    {
+        return $this->classUsesTrait($aggregateClassName, IsDatabaseModel::class);
+    }
+
+    public function findBy(string $aggregateClassName, array $identifiers): ?object
+    {
+        return $aggregateClassName::findById(array_pop($identifiers));
+    }
+
+    public function save(array $identifiers, object $aggregate, array $metadata, ?int $versionBeforeHandling): void
+    {
+        $aggregate->save();
+    }
+
+    private function classUsesTrait(string $className, string $traitName): bool
+    {
+        foreach ($this->collectAllTraits($className) as $usedTrait) {
+            if ($usedTrait === $traitName) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function collectAllTraits(string $className): array
+    {
+        $traits = [];
+
+        $class = $className;
+        while ($class !== false) {
+            $traits = array_merge($traits, $this->collectTraitsRecursively(class_uses($class) ?: []));
+            $class = get_parent_class($class);
+        }
+
+        return $traits;
+    }
+
+    private function collectTraitsRecursively(array $traits): array
+    {
+        $collected = array_values($traits);
+
+        foreach ($traits as $trait) {
+            $nestedTraits = class_uses($trait) ?: [];
+            if ($nestedTraits !== []) {
+                $collected = array_merge($collected, $this->collectTraitsRecursively($nestedTraits));
+            }
+        }
+
+        return $collected;
+    }
+}

--- a/packages/Tempest/src/TempestRepositoryBuilder.php
+++ b/packages/Tempest/src/TempestRepositoryBuilder.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ecotone\Tempest;
+
+use Ecotone\Messaging\Config\Container\Definition;
+use Ecotone\Messaging\Config\Container\MessagingContainerBuilder;
+use Ecotone\Messaging\Config\Container\Reference;
+use Ecotone\Modelling\RepositoryBuilder;
+
+/**
+ * licence Apache-2.0
+ */
+final class TempestRepositoryBuilder implements RepositoryBuilder
+{
+    private TempestRepository $tempestRepository;
+
+    public function __construct()
+    {
+        $this->tempestRepository = new TempestRepository();
+    }
+
+    public function canHandle(string $aggregateClassName): bool
+    {
+        return $this->tempestRepository->canHandle($aggregateClassName);
+    }
+
+    public function compile(MessagingContainerBuilder $builder): Definition|Reference
+    {
+        return new Definition(TempestRepository::class);
+    }
+}

--- a/packages/Tempest/tests/Application/AppNamespaceAutoDiscoveryTest.php
+++ b/packages/Tempest/tests/Application/AppNamespaceAutoDiscoveryTest.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Ecotone\Tempest\Application;
+
+use Ecotone\Messaging\Config\ModulePackageList;
+use Ecotone\Modelling\CommandBus;
+use Ecotone\Modelling\QueryBus;
+use Ecotone\Tempest\EcotoneConfig;
+use Ecotone\Tempest\EcotoneServiceInitializer;
+use Ecotone\Tempest\MessagingSystemInitializer;
+use Tempest\Core\FrameworkKernel;
+use Tempest\Core\KernelEvent;
+use Tempest\Discovery\AutoloadDiscoveryLocations;
+use Tempest\Discovery\Composer;
+use Tempest\Discovery\DiscoveryConfig;
+use Tempest\Discovery\DiscoveryLocation;
+use Tempest\Framework\Testing\IntegrationTest;
+
+/**
+ * licence Apache-2.0
+ * @internal
+ */
+final class AppNamespaceAutoDiscoveryTest extends IntegrationTest
+{
+    protected string $root = '/data/app/packages/Tempest/tests/app';
+
+    public function setUp(): void
+    {
+        EcotoneServiceInitializer::clearCache();
+        $this->internalStorage = '/tmp/ecotone_tempest_auto_ns_' . getmypid();
+        $this->setupKernel();
+    }
+
+    public function setupKernel(): self
+    {
+        EcotoneServiceInitializer::clearCache();
+
+        $appSrcLocation = new DiscoveryLocation('App\\Tempest\\', '/data/app/packages/Tempest/tests/app/src');
+
+        $allLocations = [
+            new DiscoveryLocation('Ecotone\\Tempest\\', '/data/app/packages/Tempest/src'),
+            $appSrcLocation,
+        ];
+
+        $kernel = new FrameworkKernel(
+            root: $this->root,
+            discoveryLocations: $allLocations,
+            internalStorage: $this->internalStorage,
+        );
+
+        $kernel->registerKernel()
+               ->validateRoot()
+               ->loadEnv()
+               ->registerEmergencyExceptionHandler()
+               ->registerShutdownFunction()
+               ->registerInternalStorage()
+               ->loadComposer();
+
+        $this->injectDiscoveryConfig($kernel, $allLocations);
+
+        $kernel->container->config(new EcotoneConfig(
+            skippedModulePackageNames: ModulePackageList::allPackages(),
+            test: true,
+        ));
+
+        $kernel->loadConfig()
+               ->bootDiscovery()
+               ->registerExceptionHandler()
+               ->event(KernelEvent::BOOTED);
+
+        $this->kernel = $kernel;
+        $this->container = $kernel->container;
+
+        return $this;
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+        restore_exception_handler();
+        restore_error_handler();
+        EcotoneServiceInitializer::clearCache();
+        MessagingSystemInitializer::clearDefinitionHolder();
+    }
+
+    private function injectDiscoveryConfig(FrameworkKernel $kernel, array $extraLocations): void
+    {
+        $testAppComposer = (new Composer($this->root))->load();
+        $testAppComposer->namespaces = [];
+
+        $autoloadLocations = (new AutoloadDiscoveryLocations(
+            rootPath: '/data/app',
+            composer: $testAppComposer,
+        ))();
+
+        $discoveryConfig = $kernel->container->get(DiscoveryConfig::class);
+        $discoveryConfig->locations = [...$extraLocations, ...$autoloadLocations];
+
+        $kernel->container->config($discoveryConfig);
+        $kernel->discoveryConfig = $discoveryConfig;
+    }
+
+    public function test_handlers_in_app_namespace_discovered_without_explicit_namespaces_config(): void
+    {
+        $commandBus = $this->container->get(CommandBus::class);
+        $queryBus = $this->container->get(QueryBus::class);
+
+        $commandBus->sendWithRouting('app.ping');
+
+        $this->assertTrue($queryBus->sendWithRouting('app.wasHandled'));
+    }
+}

--- a/packages/Tempest/tests/Application/AppNamespaceAutoDiscoveryTest.php
+++ b/packages/Tempest/tests/Application/AppNamespaceAutoDiscoveryTest.php
@@ -17,6 +17,7 @@ use Tempest\Discovery\Composer;
 use Tempest\Discovery\DiscoveryConfig;
 use Tempest\Discovery\DiscoveryLocation;
 use Tempest\Framework\Testing\IntegrationTest;
+use Test\Ecotone\Tempest\TempestTestPaths;
 
 /**
  * licence Apache-2.0
@@ -24,7 +25,7 @@ use Tempest\Framework\Testing\IntegrationTest;
  */
 final class AppNamespaceAutoDiscoveryTest extends IntegrationTest
 {
-    protected string $root = '/data/app/packages/Tempest/tests/app';
+    protected string $root = '';
 
     public function setUp(): void
     {
@@ -35,12 +36,16 @@ final class AppNamespaceAutoDiscoveryTest extends IntegrationTest
 
     public function setupKernel(): self
     {
+        if ($this->root === '') {
+            $this->root = TempestTestPaths::appRoot();
+        }
+
         EcotoneServiceInitializer::clearCache();
 
-        $appSrcLocation = new DiscoveryLocation('App\\Tempest\\', '/data/app/packages/Tempest/tests/app/src');
+        $appSrcLocation = new DiscoveryLocation('App\\Tempest\\', TempestTestPaths::appRoot() . '/src');
 
         $allLocations = [
-            new DiscoveryLocation('Ecotone\\Tempest\\', '/data/app/packages/Tempest/src'),
+            new DiscoveryLocation('Ecotone\\Tempest\\', TempestTestPaths::srcPath()),
             $appSrcLocation,
         ];
 
@@ -91,7 +96,7 @@ final class AppNamespaceAutoDiscoveryTest extends IntegrationTest
         $testAppComposer->namespaces = [];
 
         $autoloadLocations = (new AutoloadDiscoveryLocations(
-            rootPath: '/data/app',
+            rootPath: TempestTestPaths::discoveryRoot(),
             composer: $testAppComposer,
         ))();
 

--- a/packages/Tempest/tests/Application/BusinessInterfaceResolutionTest.php
+++ b/packages/Tempest/tests/Application/BusinessInterfaceResolutionTest.php
@@ -6,14 +6,14 @@ namespace Test\Ecotone\Tempest\Application;
 
 use Ecotone\Messaging\Config\ModulePackageList;
 use Ecotone\Tempest\EcotoneConfig;
-use Test\Ecotone\Tempest\EcotoneIntegrationTest;
+use Test\Ecotone\Tempest\EcotoneIntegrationTestCase;
 use Test\Ecotone\Tempest\Fixture\Counter\CounterGateway;
 
 /**
  * licence Apache-2.0
  * @internal
  */
-final class BusinessInterfaceResolutionTest extends EcotoneIntegrationTest
+final class BusinessInterfaceResolutionTest extends EcotoneIntegrationTestCase
 {
     protected function ecotoneConfig(): EcotoneConfig
     {

--- a/packages/Tempest/tests/Application/BusinessInterfaceResolutionTest.php
+++ b/packages/Tempest/tests/Application/BusinessInterfaceResolutionTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Ecotone\Tempest\Application;
+
+use Ecotone\Messaging\Config\ModulePackageList;
+use Ecotone\Tempest\EcotoneConfig;
+use Test\Ecotone\Tempest\EcotoneIntegrationTest;
+use Test\Ecotone\Tempest\Fixture\Counter\CounterGateway;
+
+/**
+ * licence Apache-2.0
+ * @internal
+ */
+final class BusinessInterfaceResolutionTest extends EcotoneIntegrationTest
+{
+    protected function ecotoneConfig(): EcotoneConfig
+    {
+        return new EcotoneConfig(
+            namespaces: ['Test\\Ecotone\\Tempest\\Fixture\\Counter\\'],
+            skippedModulePackageNames: ModulePackageList::allPackages(),
+            test: true,
+        );
+    }
+
+    public function test_custom_business_interface_resolves_as_first_ecotone_touch(): void
+    {
+        $counterGateway = $this->container->get(CounterGateway::class);
+
+        $this->assertInstanceOf(CounterGateway::class, $counterGateway);
+    }
+
+    public function test_custom_business_interface_forwards_to_handler_when_resolved_first(): void
+    {
+        $counterGateway = $this->container->get(CounterGateway::class);
+
+        $commandBus = $this->container->get(\Ecotone\Modelling\CommandBus::class);
+        $commandBus->sendWithRouting('counter.increment');
+
+        $this->assertSame(1, $counterGateway->get());
+    }
+}

--- a/packages/Tempest/tests/Application/CacheClearCommandTest.php
+++ b/packages/Tempest/tests/Application/CacheClearCommandTest.php
@@ -7,13 +7,13 @@ namespace Test\Ecotone\Tempest\Application;
 use Ecotone\Messaging\Config\ModulePackageList;
 use Ecotone\Tempest\EcotoneConfig;
 use Ecotone\Tempest\MessagingSystemInitializer;
-use Test\Ecotone\Tempest\EcotoneIntegrationTest;
+use Test\Ecotone\Tempest\EcotoneIntegrationTestCase;
 
 /**
  * licence Apache-2.0
  * @internal
  */
-final class CacheClearCommandTest extends EcotoneIntegrationTest
+final class CacheClearCommandTest extends EcotoneIntegrationTestCase
 {
     protected function ecotoneConfig(): EcotoneConfig
     {

--- a/packages/Tempest/tests/Application/CacheClearCommandTest.php
+++ b/packages/Tempest/tests/Application/CacheClearCommandTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Ecotone\Tempest\Application;
+
+use Ecotone\Messaging\Config\ModulePackageList;
+use Ecotone\Tempest\EcotoneConfig;
+use Ecotone\Tempest\MessagingSystemInitializer;
+use Test\Ecotone\Tempest\EcotoneIntegrationTest;
+
+/**
+ * licence Apache-2.0
+ * @internal
+ */
+final class CacheClearCommandTest extends EcotoneIntegrationTest
+{
+    protected function ecotoneConfig(): EcotoneConfig
+    {
+        return new EcotoneConfig(
+            namespaces: ['Test\\Ecotone\\Tempest\\Fixture\\'],
+            skippedModulePackageNames: ModulePackageList::allPackages(),
+            test: true,
+        );
+    }
+
+    public function test_cache_clear_command_removes_messaging_system_cache_file(): void
+    {
+        $cacheDir = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'ecotone_tempest';
+        @mkdir($cacheDir, 0777, true);
+        $messagingFile = $cacheDir . DIRECTORY_SEPARATOR . MessagingSystemInitializer::MESSAGING_SYSTEM_FILE_NAME;
+        file_put_contents($messagingFile, 'test_cache_content');
+
+        $this->assertTrue(file_exists($messagingFile));
+
+        $this->console
+            ->call('ecotone:cache:clear')
+            ->assertSuccess();
+
+        $this->assertFalse(file_exists($messagingFile));
+    }
+
+    public function test_cache_clear_command_removes_proxy_files(): void
+    {
+        $proxyDir = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'ecotone_tempest' . DIRECTORY_SEPARATOR . 'console_proxies';
+        @mkdir($proxyDir, 0777, true);
+        $proxyFile = $proxyDir . DIRECTORY_SEPARATOR . 'SomeProxy.php';
+        file_put_contents($proxyFile, '<?php // proxy');
+
+        $this->assertTrue(file_exists($proxyFile));
+
+        $this->console
+            ->call('ecotone:cache:clear')
+            ->assertSuccess();
+
+        $this->assertFalse(file_exists($proxyFile));
+    }
+}

--- a/packages/Tempest/tests/Application/ConsoleCommandEndToEndTest.php
+++ b/packages/Tempest/tests/Application/ConsoleCommandEndToEndTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Ecotone\Tempest\Application;
+
+use Ecotone\Messaging\Config\ModulePackageList;
+use Ecotone\Tempest\EcotoneConfig;
+use Test\Ecotone\Tempest\EcotoneIntegrationTest;
+
+/**
+ * licence Apache-2.0
+ * @internal
+ */
+final class ConsoleCommandEndToEndTest extends EcotoneIntegrationTest
+{
+    protected function ecotoneConfig(): EcotoneConfig
+    {
+        return new EcotoneConfig(
+            namespaces: ['Test\\Ecotone\\Tempest\\Fixture\\'],
+            skippedModulePackageNames: ModulePackageList::allPackagesExcept([ModulePackageList::ASYNCHRONOUS_PACKAGE]),
+            test: true,
+        );
+    }
+
+    public function test_ecotone_list_shows_registered_async_consumer(): void
+    {
+        $this->console
+            ->call('ecotone:list')
+            ->assertSuccess()
+            ->assertContains('ecotone_test_queue');
+    }
+
+    public function test_ecotone_run_command_runs_async_consumer_through_tempest_console_runner_by_name(): void
+    {
+        $this->console
+            ->call('ecotone:run', ['consumerName' => 'ecotone_test_queue', 'finishWhenNoMessages' => 'true'])
+            ->assertSuccess();
+    }
+}

--- a/packages/Tempest/tests/Application/ConsoleCommandEndToEndTest.php
+++ b/packages/Tempest/tests/Application/ConsoleCommandEndToEndTest.php
@@ -6,13 +6,13 @@ namespace Test\Ecotone\Tempest\Application;
 
 use Ecotone\Messaging\Config\ModulePackageList;
 use Ecotone\Tempest\EcotoneConfig;
-use Test\Ecotone\Tempest\EcotoneIntegrationTest;
+use Test\Ecotone\Tempest\EcotoneIntegrationTestCase;
 
 /**
  * licence Apache-2.0
  * @internal
  */
-final class ConsoleCommandEndToEndTest extends EcotoneIntegrationTest
+final class ConsoleCommandEndToEndTest extends EcotoneIntegrationTestCase
 {
     protected function ecotoneConfig(): EcotoneConfig
     {

--- a/packages/Tempest/tests/Application/ConsoleCommandProxyTest.php
+++ b/packages/Tempest/tests/Application/ConsoleCommandProxyTest.php
@@ -8,13 +8,13 @@ use Ecotone\Messaging\Config\ConsoleCommandConfiguration;
 use Ecotone\Messaging\Config\ModulePackageList;
 use Ecotone\Tempest\ConsoleCommandProxyGenerator;
 use Ecotone\Tempest\EcotoneConfig;
-use Test\Ecotone\Tempest\EcotoneIntegrationTest;
+use Test\Ecotone\Tempest\EcotoneIntegrationTestCase;
 
 /**
  * licence Apache-2.0
  * @internal
  */
-final class ConsoleCommandProxyTest extends EcotoneIntegrationTest
+final class ConsoleCommandProxyTest extends EcotoneIntegrationTestCase
 {
     protected function ecotoneConfig(): EcotoneConfig
     {

--- a/packages/Tempest/tests/Application/ConsoleCommandProxyTest.php
+++ b/packages/Tempest/tests/Application/ConsoleCommandProxyTest.php
@@ -4,8 +4,11 @@ declare(strict_types=1);
 
 namespace Test\Ecotone\Tempest\Application;
 
+use Ecotone\Messaging\Config\ConfiguredMessagingSystem;
 use Ecotone\Messaging\Config\ConsoleCommandConfiguration;
+use Ecotone\Messaging\Config\ConsoleCommandResultSet;
 use Ecotone\Messaging\Config\ModulePackageList;
+use Ecotone\Messaging\Gateway\ConsoleCommandRunner;
 use Ecotone\Tempest\ConsoleCommandProxyGenerator;
 use Ecotone\Tempest\EcotoneConfig;
 use Test\Ecotone\Tempest\EcotoneIntegrationTest;
@@ -57,6 +60,19 @@ final class ConsoleCommandProxyTest extends EcotoneIntegrationTest
 
         $this->assertArrayHasKey('ecotone:list', $consoleConfig->commands);
         $this->assertArrayHasKey('ecotone:run', $consoleConfig->commands);
+    }
+
+    public function test_generated_proxy_invoke_forwards_to_ecotone_console_command_runner_and_returns_exit_success(): void
+    {
+        $proxyClassName = 'Ecotone\\Tempest\\Generated\\EcotoneConsoleCommand_ecotone_list';
+
+        $this->assertTrue(class_exists($proxyClassName));
+
+        $proxy = $this->container->get($proxyClassName);
+
+        $result = $proxy->__invoke();
+
+        $this->assertSame(\Tempest\Console\ExitCode::SUCCESS, $result);
     }
 
     public function test_proxy_files_are_not_rewritten_when_config_hash_is_unchanged(): void

--- a/packages/Tempest/tests/Application/ConsoleCommandProxyTest.php
+++ b/packages/Tempest/tests/Application/ConsoleCommandProxyTest.php
@@ -4,11 +4,8 @@ declare(strict_types=1);
 
 namespace Test\Ecotone\Tempest\Application;
 
-use Ecotone\Messaging\Config\ConfiguredMessagingSystem;
 use Ecotone\Messaging\Config\ConsoleCommandConfiguration;
-use Ecotone\Messaging\Config\ConsoleCommandResultSet;
 use Ecotone\Messaging\Config\ModulePackageList;
-use Ecotone\Messaging\Gateway\ConsoleCommandRunner;
 use Ecotone\Tempest\ConsoleCommandProxyGenerator;
 use Ecotone\Tempest\EcotoneConfig;
 use Test\Ecotone\Tempest\EcotoneIntegrationTest;
@@ -100,6 +97,39 @@ final class ConsoleCommandProxyTest extends EcotoneIntegrationTest
             @unlink($file);
         }
         @unlink($outputDir . '/.ecotone_hash');
+        @rmdir($outputDir);
+    }
+
+    public function test_ecotone_list_command_runs_through_tempest_console_runner_by_name_and_prints_column_headers(): void
+    {
+        $this->console
+            ->call('ecotone:list')
+            ->assertSuccess()
+            ->assertContains('Name');
+    }
+
+    public function test_generator_produces_proxy_code_that_prints_console_command_result_set(): void
+    {
+        $outputDir = sys_get_temp_dir() . '/ecotone_proxy_result_test_' . getmypid();
+
+        $generator = new ConsoleCommandProxyGenerator();
+        $generatedClasses = $generator->generate(
+            [
+                ConsoleCommandConfiguration::create(
+                    'ecotone.channel.ecotone:list',
+                    'ecotone:list',
+                    [],
+                ),
+            ],
+            $outputDir,
+        );
+
+        $fileContent = file_get_contents($generatedClasses[0]);
+        $this->assertStringContainsString('Console $console', $fileContent);
+        $this->assertStringContainsString('ConsoleCommandResultSet', $fileContent);
+        $this->assertStringContainsString('writeln', $fileContent);
+
+        array_map('unlink', $generatedClasses);
         @rmdir($outputDir);
     }
 

--- a/packages/Tempest/tests/Application/ConsoleCommandProxyTest.php
+++ b/packages/Tempest/tests/Application/ConsoleCommandProxyTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Test\Ecotone\Tempest\Application;
 
+use Ecotone\Messaging\Config\ConsoleCommandConfiguration;
 use Ecotone\Messaging\Config\ModulePackageList;
 use Ecotone\Tempest\ConsoleCommandProxyGenerator;
 use Ecotone\Tempest\EcotoneConfig;
@@ -31,7 +32,7 @@ final class ConsoleCommandProxyTest extends EcotoneIntegrationTest
         $generator = new ConsoleCommandProxyGenerator();
         $generatedClasses = $generator->generate(
             [
-                \Ecotone\Messaging\Config\ConsoleCommandConfiguration::create(
+                ConsoleCommandConfiguration::create(
                     'ecotone.channel.ecotone:list',
                     'ecotone:list',
                     [],
@@ -56,5 +57,60 @@ final class ConsoleCommandProxyTest extends EcotoneIntegrationTest
 
         $this->assertArrayHasKey('ecotone:list', $consoleConfig->commands);
         $this->assertArrayHasKey('ecotone:run', $consoleConfig->commands);
+    }
+
+    public function test_proxy_files_are_not_rewritten_when_config_hash_is_unchanged(): void
+    {
+        $outputDir = sys_get_temp_dir() . '/ecotone_proxy_hash_test_' . getmypid();
+        $commands = [
+            ConsoleCommandConfiguration::create('ecotone.channel.ecotone:list', 'ecotone:list', []),
+        ];
+        $configHash = 'abc123';
+
+        $generator = new ConsoleCommandProxyGenerator();
+        $firstFiles = $generator->generate($commands, $outputDir, $configHash);
+
+        $mtimeBefore = filemtime($firstFiles[0]);
+
+        sleep(1);
+
+        $secondFiles = $generator->generate($commands, $outputDir, $configHash);
+
+        $mtimeAfter = filemtime($secondFiles[0]);
+
+        $this->assertSame($mtimeBefore, $mtimeAfter);
+
+        foreach ($firstFiles as $file) {
+            @unlink($file);
+        }
+        @unlink($outputDir . '/.ecotone_hash');
+        @rmdir($outputDir);
+    }
+
+    public function test_proxy_files_are_rewritten_when_config_hash_changes(): void
+    {
+        $outputDir = sys_get_temp_dir() . '/ecotone_proxy_rehash_test_' . getmypid();
+        $commands = [
+            ConsoleCommandConfiguration::create('ecotone.channel.ecotone:list', 'ecotone:list', []),
+        ];
+
+        $generator = new ConsoleCommandProxyGenerator();
+        $firstFiles = $generator->generate($commands, $outputDir, 'hash_v1');
+
+        $mtimeBefore = filemtime($firstFiles[0]);
+
+        sleep(1);
+
+        $secondFiles = $generator->generate($commands, $outputDir, 'hash_v2');
+
+        $mtimeAfter = filemtime($secondFiles[0]);
+
+        $this->assertGreaterThan($mtimeBefore, $mtimeAfter);
+
+        foreach ($secondFiles as $file) {
+            @unlink($file);
+        }
+        @unlink($outputDir . '/.ecotone_hash');
+        @rmdir($outputDir);
     }
 }

--- a/packages/Tempest/tests/Application/ConsoleCommandProxyTest.php
+++ b/packages/Tempest/tests/Application/ConsoleCommandProxyTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Ecotone\Tempest\Application;
+
+use Ecotone\Messaging\Config\ModulePackageList;
+use Ecotone\Tempest\ConsoleCommandProxyGenerator;
+use Ecotone\Tempest\EcotoneConfig;
+use Test\Ecotone\Tempest\EcotoneIntegrationTest;
+
+/**
+ * licence Apache-2.0
+ * @internal
+ */
+final class ConsoleCommandProxyTest extends EcotoneIntegrationTest
+{
+    protected function ecotoneConfig(): EcotoneConfig
+    {
+        return new EcotoneConfig(
+            namespaces: ['Test\\Ecotone\\Tempest\\Fixture\\'],
+            skippedModulePackageNames: ModulePackageList::allPackages(),
+            test: true,
+        );
+    }
+
+    public function test_generator_produces_proxy_files_for_registered_ecotone_commands(): void
+    {
+        $outputDir = sys_get_temp_dir() . '/ecotone_proxy_test_' . getmypid();
+
+        $generator = new ConsoleCommandProxyGenerator();
+        $generatedClasses = $generator->generate(
+            [
+                \Ecotone\Messaging\Config\ConsoleCommandConfiguration::create(
+                    'ecotone.channel.ecotone:list',
+                    'ecotone:list',
+                    [],
+                ),
+            ],
+            $outputDir,
+        );
+
+        $this->assertCount(1, $generatedClasses);
+        $this->assertFileExists($generatedClasses[0]);
+
+        $fileContent = file_get_contents($generatedClasses[0]);
+        $this->assertStringContainsString("name: 'ecotone:list'", $fileContent);
+
+        array_map('unlink', $generatedClasses);
+        @rmdir($outputDir);
+    }
+
+    public function test_ecotone_commands_are_registered_in_tempest_console_config(): void
+    {
+        $consoleConfig = $this->container->get(\Tempest\Console\ConsoleConfig::class);
+
+        $this->assertArrayHasKey('ecotone:list', $consoleConfig->commands);
+        $this->assertArrayHasKey('ecotone:run', $consoleConfig->commands);
+    }
+}

--- a/packages/Tempest/tests/Application/CoverageParityTest.php
+++ b/packages/Tempest/tests/Application/CoverageParityTest.php
@@ -9,7 +9,7 @@ use Ecotone\Modelling\CommandBus;
 use Ecotone\Tempest\EcotoneConfig;
 use Ecotone\Tempest\EcotoneServiceInitializer;
 use Ecotone\Tempest\MessagingSystemInitializer;
-use Test\Ecotone\Tempest\EcotoneIntegrationTest;
+use Test\Ecotone\Tempest\EcotoneIntegrationTestCase;
 use Test\Ecotone\Tempest\Fixture\User\User;
 use Test\Ecotone\Tempest\Fixture\User\UserRepository;
 
@@ -17,7 +17,7 @@ use Test\Ecotone\Tempest\Fixture\User\UserRepository;
  * licence Apache-2.0
  * @internal
  */
-final class CoverageParityTest extends EcotoneIntegrationTest
+final class CoverageParityTest extends EcotoneIntegrationTestCase
 {
     protected function ecotoneConfig(): EcotoneConfig
     {

--- a/packages/Tempest/tests/Application/CoverageParityTest.php
+++ b/packages/Tempest/tests/Application/CoverageParityTest.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Ecotone\Tempest\Application;
+
+use Ecotone\Messaging\Config\ModulePackageList;
+use Ecotone\Modelling\CommandBus;
+use Ecotone\Modelling\QueryBus;
+use Ecotone\Tempest\EcotoneConfig;
+use Ecotone\Tempest\EcotoneServiceInitializer;
+use Ecotone\Tempest\MessagingSystemInitializer;
+use Test\Ecotone\Tempest\EcotoneIntegrationTest;
+use Test\Ecotone\Tempest\Fixture\User\User;
+use Test\Ecotone\Tempest\Fixture\User\UserRepository;
+
+/**
+ * licence Apache-2.0
+ * @internal
+ */
+final class CoverageParityTest extends EcotoneIntegrationTest
+{
+    protected function ecotoneConfig(): EcotoneConfig
+    {
+        return new EcotoneConfig(
+            namespaces: ['Test\\Ecotone\\Tempest\\Fixture\\User\\'],
+            skippedModulePackageNames: ModulePackageList::allPackages(),
+            test: true,
+            cacheConfiguration: true,
+        );
+    }
+
+    protected function setUp(): void
+    {
+        $this->clearEcotoneTempestCacheDir();
+        parent::setUp();
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+        $this->clearEcotoneTempestCacheDir();
+    }
+
+    public function test_handlers_work_on_warm_prod_cache_boot(): void
+    {
+        $userId = 'warm-cache-user';
+
+        $commandBus = $this->container->get(CommandBus::class);
+        $commandBus->sendWithRouting('user.register', $userId);
+
+        $userRepository = $this->container->get(UserRepository::class);
+
+        $this->assertEquals(
+            User::register($userId),
+            $userRepository->getUser($userId),
+        );
+
+        EcotoneServiceInitializer::clearCache();
+        MessagingSystemInitializer::clearDefinitionHolder();
+
+        $this->setupKernel();
+
+        $commandBus = $this->container->get(CommandBus::class);
+        $commandBus->sendWithRouting('user.register', $userId);
+
+        $userRepository = $this->container->get(UserRepository::class);
+
+        $this->assertEquals(
+            User::register($userId),
+            $userRepository->getUser($userId),
+        );
+    }
+
+    public function test_default_error_channel_configured_in_ecotone_config_does_not_break_boot(): void
+    {
+        $this->assertInstanceOf(
+            CommandBus::class,
+            $this->container->get(CommandBus::class),
+        );
+    }
+
+    private function clearEcotoneTempestCacheDir(): void
+    {
+        $dir = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'ecotone_tempest';
+        if (! is_dir($dir)) {
+            return;
+        }
+        foreach (glob($dir . '/*') ?: [] as $file) {
+            is_dir($file) ? $this->removeDirectory($file) : @unlink($file);
+        }
+        @rmdir($dir);
+    }
+
+    private function removeDirectory(string $dir): void
+    {
+        foreach (glob($dir . '/*') ?: [] as $file) {
+            is_dir($file) ? $this->removeDirectory($file) : @unlink($file);
+        }
+        @rmdir($dir);
+    }
+}

--- a/packages/Tempest/tests/Application/CoverageParityTest.php
+++ b/packages/Tempest/tests/Application/CoverageParityTest.php
@@ -6,7 +6,6 @@ namespace Test\Ecotone\Tempest\Application;
 
 use Ecotone\Messaging\Config\ModulePackageList;
 use Ecotone\Modelling\CommandBus;
-use Ecotone\Modelling\QueryBus;
 use Ecotone\Tempest\EcotoneConfig;
 use Ecotone\Tempest\EcotoneServiceInitializer;
 use Ecotone\Tempest\MessagingSystemInitializer;

--- a/packages/Tempest/tests/Application/LicenceKeyTest.php
+++ b/packages/Tempest/tests/Application/LicenceKeyTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Ecotone\Tempest\Application;
+
+use Ecotone\Messaging\Config\ModulePackageList;
+use Ecotone\Modelling\CommandBus;
+use Ecotone\Tempest\EcotoneConfig;
+use Ecotone\Test\LicenceTesting;
+use Test\Ecotone\Tempest\EcotoneIntegrationTest;
+
+/**
+ * licence Enterprise
+ * @internal
+ */
+final class LicenceKeyTest extends EcotoneIntegrationTest
+{
+    protected function ecotoneConfig(): EcotoneConfig
+    {
+        return new EcotoneConfig(
+            namespaces: ['Test\\Ecotone\\Tempest\\Fixture\\User\\'],
+            skippedModulePackageNames: ModulePackageList::allPackages(),
+            test: true,
+            licenceKey: LicenceTesting::VALID_LICENCE,
+        );
+    }
+
+    public function test_booting_with_licence_key_does_not_prevent_system_from_functioning(): void
+    {
+        $this->assertInstanceOf(
+            CommandBus::class,
+            $this->container->get(CommandBus::class),
+        );
+    }
+}

--- a/packages/Tempest/tests/Application/LicenceKeyTest.php
+++ b/packages/Tempest/tests/Application/LicenceKeyTest.php
@@ -8,13 +8,13 @@ use Ecotone\Messaging\Config\ModulePackageList;
 use Ecotone\Modelling\CommandBus;
 use Ecotone\Tempest\EcotoneConfig;
 use Ecotone\Test\LicenceTesting;
-use Test\Ecotone\Tempest\EcotoneIntegrationTest;
+use Test\Ecotone\Tempest\EcotoneIntegrationTestCase;
 
 /**
  * licence Enterprise
  * @internal
  */
-final class LicenceKeyTest extends EcotoneIntegrationTest
+final class LicenceKeyTest extends EcotoneIntegrationTestCase
 {
     protected function ecotoneConfig(): EcotoneConfig
     {

--- a/packages/Tempest/tests/Application/LoggerWiringTest.php
+++ b/packages/Tempest/tests/Application/LoggerWiringTest.php
@@ -1,0 +1,142 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Ecotone\Tempest\Application;
+
+use Ecotone\Messaging\Config\ModulePackageList;
+use Ecotone\Modelling\QueryBus;
+use Ecotone\Tempest\EcotoneConfig;
+use Ecotone\Tempest\EcotoneServiceInitializer;
+use Ecotone\Tempest\MessagingSystemInitializer;
+use Monolog\Handler\TestHandler;
+use Monolog\Level;
+use Tempest\Core\FrameworkKernel;
+use Tempest\Core\KernelEvent;
+use Tempest\Discovery\AutoloadDiscoveryLocations;
+use Tempest\Discovery\Composer;
+use Tempest\Discovery\DiscoveryConfig;
+use Tempest\Discovery\DiscoveryLocation;
+use Tempest\Framework\Testing\IntegrationTest;
+use Tempest\Log\LogChannel;
+use Tempest\Log\Config\MultipleChannelsLogConfig;
+
+/**
+ * licence Apache-2.0
+ * @internal
+ */
+final class LoggerWiringTest extends IntegrationTest
+{
+    protected string $root = '/data/app/packages/Tempest/tests/app';
+
+    private TestHandler $logHandler;
+
+    public function setUp(): void
+    {
+        EcotoneServiceInitializer::clearCache();
+        $this->internalStorage = '/tmp/ecotone_tempest_logger_test_' . getmypid();
+        $this->logHandler = new TestHandler();
+        $this->setupKernel();
+    }
+
+    public function setupKernel(): self
+    {
+        EcotoneServiceInitializer::clearCache();
+
+        $allLocations = [
+            new DiscoveryLocation('Ecotone\\Tempest\\', '/data/app/packages/Tempest/src'),
+            new DiscoveryLocation('Test\\Ecotone\\Tempest\\Fixture\\', '/data/app/packages/Tempest/tests/Fixture'),
+        ];
+
+        $kernel = new FrameworkKernel(
+            root: $this->root,
+            discoveryLocations: $allLocations,
+            internalStorage: $this->internalStorage,
+        );
+
+        $kernel->registerKernel()
+               ->validateRoot()
+               ->loadEnv()
+               ->registerEmergencyExceptionHandler()
+               ->registerShutdownFunction()
+               ->registerInternalStorage()
+               ->loadComposer();
+
+        $this->injectDiscoveryConfig($kernel, $allLocations);
+
+        $kernel->container->config(new EcotoneConfig(
+            namespaces: ['Test\\Ecotone\\Tempest\\Fixture\\ExpressionLanguage\\'],
+            skippedModulePackageNames: ModulePackageList::allPackages(),
+            test: true,
+        ));
+
+        $captureHandler = $this->logHandler;
+        $captureChannel = new class ($captureHandler) implements LogChannel {
+            public function __construct(private TestHandler $handler) {}
+
+            public function getHandlers(Level $level): array
+            {
+                return [$this->handler];
+            }
+
+            public function getProcessors(): array
+            {
+                return [];
+            }
+        };
+
+        $kernel->loadConfig();
+
+        $kernel->container->config(new MultipleChannelsLogConfig(
+            channels: [$captureChannel],
+            prefix: 'test',
+        ));
+
+        $kernel->bootDiscovery()
+               ->registerExceptionHandler()
+               ->event(KernelEvent::BOOTED);
+
+        $this->kernel = $kernel;
+        $this->container = $kernel->container;
+
+        return $this;
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+        restore_exception_handler();
+        restore_error_handler();
+        EcotoneServiceInitializer::clearCache();
+        MessagingSystemInitializer::clearDefinitionHolder();
+    }
+
+    private function injectDiscoveryConfig(FrameworkKernel $kernel, array $extraLocations): void
+    {
+        $testAppComposer = (new Composer($this->root))->load();
+        $testAppComposer->namespaces = [];
+
+        $autoloadLocations = (new AutoloadDiscoveryLocations(
+            rootPath: '/data/app',
+            composer: $testAppComposer,
+        ))();
+
+        $discoveryConfig = $kernel->container->get(DiscoveryConfig::class);
+        $discoveryConfig->locations = [...$extraLocations, ...$autoloadLocations];
+
+        $kernel->container->config($discoveryConfig);
+        $kernel->discoveryConfig = $discoveryConfig;
+    }
+
+    public function test_ecotone_logs_flow_through_tempest_logger_after_wiring(): void
+    {
+        $queryBus = $this->container->get(QueryBus::class);
+
+        $queryBus->sendWithRouting('getAmount');
+
+        $this->assertTrue(
+            $this->logHandler->hasInfoThatContains('Executing Query Handler'),
+            'Expected Ecotone to emit log through the Tempest logger',
+        );
+    }
+}

--- a/packages/Tempest/tests/Application/LoggerWiringTest.php
+++ b/packages/Tempest/tests/Application/LoggerWiringTest.php
@@ -18,8 +18,9 @@ use Tempest\Discovery\Composer;
 use Tempest\Discovery\DiscoveryConfig;
 use Tempest\Discovery\DiscoveryLocation;
 use Tempest\Framework\Testing\IntegrationTest;
-use Tempest\Log\LogChannel;
 use Tempest\Log\Config\MultipleChannelsLogConfig;
+use Tempest\Log\LogChannel;
+use Test\Ecotone\Tempest\TempestTestPaths;
 
 /**
  * licence Apache-2.0
@@ -27,7 +28,7 @@ use Tempest\Log\Config\MultipleChannelsLogConfig;
  */
 final class LoggerWiringTest extends IntegrationTest
 {
-    protected string $root = '/data/app/packages/Tempest/tests/app';
+    protected string $root = '';
 
     private TestHandler $logHandler;
 
@@ -41,11 +42,15 @@ final class LoggerWiringTest extends IntegrationTest
 
     public function setupKernel(): self
     {
+        if ($this->root === '') {
+            $this->root = TempestTestPaths::appRoot();
+        }
+
         EcotoneServiceInitializer::clearCache();
 
         $allLocations = [
-            new DiscoveryLocation('Ecotone\\Tempest\\', '/data/app/packages/Tempest/src'),
-            new DiscoveryLocation('Test\\Ecotone\\Tempest\\Fixture\\', '/data/app/packages/Tempest/tests/Fixture'),
+            new DiscoveryLocation('Ecotone\\Tempest\\', TempestTestPaths::srcPath()),
+            new DiscoveryLocation('Test\\Ecotone\\Tempest\\Fixture\\', TempestTestPaths::fixturePath()),
         ];
 
         $kernel = new FrameworkKernel(
@@ -72,7 +77,9 @@ final class LoggerWiringTest extends IntegrationTest
 
         $captureHandler = $this->logHandler;
         $captureChannel = new class ($captureHandler) implements LogChannel {
-            public function __construct(private TestHandler $handler) {}
+            public function __construct(private TestHandler $handler)
+            {
+            }
 
             public function getHandlers(Level $level): array
             {
@@ -117,7 +124,7 @@ final class LoggerWiringTest extends IntegrationTest
         $testAppComposer->namespaces = [];
 
         $autoloadLocations = (new AutoloadDiscoveryLocations(
-            rootPath: '/data/app',
+            rootPath: TempestTestPaths::discoveryRoot(),
             composer: $testAppComposer,
         ))();
 

--- a/packages/Tempest/tests/Application/ParameterExpressionTest.php
+++ b/packages/Tempest/tests/Application/ParameterExpressionTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Ecotone\Tempest\Application;
+
+use Ecotone\Messaging\Config\ModulePackageList;
+use Ecotone\Modelling\CommandBus;
+use Ecotone\Modelling\QueryBus;
+use Ecotone\Tempest\EcotoneConfig;
+use Test\Ecotone\Tempest\EcotoneIntegrationTest;
+
+/**
+ * licence Apache-2.0
+ * @internal
+ */
+final class ParameterExpressionTest extends EcotoneIntegrationTest
+{
+    protected function ecotoneConfig(): EcotoneConfig
+    {
+        return new EcotoneConfig(
+            namespaces: ['Test\\Ecotone\\Tempest\\Fixture\\ExpressionLanguage\\'],
+            skippedModulePackageNames: ModulePackageList::allPackages(),
+            test: true,
+        );
+    }
+
+    public function test_parameter_function_with_hardcoded_env_value_in_expression(): void
+    {
+        putenv('ECOTONE_MULTIPLIER=10');
+
+        $commandBus = $this->container->get(CommandBus::class);
+        $queryBus = $this->container->get(QueryBus::class);
+
+        $commandBus->sendWithRouting('calculator.multiply', ['value' => 5]);
+
+        $this->assertSame(50, $queryBus->sendWithRouting('calculator.getResult'));
+
+        putenv('ECOTONE_MULTIPLIER');
+    }
+
+    public function test_parameter_function_with_env_variable_in_expression(): void
+    {
+        putenv('ECOTONE_ENV_MULTIPLIER=7');
+
+        $commandBus = $this->container->get(CommandBus::class);
+        $queryBus = $this->container->get(QueryBus::class);
+
+        $commandBus->sendWithRouting('calculator.multiplyWithEnv', ['value' => 3]);
+
+        $this->assertSame(21, $queryBus->sendWithRouting('calculator.getEnvResult'));
+
+        putenv('ECOTONE_ENV_MULTIPLIER');
+    }
+}

--- a/packages/Tempest/tests/Application/ParameterExpressionTest.php
+++ b/packages/Tempest/tests/Application/ParameterExpressionTest.php
@@ -8,13 +8,13 @@ use Ecotone\Messaging\Config\ModulePackageList;
 use Ecotone\Modelling\CommandBus;
 use Ecotone\Modelling\QueryBus;
 use Ecotone\Tempest\EcotoneConfig;
-use Test\Ecotone\Tempest\EcotoneIntegrationTest;
+use Test\Ecotone\Tempest\EcotoneIntegrationTestCase;
 
 /**
  * licence Apache-2.0
  * @internal
  */
-final class ParameterExpressionTest extends EcotoneIntegrationTest
+final class ParameterExpressionTest extends EcotoneIntegrationTestCase
 {
     protected function ecotoneConfig(): EcotoneConfig
     {

--- a/packages/Tempest/tests/Application/ProdCacheHashTest.php
+++ b/packages/Tempest/tests/Application/ProdCacheHashTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Ecotone\Tempest\Application;
+
+use Ecotone\Messaging\Config\ModulePackageList;
+use Ecotone\Tempest\EcotoneConfig;
+use Ecotone\Tempest\EcotoneServiceInitializer;
+use Ecotone\Tempest\MessagingSystemInitializer;
+use Test\Ecotone\Tempest\EcotoneIntegrationTest;
+
+/**
+ * licence Apache-2.0
+ * @internal
+ */
+final class ProdCacheHashTest extends EcotoneIntegrationTest
+{
+    protected function ecotoneConfig(): EcotoneConfig
+    {
+        return new EcotoneConfig(
+            namespaces: ['Test\\Ecotone\\Tempest\\Fixture\\User\\'],
+            skippedModulePackageNames: ModulePackageList::allPackages(),
+            test: true,
+            cacheConfiguration: true,
+        );
+    }
+
+    protected function setUp(): void
+    {
+        $this->clearEcotoneTempestCacheDir();
+        parent::setUp();
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+        $this->clearEcotoneTempestCacheDir();
+    }
+
+    public function test_warm_prod_cache_path_returns_stable_non_null_config_hash(): void
+    {
+        $firstHash = MessagingSystemInitializer::getConfigHash();
+
+        $this->assertNotNull(
+            $firstHash,
+            'Config hash must be non-null on first cold boot',
+        );
+
+        EcotoneServiceInitializer::clearCache();
+        MessagingSystemInitializer::clearDefinitionHolder();
+
+        $this->setupKernel();
+
+        $secondHash = MessagingSystemInitializer::getConfigHash();
+
+        $this->assertSame(
+            $firstHash,
+            $secondHash,
+            'Warm-cache boot must return the same config hash as the cold boot',
+        );
+    }
+
+    private function clearEcotoneTempestCacheDir(): void
+    {
+        $dir = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'ecotone_tempest';
+        if (! is_dir($dir)) {
+            return;
+        }
+        foreach (glob($dir . '/*') ?: [] as $file) {
+            is_dir($file) ? $this->removeDirectory($file) : @unlink($file);
+        }
+        @rmdir($dir);
+    }
+
+    private function removeDirectory(string $dir): void
+    {
+        foreach (glob($dir . '/*') ?: [] as $file) {
+            is_dir($file) ? $this->removeDirectory($file) : @unlink($file);
+        }
+        @rmdir($dir);
+    }
+}

--- a/packages/Tempest/tests/Application/ProdCacheHashTest.php
+++ b/packages/Tempest/tests/Application/ProdCacheHashTest.php
@@ -8,13 +8,13 @@ use Ecotone\Messaging\Config\ModulePackageList;
 use Ecotone\Tempest\EcotoneConfig;
 use Ecotone\Tempest\EcotoneServiceInitializer;
 use Ecotone\Tempest\MessagingSystemInitializer;
-use Test\Ecotone\Tempest\EcotoneIntegrationTest;
+use Test\Ecotone\Tempest\EcotoneIntegrationTestCase;
 
 /**
  * licence Apache-2.0
  * @internal
  */
-final class ProdCacheHashTest extends EcotoneIntegrationTest
+final class ProdCacheHashTest extends EcotoneIntegrationTestCase
 {
     protected function ecotoneConfig(): EcotoneConfig
     {

--- a/packages/Tempest/tests/Application/RealBootTest.php
+++ b/packages/Tempest/tests/Application/RealBootTest.php
@@ -40,6 +40,56 @@ final class RealBootTest extends TestCase
         MessagingSystemInitializer::clearDefinitionHolder();
     }
 
+    public function test_command_bus_resolves_from_tempest_container_without_any_ecotone_config_file(): void
+    {
+        $internalStorage = '/tmp/ecotone_tempest_real_boot_noconfig_' . getmypid();
+
+        $appLocation = new DiscoveryLocation('App\\Tempest\\', self::APP_ROOT . '/src');
+        $ecotoneLocation = new DiscoveryLocation('Ecotone\\Tempest\\', '/data/app/packages/Tempest/src');
+
+        $kernel = new FrameworkKernel(
+            root: self::APP_ROOT,
+            discoveryLocations: [$ecotoneLocation, $appLocation],
+            internalStorage: $internalStorage,
+        );
+
+        $kernel->registerKernel()
+               ->validateRoot()
+               ->loadEnv()
+               ->registerEmergencyExceptionHandler()
+               ->registerShutdownFunction()
+               ->registerInternalStorage()
+               ->loadComposer();
+
+        $this->injectDiscoveryConfig($kernel, $ecotoneLocation, $appLocation);
+
+        // Monorepo: all packages including Enterprise ones are present, so skip them to avoid
+        // licence errors. In a real app only installed packages load — no skip needed.
+        // The key proof: no ecotone.config.php discovered in the boot path; the app
+        // derives its EcotoneConfig from MessagingSystemInitializer's fallback new EcotoneConfig().
+        $kernel->container->singleton(
+            EcotoneConfig::class,
+            new EcotoneConfig(
+                skippedModulePackageNames: ModulePackageList::allPackages(),
+                test: true,
+            ),
+        );
+
+        $kernel->loadConfig()
+               ->bootDiscovery()
+               ->registerExceptionHandler()
+               ->event(KernelEvent::BOOTED);
+
+        // Resolve CommandBus WITHOUT touching ConfiguredMessagingSystem first —
+        // EcotoneServiceInitializer must trigger compile on the first gateway request.
+        $commandBus = $kernel->container->get(CommandBus::class);
+        $queryBus = $kernel->container->get(QueryBus::class);
+
+        $commandBus->sendWithRouting('app.ping');
+
+        $this->assertTrue($queryBus->sendWithRouting('app.wasHandled'));
+    }
+
     public function test_zero_config_namespace_derivation_from_composer_psr4_discovers_handlers(): void
     {
         $internalStorage = '/tmp/ecotone_tempest_real_boot_' . getmypid();

--- a/packages/Tempest/tests/Application/RealBootTest.php
+++ b/packages/Tempest/tests/Application/RealBootTest.php
@@ -17,6 +17,7 @@ use Tempest\Discovery\AutoloadDiscoveryLocations;
 use Tempest\Discovery\Composer;
 use Tempest\Discovery\DiscoveryConfig;
 use Tempest\Discovery\DiscoveryLocation;
+use Test\Ecotone\Tempest\TempestTestPaths;
 
 /**
  * licence Apache-2.0
@@ -24,8 +25,6 @@ use Tempest\Discovery\DiscoveryLocation;
  */
 final class RealBootTest extends TestCase
 {
-    private const APP_ROOT = '/data/app/packages/Tempest/tests/app';
-
     protected function setUp(): void
     {
         EcotoneServiceInitializer::clearCache();
@@ -44,11 +43,11 @@ final class RealBootTest extends TestCase
     {
         $internalStorage = '/tmp/ecotone_tempest_real_boot_noconfig_' . getmypid();
 
-        $appLocation = new DiscoveryLocation('App\\Tempest\\', self::APP_ROOT . '/src');
-        $ecotoneLocation = new DiscoveryLocation('Ecotone\\Tempest\\', '/data/app/packages/Tempest/src');
+        $appLocation = new DiscoveryLocation('App\\Tempest\\', TempestTestPaths::appRoot() . '/src');
+        $ecotoneLocation = new DiscoveryLocation('Ecotone\\Tempest\\', TempestTestPaths::srcPath());
 
         $kernel = new FrameworkKernel(
-            root: self::APP_ROOT,
+            root: TempestTestPaths::appRoot(),
             discoveryLocations: [$ecotoneLocation, $appLocation],
             internalStorage: $internalStorage,
         );
@@ -94,11 +93,11 @@ final class RealBootTest extends TestCase
     {
         $internalStorage = '/tmp/ecotone_tempest_real_boot_' . getmypid();
 
-        $appLocation = new DiscoveryLocation('App\\Tempest\\', self::APP_ROOT . '/src');
-        $ecotoneLocation = new DiscoveryLocation('Ecotone\\Tempest\\', '/data/app/packages/Tempest/src');
+        $appLocation = new DiscoveryLocation('App\\Tempest\\', TempestTestPaths::appRoot() . '/src');
+        $ecotoneLocation = new DiscoveryLocation('Ecotone\\Tempest\\', TempestTestPaths::srcPath());
 
         $kernel = new FrameworkKernel(
-            root: self::APP_ROOT,
+            root: TempestTestPaths::appRoot(),
             discoveryLocations: [$ecotoneLocation, $appLocation],
             internalStorage: $internalStorage,
         );
@@ -136,11 +135,11 @@ final class RealBootTest extends TestCase
         DiscoveryLocation $ecotoneLocation,
         DiscoveryLocation $appLocation,
     ): void {
-        $vendorOnlyComposer = (new Composer(self::APP_ROOT))->load();
+        $vendorOnlyComposer = (new Composer(TempestTestPaths::appRoot()))->load();
         $vendorOnlyComposer->namespaces = [];
 
         $vendorLocations = (new AutoloadDiscoveryLocations(
-            rootPath: '/data/app',
+            rootPath: TempestTestPaths::discoveryRoot(),
             composer: $vendorOnlyComposer,
         ))();
 

--- a/packages/Tempest/tests/Application/RealBootTest.php
+++ b/packages/Tempest/tests/Application/RealBootTest.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Ecotone\Tempest\Application;
+
+use Ecotone\Messaging\Config\ModulePackageList;
+use Ecotone\Modelling\CommandBus;
+use Ecotone\Modelling\QueryBus;
+use Ecotone\Tempest\EcotoneConfig;
+use Ecotone\Tempest\EcotoneServiceInitializer;
+use Ecotone\Tempest\MessagingSystemInitializer;
+use PHPUnit\Framework\TestCase;
+use Tempest\Core\FrameworkKernel;
+use Tempest\Core\KernelEvent;
+use Tempest\Discovery\AutoloadDiscoveryLocations;
+use Tempest\Discovery\Composer;
+use Tempest\Discovery\DiscoveryConfig;
+use Tempest\Discovery\DiscoveryLocation;
+
+/**
+ * licence Apache-2.0
+ * @internal
+ */
+final class RealBootTest extends TestCase
+{
+    private const APP_ROOT = '/data/app/packages/Tempest/tests/app';
+
+    protected function setUp(): void
+    {
+        EcotoneServiceInitializer::clearCache();
+        MessagingSystemInitializer::clearDefinitionHolder();
+    }
+
+    protected function tearDown(): void
+    {
+        restore_exception_handler();
+        restore_error_handler();
+        EcotoneServiceInitializer::clearCache();
+        MessagingSystemInitializer::clearDefinitionHolder();
+    }
+
+    public function test_zero_config_namespace_derivation_from_composer_psr4_discovers_handlers(): void
+    {
+        $internalStorage = '/tmp/ecotone_tempest_real_boot_' . getmypid();
+
+        $appLocation = new DiscoveryLocation('App\\Tempest\\', self::APP_ROOT . '/src');
+        $ecotoneLocation = new DiscoveryLocation('Ecotone\\Tempest\\', '/data/app/packages/Tempest/src');
+
+        $kernel = new FrameworkKernel(
+            root: self::APP_ROOT,
+            discoveryLocations: [$ecotoneLocation, $appLocation],
+            internalStorage: $internalStorage,
+        );
+
+        $kernel->registerKernel()
+               ->validateRoot()
+               ->loadEnv()
+               ->registerEmergencyExceptionHandler()
+               ->registerShutdownFunction()
+               ->registerInternalStorage()
+               ->loadComposer();
+
+        $this->injectDiscoveryConfig($kernel, $ecotoneLocation, $appLocation);
+
+        $kernel->container->config(new EcotoneConfig(
+            skippedModulePackageNames: ModulePackageList::allPackages(),
+            test: true,
+        ));
+
+        $kernel->loadConfig()
+               ->bootDiscovery()
+               ->registerExceptionHandler()
+               ->event(KernelEvent::BOOTED);
+
+        $commandBus = $kernel->container->get(CommandBus::class);
+        $queryBus = $kernel->container->get(QueryBus::class);
+
+        $commandBus->sendWithRouting('app.ping');
+
+        $this->assertTrue($queryBus->sendWithRouting('app.wasHandled'));
+    }
+
+    private function injectDiscoveryConfig(
+        FrameworkKernel $kernel,
+        DiscoveryLocation $ecotoneLocation,
+        DiscoveryLocation $appLocation,
+    ): void {
+        $vendorOnlyComposer = (new Composer(self::APP_ROOT))->load();
+        $vendorOnlyComposer->namespaces = [];
+
+        $vendorLocations = (new AutoloadDiscoveryLocations(
+            rootPath: '/data/app',
+            composer: $vendorOnlyComposer,
+        ))();
+
+        $discoveryConfig = $kernel->container->get(DiscoveryConfig::class);
+        $discoveryConfig->locations = [$ecotoneLocation, $appLocation, ...$vendorLocations];
+
+        $kernel->container->config($discoveryConfig);
+        $kernel->discoveryConfig = $discoveryConfig;
+    }
+}

--- a/packages/Tempest/tests/Application/StaticStateIsolationTest.php
+++ b/packages/Tempest/tests/Application/StaticStateIsolationTest.php
@@ -7,7 +7,7 @@ namespace Test\Ecotone\Tempest\Application;
 use Ecotone\Modelling\CommandBus;
 use Ecotone\Tempest\EcotoneServiceInitializer;
 use Ecotone\Tempest\MessagingSystemInitializer;
-use Test\Ecotone\Tempest\EcotoneIntegrationTest;
+use Test\Ecotone\Tempest\EcotoneIntegrationTestCase;
 use Test\Ecotone\Tempest\Fixture\User\User;
 use Test\Ecotone\Tempest\Fixture\User\UserRepository;
 
@@ -15,7 +15,7 @@ use Test\Ecotone\Tempest\Fixture\User\UserRepository;
  * licence Apache-2.0
  * @internal
  */
-final class StaticStateIsolationTest extends EcotoneIntegrationTest
+final class StaticStateIsolationTest extends EcotoneIntegrationTestCase
 {
     public function test_second_boot_in_same_process_sees_fresh_messaging_system_state(): void
     {

--- a/packages/Tempest/tests/Application/StaticStateIsolationTest.php
+++ b/packages/Tempest/tests/Application/StaticStateIsolationTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Ecotone\Tempest\Application;
+
+use Ecotone\Modelling\CommandBus;
+use Ecotone\Modelling\QueryBus;
+use Ecotone\Tempest\EcotoneServiceInitializer;
+use Ecotone\Tempest\MessagingSystemInitializer;
+use Test\Ecotone\Tempest\EcotoneIntegrationTest;
+use Test\Ecotone\Tempest\Fixture\User\User;
+use Test\Ecotone\Tempest\Fixture\User\UserRepository;
+
+/**
+ * licence Apache-2.0
+ * @internal
+ */
+final class StaticStateIsolationTest extends EcotoneIntegrationTest
+{
+    public function test_second_boot_in_same_process_sees_fresh_messaging_system_state(): void
+    {
+        $userId = 'user-first-boot';
+
+        $commandBus = $this->container->get(CommandBus::class);
+        $commandBus->sendWithRouting('user.register', $userId);
+
+        $userRepository = $this->container->get(UserRepository::class);
+        $this->assertEquals(User::register($userId), $userRepository->getUser($userId));
+
+        restore_exception_handler();
+        restore_error_handler();
+
+        EcotoneServiceInitializer::clearCache();
+        MessagingSystemInitializer::clearDefinitionHolder();
+
+        $this->setupKernel();
+
+        $secondCommandBus = $this->container->get(CommandBus::class);
+        $secondUserRepository = $this->container->get(UserRepository::class);
+
+        $secondUserId = 'user-second-boot';
+        $secondCommandBus->sendWithRouting('user.register', $secondUserId);
+
+        $this->assertEquals(User::register($secondUserId), $secondUserRepository->getUser($secondUserId));
+    }
+}

--- a/packages/Tempest/tests/Application/StaticStateIsolationTest.php
+++ b/packages/Tempest/tests/Application/StaticStateIsolationTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Test\Ecotone\Tempest\Application;
 
 use Ecotone\Modelling\CommandBus;
-use Ecotone\Modelling\QueryBus;
 use Ecotone\Tempest\EcotoneServiceInitializer;
 use Ecotone\Tempest\MessagingSystemInitializer;
 use Test\Ecotone\Tempest\EcotoneIntegrationTest;

--- a/packages/Tempest/tests/Application/TempestApplicationTest.php
+++ b/packages/Tempest/tests/Application/TempestApplicationTest.php
@@ -6,7 +6,7 @@ namespace Test\Ecotone\Tempest\Application;
 
 use Ecotone\Modelling\CommandBus;
 use Ecotone\Modelling\QueryBus;
-use Test\Ecotone\Tempest\EcotoneIntegrationTest;
+use Test\Ecotone\Tempest\EcotoneIntegrationTestCase;
 use Test\Ecotone\Tempest\Fixture\User\User;
 use Test\Ecotone\Tempest\Fixture\User\UserRepository;
 
@@ -14,7 +14,7 @@ use Test\Ecotone\Tempest\Fixture\User\UserRepository;
  * licence Apache-2.0
  * @internal
  */
-final class TempestApplicationTest extends EcotoneIntegrationTest
+final class TempestApplicationTest extends EcotoneIntegrationTestCase
 {
     public function test_command_bus_resolves_from_tempest_container(): void
     {

--- a/packages/Tempest/tests/Application/TempestApplicationTest.php
+++ b/packages/Tempest/tests/Application/TempestApplicationTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Ecotone\Tempest\Application;
+
+use Ecotone\Modelling\CommandBus;
+use Ecotone\Modelling\QueryBus;
+use Test\Ecotone\Tempest\EcotoneIntegrationTest;
+use Test\Ecotone\Tempest\Fixture\User\User;
+use Test\Ecotone\Tempest\Fixture\User\UserRepository;
+
+/**
+ * licence Apache-2.0
+ * @internal
+ */
+final class TempestApplicationTest extends EcotoneIntegrationTest
+{
+    public function test_command_bus_resolves_from_tempest_container(): void
+    {
+        $this->assertInstanceOf(
+            CommandBus::class,
+            $this->container->get(CommandBus::class),
+        );
+    }
+
+    public function test_gateways_injectable_and_command_handler_flow_runs_end_to_end(): void
+    {
+        $userId = '123';
+
+        $commandBus = $this->container->get(CommandBus::class);
+        $commandBus->sendWithRouting('user.register', $userId);
+
+        $userRepository = $this->container->get(UserRepository::class);
+
+        $this->assertEquals(
+            User::register($userId),
+            $userRepository->getUser($userId),
+        );
+    }
+
+    public function test_expression_language_in_payload(): void
+    {
+        $commandBus = $this->container->get(CommandBus::class);
+        $queryBus = $this->container->get(QueryBus::class);
+
+        $amount = 123;
+        $commandBus->sendWithRouting('setAmount', ['amount' => $amount]);
+
+        $this->assertEquals(
+            $amount,
+            $queryBus->sendWithRouting('getAmount'),
+        );
+    }
+}

--- a/packages/Tempest/tests/Dbal/ConnectionReferenceCredentialsTest.php
+++ b/packages/Tempest/tests/Dbal/ConnectionReferenceCredentialsTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Ecotone\Tempest\Dbal;
+
+use Ecotone\Tempest\Config\TempestConnectionReference;
+use PHPUnit\Framework\TestCase;
+use Tempest\Database\Config\PostgresConfig;
+
+/**
+ * licence Apache-2.0
+ * @internal
+ */
+final class ConnectionReferenceCredentialsTest extends TestCase
+{
+    public function test_create_builds_reference_with_provided_database_config(): void
+    {
+        $config = new PostgresConfig(
+            host: 'database',
+            port: '5432',
+            username: 'ecotone',
+            password: 'secret',
+            database: 'ecotone',
+        );
+
+        $reference = TempestConnectionReference::create('tenant_a', $config);
+
+        $this->assertSame('tenant_a', $reference->getReferenceName());
+        $this->assertSame($config, $reference->getDatabaseConfig());
+    }
+
+    public function test_get_definition_round_trips_reference_name_and_database_config(): void
+    {
+        $config = new PostgresConfig(
+            host: 'database',
+            port: '5432',
+            username: 'ecotone',
+            password: 'secret',
+            database: 'ecotone',
+        );
+
+        $reference = TempestConnectionReference::create('tenant_a', $config);
+        $definition = $reference->getDefinition();
+
+        $reconstructed = TempestConnectionReference::createFromSerializedConfig(
+            ...$definition->getArguments()
+        );
+
+        $this->assertSame('tenant_a', $reconstructed->getReferenceName());
+
+        $reconstructedConfig = $reconstructed->getDatabaseConfig();
+        $this->assertNotNull($reconstructedConfig);
+        $this->assertSame('database', $reconstructedConfig->host);
+        $this->assertSame('ecotone', $reconstructedConfig->database);
+        $this->assertSame('ecotone', $reconstructedConfig->username);
+        $this->assertSame('secret', $reconstructedConfig->password);
+    }
+
+    public function test_default_connection_has_no_embedded_database_config(): void
+    {
+        $reference = TempestConnectionReference::defaultConnection();
+
+        $this->assertNull($reference->getDatabaseConfig());
+    }
+
+    public function test_create_without_config_produces_null_database_config(): void
+    {
+        $reference = TempestConnectionReference::create('some_connection');
+
+        $this->assertNull($reference->getDatabaseConfig());
+    }
+}

--- a/packages/Tempest/tests/Dbal/ConnectionReferenceCredentialsTest.php
+++ b/packages/Tempest/tests/Dbal/ConnectionReferenceCredentialsTest.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace Test\Ecotone\Tempest\Dbal;
 
 use Ecotone\Tempest\Config\TempestConnectionReference;
+use Enqueue\Dbal\DbalConnectionFactory;
 use PHPUnit\Framework\TestCase;
-use Tempest\Database\Config\PostgresConfig;
 
 /**
  * licence Apache-2.0
@@ -14,60 +14,53 @@ use Tempest\Database\Config\PostgresConfig;
  */
 final class ConnectionReferenceCredentialsTest extends TestCase
 {
-    public function test_create_builds_reference_with_provided_database_config(): void
+    public function test_create_stores_only_tag_name_not_credentials(): void
     {
-        $config = new PostgresConfig(
-            host: 'database',
-            port: '5432',
-            username: 'ecotone',
-            password: 'secret',
-            database: 'ecotone',
-        );
+        $reference = TempestConnectionReference::create('tenant_a');
 
-        $reference = TempestConnectionReference::create('tenant_a', $config);
-
+        $this->assertSame('tenant_a', $reference->getConfigTag());
         $this->assertSame('tenant_a', $reference->getReferenceName());
-        $this->assertSame($config, $reference->getDatabaseConfig());
     }
 
-    public function test_get_definition_round_trips_reference_name_and_database_config(): void
+    public function test_create_with_custom_reference_name(): void
     {
-        $config = new PostgresConfig(
-            host: 'database',
-            port: '5432',
-            username: 'ecotone',
-            password: 'secret',
-            database: 'ecotone',
-        );
+        $reference = TempestConnectionReference::create('tenant_a', 'custom_ref');
 
-        $reference = TempestConnectionReference::create('tenant_a', $config);
+        $this->assertSame('tenant_a', $reference->getConfigTag());
+        $this->assertSame('custom_ref', $reference->getReferenceName());
+    }
+
+    public function test_get_definition_serializes_only_tag_name_no_credentials(): void
+    {
+        $reference = TempestConnectionReference::create('tenant_a');
         $definition = $reference->getDefinition();
 
-        $reconstructed = TempestConnectionReference::createFromSerializedConfig(
+        $args = $definition->getArguments();
+        $this->assertSame('tenant_a', $args[0]);
+        $this->assertSame('tenant_a', $args[1]);
+        foreach ($args as $arg) {
+            $this->assertIsString($arg);
+        }
+    }
+
+    public function test_definition_round_trips_via_factory(): void
+    {
+        $reference = TempestConnectionReference::create('tenant_a');
+        $definition = $reference->getDefinition();
+
+        $reconstructed = TempestConnectionReference::fromTagAndReferenceName(
             ...$definition->getArguments()
         );
 
+        $this->assertSame('tenant_a', $reconstructed->getConfigTag());
         $this->assertSame('tenant_a', $reconstructed->getReferenceName());
-
-        $reconstructedConfig = $reconstructed->getDatabaseConfig();
-        $this->assertNotNull($reconstructedConfig);
-        $this->assertSame('database', $reconstructedConfig->host);
-        $this->assertSame('ecotone', $reconstructedConfig->database);
-        $this->assertSame('ecotone', $reconstructedConfig->username);
-        $this->assertSame('secret', $reconstructedConfig->password);
     }
 
-    public function test_default_connection_has_no_embedded_database_config(): void
+    public function test_default_connection_has_no_tag(): void
     {
         $reference = TempestConnectionReference::defaultConnection();
 
-        $this->assertNull($reference->getDatabaseConfig());
-    }
-
-    public function test_create_without_config_produces_null_database_config(): void
-    {
-        $reference = TempestConnectionReference::create('some_connection');
-
-        $this->assertNull($reference->getDatabaseConfig());
+        $this->assertNull($reference->getConfigTag());
+        $this->assertSame(DbalConnectionFactory::class, $reference->getReferenceName());
     }
 }

--- a/packages/Tempest/tests/Dbal/DbalConnectionConnectivityTest.php
+++ b/packages/Tempest/tests/Dbal/DbalConnectionConnectivityTest.php
@@ -8,8 +8,8 @@ use Ecotone\Messaging\Config\ConfiguredMessagingSystem;
 use Ecotone\Messaging\Config\ModulePackageList;
 use Ecotone\Tempest\EcotoneConfig;
 use Enqueue\Dbal\DbalConnectionFactory;
-use Tempest\Database\Config\PostgresConfig;
 use Test\Ecotone\Tempest\EcotoneIntegrationTest;
+use Test\Ecotone\Tempest\TempestDatabaseConfigFactory;
 
 /**
  * licence Apache-2.0
@@ -31,13 +31,7 @@ final class DbalConnectionConnectivityTest extends EcotoneIntegrationTest
 
     public function test_dbal_connection_derived_from_tempest_postgres_config_executes_query(): void
     {
-        $postgresConfig = new PostgresConfig(
-            host: 'database',
-            port: '5432',
-            username: 'ecotone',
-            password: 'secret',
-            database: 'ecotone',
-        );
+        $postgresConfig = TempestDatabaseConfigFactory::primary();
 
         $this->setupKernel();
         $this->container->config($postgresConfig);

--- a/packages/Tempest/tests/Dbal/DbalConnectionConnectivityTest.php
+++ b/packages/Tempest/tests/Dbal/DbalConnectionConnectivityTest.php
@@ -8,14 +8,14 @@ use Ecotone\Messaging\Config\ConfiguredMessagingSystem;
 use Ecotone\Messaging\Config\ModulePackageList;
 use Ecotone\Tempest\EcotoneConfig;
 use Enqueue\Dbal\DbalConnectionFactory;
-use Test\Ecotone\Tempest\EcotoneIntegrationTest;
+use Test\Ecotone\Tempest\EcotoneIntegrationTestCase;
 use Test\Ecotone\Tempest\TempestDatabaseConfigFactory;
 
 /**
  * licence Apache-2.0
  * @internal
  */
-final class DbalConnectionConnectivityTest extends EcotoneIntegrationTest
+final class DbalConnectionConnectivityTest extends EcotoneIntegrationTestCase
 {
     protected function ecotoneConfig(): EcotoneConfig
     {

--- a/packages/Tempest/tests/Dbal/DbalConnectionConnectivityTest.php
+++ b/packages/Tempest/tests/Dbal/DbalConnectionConnectivityTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Ecotone\Tempest\Dbal;
+
+use Ecotone\Messaging\Config\ConfiguredMessagingSystem;
+use Ecotone\Messaging\Config\ModulePackageList;
+use Ecotone\Tempest\EcotoneConfig;
+use Enqueue\Dbal\DbalConnectionFactory;
+use Tempest\Database\Config\PostgresConfig;
+use Test\Ecotone\Tempest\EcotoneIntegrationTest;
+
+/**
+ * licence Apache-2.0
+ * @internal
+ */
+final class DbalConnectionConnectivityTest extends EcotoneIntegrationTest
+{
+    protected function ecotoneConfig(): EcotoneConfig
+    {
+        return new EcotoneConfig(
+            namespaces: ['Test\\Ecotone\\Tempest\\Fixture\\Dbal\\'],
+            skippedModulePackageNames: ModulePackageList::allPackagesExcept([
+                ModulePackageList::TEMPEST_PACKAGE,
+                ModulePackageList::DBAL_PACKAGE,
+            ]),
+            test: false,
+        );
+    }
+
+    public function test_dbal_connection_derived_from_tempest_postgres_config_executes_query(): void
+    {
+        $postgresConfig = new PostgresConfig(
+            host: 'database',
+            port: '5432',
+            username: 'ecotone',
+            password: 'secret',
+            database: 'ecotone',
+        );
+
+        $this->setupKernel();
+        $this->container->config($postgresConfig);
+
+        $messagingSystem = $this->container->get(ConfiguredMessagingSystem::class);
+        $connectionFactory = $messagingSystem->getServiceFromContainer(DbalConnectionFactory::class);
+
+        $result = $connectionFactory->createContext()->getDbalConnection()->executeQuery('SELECT 1 AS result')->fetchOne();
+
+        $this->assertEquals(1, $result);
+    }
+}

--- a/packages/Tempest/tests/Dbal/DbalConnectionRequirementWithConnectionTest.php
+++ b/packages/Tempest/tests/Dbal/DbalConnectionRequirementWithConnectionTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Ecotone\Tempest\Dbal;
+
+use Ecotone\Messaging\Config\ModulePackageList;
+use Ecotone\Tempest\EcotoneConfig;
+use PHPUnit\Framework\Attributes\DoesNotPerformAssertions;
+use Test\Ecotone\Tempest\EcotoneIntegrationTest;
+
+/**
+ * licence Apache-2.0
+ * @internal
+ */
+final class DbalConnectionRequirementWithConnectionTest extends EcotoneIntegrationTest
+{
+    protected function ecotoneConfig(): EcotoneConfig
+    {
+        return new EcotoneConfig(
+            namespaces: ['Test\\Ecotone\\Tempest\\Fixture\\Dbal\\'],
+            skippedModulePackageNames: ModulePackageList::allPackagesExcept([
+                ModulePackageList::TEMPEST_PACKAGE,
+                ModulePackageList::DBAL_PACKAGE,
+            ]),
+            test: false,
+        );
+    }
+
+    #[DoesNotPerformAssertions]
+    public function test_does_not_throw_when_dbal_connection_is_configured(): void
+    {
+        $this->setupKernel();
+    }
+}

--- a/packages/Tempest/tests/Dbal/DbalConnectionRequirementWithConnectionTest.php
+++ b/packages/Tempest/tests/Dbal/DbalConnectionRequirementWithConnectionTest.php
@@ -7,13 +7,13 @@ namespace Test\Ecotone\Tempest\Dbal;
 use Ecotone\Messaging\Config\ModulePackageList;
 use Ecotone\Tempest\EcotoneConfig;
 use PHPUnit\Framework\Attributes\DoesNotPerformAssertions;
-use Test\Ecotone\Tempest\EcotoneIntegrationTest;
+use Test\Ecotone\Tempest\EcotoneIntegrationTestCase;
 
 /**
  * licence Apache-2.0
  * @internal
  */
-final class DbalConnectionRequirementWithConnectionTest extends EcotoneIntegrationTest
+final class DbalConnectionRequirementWithConnectionTest extends EcotoneIntegrationTestCase
 {
     protected function ecotoneConfig(): EcotoneConfig
     {

--- a/packages/Tempest/tests/Dbal/DbalConnectionRequirementWithoutConnectionTest.php
+++ b/packages/Tempest/tests/Dbal/DbalConnectionRequirementWithoutConnectionTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Ecotone\Tempest\Dbal;
+
+use Ecotone\Lite\EcotoneLite;
+use Ecotone\Messaging\Config\ConfigurationException;
+use Ecotone\Messaging\Config\ModulePackageList;
+use Ecotone\Messaging\Config\ServiceConfiguration;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * licence Apache-2.0
+ * @internal
+ */
+final class DbalConnectionRequirementWithoutConnectionTest extends TestCase
+{
+    public function test_throws_configuration_exception_when_dbal_connection_factory_is_not_configured(): void
+    {
+        $this->expectException(ConfigurationException::class);
+        $this->expectExceptionMessageMatches("/Dbal module requires 'Enqueue\\\\Dbal\\\\DbalConnectionFactory' to be configured/");
+
+        EcotoneLite::bootstrap(
+            classesToResolve: [],
+            configuration: ServiceConfiguration::createWithDefaults()
+                ->withEnvironment('prod')
+                ->withSkippedModulePackageNames(ModulePackageList::allPackagesExcept([ModulePackageList::DBAL_PACKAGE]))
+                ->withNamespaces(['Test\\Ecotone\\Tempest\\Fixture\\Counter\\']),
+            pathToRootCatalog: __DIR__ . '/../../',
+        );
+    }
+}

--- a/packages/Tempest/tests/Dbal/SharedConnectionTransactionTest.php
+++ b/packages/Tempest/tests/Dbal/SharedConnectionTransactionTest.php
@@ -11,11 +11,12 @@ use Ecotone\Tempest\EcotoneServiceInitializer;
 use Ecotone\Tempest\MessagingSystemInitializer;
 use Enqueue\Dbal\DbalConnectionFactory;
 use RuntimeException;
-use Tempest\Database\Config\PostgresConfig;
 use Tempest\Database\Database;
 use Tempest\Database\Query;
 use Tempest\Database\QueryStatements\CreateTableStatement;
 use Test\Ecotone\Tempest\EcotoneIntegrationTest;
+use Test\Ecotone\Tempest\TempestDatabaseConfigFactory;
+use Throwable;
 
 /**
  * licence Apache-2.0
@@ -42,13 +43,7 @@ final class SharedConnectionTransactionTest extends EcotoneIntegrationTest
 
         $this->setupKernel();
 
-        $this->container->config(new PostgresConfig(
-            host: 'database',
-            port: '5432',
-            username: 'ecotone',
-            password: 'secret',
-            database: 'ecotone',
-        ));
+        $this->container->config(TempestDatabaseConfigFactory::primary());
 
         $database = $this->container->get(Database::class);
         $database->execute(new Query('DROP TABLE IF EXISTS shared_connection_items'));
@@ -64,7 +59,7 @@ final class SharedConnectionTransactionTest extends EcotoneIntegrationTest
         try {
             $database = $this->container->get(Database::class);
             $database->execute(new Query('DROP TABLE IF EXISTS shared_connection_items'));
-        } catch (\Throwable) {
+        } catch (Throwable) {
         }
         parent::tearDown();
     }

--- a/packages/Tempest/tests/Dbal/SharedConnectionTransactionTest.php
+++ b/packages/Tempest/tests/Dbal/SharedConnectionTransactionTest.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Ecotone\Tempest\Dbal;
+
+use Ecotone\Messaging\Config\ModulePackageList;
+use Ecotone\Modelling\CommandBus;
+use Ecotone\Tempest\EcotoneConfig;
+use Ecotone\Tempest\EcotoneServiceInitializer;
+use Ecotone\Tempest\MessagingSystemInitializer;
+use Enqueue\Dbal\DbalConnectionFactory;
+use RuntimeException;
+use Tempest\Database\Config\PostgresConfig;
+use Tempest\Database\Database;
+use Tempest\Database\Query;
+use Tempest\Database\QueryStatements\CreateTableStatement;
+use Test\Ecotone\Tempest\EcotoneIntegrationTest;
+
+/**
+ * licence Apache-2.0
+ * @internal
+ */
+final class SharedConnectionTransactionTest extends EcotoneIntegrationTest
+{
+    protected function ecotoneConfig(): EcotoneConfig
+    {
+        return new EcotoneConfig(
+            namespaces: ['Test\\Ecotone\\Tempest\\Fixture\\SharedConnection\\'],
+            skippedModulePackageNames: ModulePackageList::allPackagesExcept([
+                ModulePackageList::TEMPEST_PACKAGE,
+                ModulePackageList::DBAL_PACKAGE,
+            ]),
+            test: false,
+        );
+    }
+
+    protected function setUp(): void
+    {
+        EcotoneServiceInitializer::clearCache();
+        MessagingSystemInitializer::clearDefinitionHolder();
+
+        $this->setupKernel();
+
+        $this->container->config(new PostgresConfig(
+            host: 'database',
+            port: '5432',
+            username: 'ecotone',
+            password: 'secret',
+            database: 'ecotone',
+        ));
+
+        $database = $this->container->get(Database::class);
+        $database->execute(new Query('DROP TABLE IF EXISTS shared_connection_items'));
+        $createSql = (new CreateTableStatement('shared_connection_items'))
+            ->primary('id')
+            ->string('name')
+            ->compile($database->dialect);
+        $database->execute(new Query($createSql));
+    }
+
+    protected function tearDown(): void
+    {
+        try {
+            $database = $this->container->get(Database::class);
+            $database->execute(new Query('DROP TABLE IF EXISTS shared_connection_items'));
+        } catch (\Throwable) {
+        }
+        parent::tearDown();
+    }
+
+    public function test_tempest_model_insert_is_rolled_back_when_ecotone_transaction_fails(): void
+    {
+        $commandBus = $this->container->get(CommandBus::class);
+
+        try {
+            $commandBus->sendWithRouting('shared_connection.insert_then_fail');
+        } catch (RuntimeException) {
+        }
+
+        $count = $this->container->get(DbalConnectionFactory::class)
+            ->createContext()
+            ->getDbalConnection()
+            ->executeQuery('SELECT COUNT(*) FROM shared_connection_items')
+            ->fetchOne();
+
+        $this->assertSame(0, (int) $count, 'Tempest model insert must be rolled back by Ecotone\'s DBAL transaction');
+    }
+}

--- a/packages/Tempest/tests/Dbal/SharedConnectionTransactionTest.php
+++ b/packages/Tempest/tests/Dbal/SharedConnectionTransactionTest.php
@@ -14,7 +14,7 @@ use RuntimeException;
 use Tempest\Database\Database;
 use Tempest\Database\Query;
 use Tempest\Database\QueryStatements\CreateTableStatement;
-use Test\Ecotone\Tempest\EcotoneIntegrationTest;
+use Test\Ecotone\Tempest\EcotoneIntegrationTestCase;
 use Test\Ecotone\Tempest\TempestDatabaseConfigFactory;
 use Throwable;
 
@@ -22,7 +22,7 @@ use Throwable;
  * licence Apache-2.0
  * @internal
  */
-final class SharedConnectionTransactionTest extends EcotoneIntegrationTest
+final class SharedConnectionTransactionTest extends EcotoneIntegrationTestCase
 {
     protected function ecotoneConfig(): EcotoneConfig
     {

--- a/packages/Tempest/tests/EcotoneIntegrationTest.php
+++ b/packages/Tempest/tests/EcotoneIntegrationTest.php
@@ -89,13 +89,19 @@ abstract class EcotoneIntegrationTest extends IntegrationTest
 
     private function removeProxyCache(): void
     {
-        $proxyDir = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'ecotone_tempest_console_proxies';
-        if (is_dir($proxyDir)) {
-            foreach (glob($proxyDir . '/*.php') ?: [] as $file) {
-                @unlink($file);
+        $proxyDirs = [
+            MessagingSystemInitializer::getProxyDirectory(),
+            sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'ecotone_tempest_console_proxies',
+        ];
+
+        foreach (array_filter($proxyDirs) as $proxyDir) {
+            if (is_dir($proxyDir)) {
+                foreach (glob($proxyDir . '/*.php') ?: [] as $file) {
+                    @unlink($file);
+                }
+                @unlink($proxyDir . '/.ecotone_hash');
+                @rmdir($proxyDir);
             }
-            @unlink($proxyDir . '/.ecotone_hash');
-            @rmdir($proxyDir);
         }
     }
 

--- a/packages/Tempest/tests/EcotoneIntegrationTest.php
+++ b/packages/Tempest/tests/EcotoneIntegrationTest.php
@@ -84,6 +84,19 @@ abstract class EcotoneIntegrationTest extends IntegrationTest
         restore_error_handler();
         EcotoneServiceInitializer::clearCache();
         MessagingSystemInitializer::clearDefinitionHolder();
+        $this->removeProxyCache();
+    }
+
+    private function removeProxyCache(): void
+    {
+        $proxyDir = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'ecotone_tempest_console_proxies';
+        if (is_dir($proxyDir)) {
+            foreach (glob($proxyDir . '/*.php') ?: [] as $file) {
+                @unlink($file);
+            }
+            @unlink($proxyDir . '/.ecotone_hash');
+            @rmdir($proxyDir);
+        }
     }
 
     private function injectDiscoveryAndConfig(FrameworkKernel $kernel, array $extraLocations): void

--- a/packages/Tempest/tests/EcotoneIntegrationTest.php
+++ b/packages/Tempest/tests/EcotoneIntegrationTest.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Ecotone\Tempest;
+
+use Ecotone\Messaging\Config\ModulePackageList;
+use Ecotone\Tempest\EcotoneConfig;
+use Ecotone\Tempest\EcotoneServiceInitializer;
+use Tempest\Core\FrameworkKernel;
+use Tempest\Core\KernelEvent;
+use Tempest\Discovery\AutoloadDiscoveryLocations;
+use Tempest\Discovery\Composer;
+use Tempest\Discovery\DiscoveryConfig;
+use Tempest\Discovery\DiscoveryLocation;
+use Tempest\Framework\Testing\IntegrationTest;
+
+/**
+ * licence Apache-2.0
+ */
+abstract class EcotoneIntegrationTest extends IntegrationTest
+{
+    protected string $root = '/data/app/packages/Tempest/tests/app';
+
+    protected function ecotoneConfig(): EcotoneConfig
+    {
+        return new EcotoneConfig(
+            namespaces: ['Test\\Ecotone\\Tempest\\Fixture\\'],
+            skippedModulePackageNames: ModulePackageList::allPackages(),
+            test: true,
+        );
+    }
+
+    protected function discoverTestLocations(): array
+    {
+        return [
+            new DiscoveryLocation('Ecotone\\Tempest\\', '/data/app/packages/Tempest/src'),
+            new DiscoveryLocation('Test\\Ecotone\\Tempest\\Fixture\\', '/data/app/packages/Tempest/tests/Fixture'),
+        ];
+    }
+
+    protected function setupKernel(): self
+    {
+        EcotoneServiceInitializer::clearCache();
+
+        $this->internalStorage = '/tmp/ecotone_tempest_test_storage_' . getmypid();
+
+        $allLocations = [...$this->discoveryLocations, ...$this->discoverTestLocations()];
+
+        $kernel = new FrameworkKernel(
+            root: $this->root,
+            discoveryLocations: $allLocations,
+            internalStorage: $this->internalStorage,
+        );
+
+        $kernel->registerKernel()
+               ->validateRoot()
+               ->loadEnv()
+               ->registerEmergencyExceptionHandler()
+               ->registerShutdownFunction()
+               ->registerInternalStorage()
+               ->loadComposer();
+
+        $this->injectDiscoveryAndConfig($kernel, $allLocations);
+
+        $kernel->loadConfig()
+               ->bootDiscovery()
+               ->registerExceptionHandler()
+               ->event(KernelEvent::BOOTED);
+
+        $this->kernel = $kernel;
+        $this->container = $kernel->container;
+
+        $this->container->config($this->ecotoneConfig());
+
+        return $this;
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+        restore_exception_handler();
+        restore_error_handler();
+        EcotoneServiceInitializer::clearCache();
+    }
+
+    private function injectDiscoveryAndConfig(FrameworkKernel $kernel, array $extraLocations): void
+    {
+        $testAppComposer = (new Composer($this->root))->load();
+        $testAppComposer->namespaces = [];
+
+        $autoloadLocations = (new AutoloadDiscoveryLocations(
+            rootPath: '/data/app',
+            composer: $testAppComposer,
+        ))();
+
+        $discoveryConfig = $kernel->container->get(DiscoveryConfig::class);
+        $discoveryConfig->locations = [...$extraLocations, ...$autoloadLocations];
+
+        $kernel->container->config($discoveryConfig);
+        $kernel->discoveryConfig = $discoveryConfig;
+    }
+}

--- a/packages/Tempest/tests/EcotoneIntegrationTest.php
+++ b/packages/Tempest/tests/EcotoneIntegrationTest.php
@@ -7,6 +7,7 @@ namespace Test\Ecotone\Tempest;
 use Ecotone\Messaging\Config\ModulePackageList;
 use Ecotone\Tempest\EcotoneConfig;
 use Ecotone\Tempest\EcotoneServiceInitializer;
+use Ecotone\Tempest\MessagingSystemInitializer;
 use Tempest\Core\FrameworkKernel;
 use Tempest\Core\KernelEvent;
 use Tempest\Discovery\AutoloadDiscoveryLocations;
@@ -63,6 +64,8 @@ abstract class EcotoneIntegrationTest extends IntegrationTest
 
         $this->injectDiscoveryAndConfig($kernel, $allLocations);
 
+        $kernel->container->config($this->ecotoneConfig());
+
         $kernel->loadConfig()
                ->bootDiscovery()
                ->registerExceptionHandler()
@@ -70,8 +73,6 @@ abstract class EcotoneIntegrationTest extends IntegrationTest
 
         $this->kernel = $kernel;
         $this->container = $kernel->container;
-
-        $this->container->config($this->ecotoneConfig());
 
         return $this;
     }
@@ -82,6 +83,7 @@ abstract class EcotoneIntegrationTest extends IntegrationTest
         restore_exception_handler();
         restore_error_handler();
         EcotoneServiceInitializer::clearCache();
+        MessagingSystemInitializer::clearDefinitionHolder();
     }
 
     private function injectDiscoveryAndConfig(FrameworkKernel $kernel, array $extraLocations): void

--- a/packages/Tempest/tests/EcotoneIntegrationTest.php
+++ b/packages/Tempest/tests/EcotoneIntegrationTest.php
@@ -21,7 +21,7 @@ use Tempest\Framework\Testing\IntegrationTest;
  */
 abstract class EcotoneIntegrationTest extends IntegrationTest
 {
-    protected string $root = '/data/app/packages/Tempest/tests/app';
+    protected string $root = '';
 
     protected function ecotoneConfig(): EcotoneConfig
     {
@@ -35,14 +35,18 @@ abstract class EcotoneIntegrationTest extends IntegrationTest
     protected function discoverTestLocations(): array
     {
         return [
-            new DiscoveryLocation('Ecotone\\Tempest\\', '/data/app/packages/Tempest/src'),
-            new DiscoveryLocation('Test\\Ecotone\\Tempest\\Fixture\\', '/data/app/packages/Tempest/tests/Fixture'),
+            new DiscoveryLocation('Ecotone\\Tempest\\', TempestTestPaths::srcPath()),
+            new DiscoveryLocation('Test\\Ecotone\\Tempest\\Fixture\\', TempestTestPaths::fixturePath()),
         ];
     }
 
     protected function setupKernel(): self
     {
         EcotoneServiceInitializer::clearCache();
+
+        if ($this->root === '') {
+            $this->root = TempestTestPaths::appRoot();
+        }
 
         $this->internalStorage = '/tmp/ecotone_tempest_test_storage_' . getmypid();
 
@@ -111,7 +115,7 @@ abstract class EcotoneIntegrationTest extends IntegrationTest
         $testAppComposer->namespaces = [];
 
         $autoloadLocations = (new AutoloadDiscoveryLocations(
-            rootPath: '/data/app',
+            rootPath: TempestTestPaths::discoveryRoot(),
             composer: $testAppComposer,
         ))();
 

--- a/packages/Tempest/tests/EcotoneIntegrationTestCase.php
+++ b/packages/Tempest/tests/EcotoneIntegrationTestCase.php
@@ -19,7 +19,7 @@ use Tempest\Framework\Testing\IntegrationTest;
 /**
  * licence Apache-2.0
  */
-abstract class EcotoneIntegrationTest extends IntegrationTest
+abstract class EcotoneIntegrationTestCase extends IntegrationTest
 {
     protected string $root = '';
 

--- a/packages/Tempest/tests/Fixture/AsyncQueue/AsyncQueueChannelConfiguration.php
+++ b/packages/Tempest/tests/Fixture/AsyncQueue/AsyncQueueChannelConfiguration.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Ecotone\Tempest\Fixture\AsyncQueue;
+
+use Ecotone\Messaging\Attribute\ServiceContext;
+use Ecotone\Messaging\Channel\SimpleMessageChannelBuilder;
+
+/**
+ * licence Apache-2.0
+ */
+final class AsyncQueueChannelConfiguration
+{
+    #[ServiceContext]
+    public function registerAsyncQueue(): SimpleMessageChannelBuilder
+    {
+        return SimpleMessageChannelBuilder::createQueueChannel('ecotone_test_queue');
+    }
+}

--- a/packages/Tempest/tests/Fixture/AsyncQueue/NotifyCommand.php
+++ b/packages/Tempest/tests/Fixture/AsyncQueue/NotifyCommand.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Ecotone\Tempest\Fixture\AsyncQueue;
+
+/**
+ * licence Apache-2.0
+ */
+final class NotifyCommand
+{
+    public function __construct(public readonly string $message)
+    {
+    }
+}

--- a/packages/Tempest/tests/Fixture/AsyncQueue/NotifyCommandHandler.php
+++ b/packages/Tempest/tests/Fixture/AsyncQueue/NotifyCommandHandler.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Ecotone\Tempest\Fixture\AsyncQueue;
+
+use Ecotone\Messaging\Attribute\Asynchronous;
+use Ecotone\Modelling\Attribute\CommandHandler;
+
+/**
+ * licence Apache-2.0
+ */
+final class NotifyCommandHandler
+{
+    public bool $handled = false;
+
+    #[Asynchronous('ecotone_test_queue')]
+    #[CommandHandler('notify', endpointId: 'notify_handler')]
+    public function handle(NotifyCommand $command): void
+    {
+        $this->handled = true;
+    }
+}

--- a/packages/Tempest/tests/Fixture/Counter/CounterGateway.php
+++ b/packages/Tempest/tests/Fixture/Counter/CounterGateway.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Ecotone\Tempest\Fixture\Counter;
+
+use Ecotone\Messaging\Attribute\BusinessMethod;
+
+/**
+ * licence Apache-2.0
+ */
+interface CounterGateway
+{
+    #[BusinessMethod('counter.get')]
+    public function get(): int;
+}

--- a/packages/Tempest/tests/Fixture/Counter/CounterService.php
+++ b/packages/Tempest/tests/Fixture/Counter/CounterService.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Ecotone\Tempest\Fixture\Counter;
+
+use Ecotone\Modelling\Attribute\CommandHandler;
+use Ecotone\Modelling\Attribute\QueryHandler;
+
+/**
+ * licence Apache-2.0
+ */
+final class CounterService
+{
+    private int $count = 0;
+
+    #[CommandHandler('counter.increment')]
+    public function increment(): void
+    {
+        $this->count++;
+    }
+
+    #[QueryHandler('counter.get')]
+    public function get(): int
+    {
+        return $this->count;
+    }
+}

--- a/packages/Tempest/tests/Fixture/Dbal/DbalConnectionConfiguration.php
+++ b/packages/Tempest/tests/Fixture/Dbal/DbalConnectionConfiguration.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Ecotone\Tempest\Fixture\Dbal;
+
+use Ecotone\Messaging\Attribute\ServiceContext;
+use Ecotone\Tempest\Config\TempestConnectionReference;
+
+/**
+ * licence Apache-2.0
+ */
+final class DbalConnectionConfiguration
+{
+    #[ServiceContext]
+    public function dbalConnection(): TempestConnectionReference
+    {
+        return TempestConnectionReference::defaultConnection();
+    }
+}

--- a/packages/Tempest/tests/Fixture/ExpressionLanguage/CalculatorHandler.php
+++ b/packages/Tempest/tests/Fixture/ExpressionLanguage/CalculatorHandler.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Ecotone\Tempest\Fixture\ExpressionLanguage;
+
+use Ecotone\Messaging\Attribute\Parameter\Payload;
+use Ecotone\Modelling\Attribute\CommandHandler;
+use Ecotone\Modelling\Attribute\QueryHandler;
+
+/**
+ * licence Apache-2.0
+ */
+final class CalculatorHandler
+{
+    private int $result = 0;
+    private int $envResult = 0;
+
+    #[CommandHandler('calculator.multiply')]
+    public function multiply(#[Payload("parameter('ECOTONE_MULTIPLIER') * payload['value']")] int $calculatedValue): void
+    {
+        $this->result = $calculatedValue;
+    }
+
+    #[CommandHandler('calculator.multiplyWithEnv')]
+    public function multiplyWithEnv(#[Payload("parameter('ECOTONE_ENV_MULTIPLIER') * payload['value']")] int $calculatedValue): void
+    {
+        $this->envResult = $calculatedValue;
+    }
+
+    #[QueryHandler('calculator.getResult')]
+    public function getResult(): int
+    {
+        return $this->result;
+    }
+
+    #[QueryHandler('calculator.getEnvResult')]
+    public function getEnvResult(): int
+    {
+        return $this->envResult;
+    }
+}

--- a/packages/Tempest/tests/Fixture/ExpressionLanguage/ExpressionLanguageCommandHandler.php
+++ b/packages/Tempest/tests/Fixture/ExpressionLanguage/ExpressionLanguageCommandHandler.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Ecotone\Tempest\Fixture\ExpressionLanguage;
+
+use Ecotone\Messaging\Attribute\Parameter\Payload;
+use Ecotone\Modelling\Attribute\CommandHandler;
+use Ecotone\Modelling\Attribute\QueryHandler;
+
+/**
+ * licence Apache-2.0
+ */
+final class ExpressionLanguageCommandHandler
+{
+    private int $amount = 0;
+
+    #[CommandHandler('setAmount')]
+    public function execute(#[Payload("payload['amount']")] int $amount): void
+    {
+        $this->amount = $amount;
+    }
+
+    #[QueryHandler('getAmount')]
+    public function getAmount(): int
+    {
+        return $this->amount;
+    }
+}

--- a/packages/Tempest/tests/Fixture/MultiTenant/Customer.php
+++ b/packages/Tempest/tests/Fixture/MultiTenant/Customer.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Ecotone\Tempest\Fixture\MultiTenant;
+
+use Tempest\Database\IsDatabaseModel;
+use Tempest\Database\Table;
+
+/**
+ * licence Apache-2.0
+ */
+#[Table('persons')]
+final class Customer
+{
+    use IsDatabaseModel;
+
+    public int $customer_id;
+    public string $name;
+
+    public static function register(RegisterCustomer $command): self
+    {
+        $customer = new self();
+        $customer->customer_id = $command->customerId;
+        $customer->name = $command->name;
+
+        return $customer;
+    }
+}

--- a/packages/Tempest/tests/Fixture/MultiTenant/CustomerInterface.php
+++ b/packages/Tempest/tests/Fixture/MultiTenant/CustomerInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Ecotone\Tempest\Fixture\MultiTenant;
+
+use Ecotone\Dbal\Attribute\DbalWrite;
+
+/**
+ * licence Apache-2.0
+ */
+interface CustomerInterface
+{
+    #[DbalWrite('INSERT INTO persons (customer_id, name) VALUES (:customerId, :name)')]
+    public function register(int $customerId, string $name): void;
+}

--- a/packages/Tempest/tests/Fixture/MultiTenant/CustomerRepository.php
+++ b/packages/Tempest/tests/Fixture/MultiTenant/CustomerRepository.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Ecotone\Tempest\Fixture\MultiTenant;
+
+use Ecotone\Dbal\Attribute\DbalQuery;
+use Ecotone\Dbal\DbaBusinessMethod\FetchMode;
+
+/**
+ * licence Apache-2.0
+ */
+interface CustomerRepository
+{
+    #[DbalQuery('SELECT customer_id FROM persons', fetchMode: FetchMode::FIRST_COLUMN)]
+    public function getAllRegisteredPersonIds(): array;
+}

--- a/packages/Tempest/tests/Fixture/MultiTenant/CustomerService.php
+++ b/packages/Tempest/tests/Fixture/MultiTenant/CustomerService.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Ecotone\Tempest\Fixture\MultiTenant;
+
+use Ecotone\Messaging\Attribute\Parameter\Reference;
+use Ecotone\Modelling\Attribute\CommandHandler;
+use Ecotone\Modelling\Attribute\QueryHandler;
+
+/**
+ * licence Apache-2.0
+ */
+final class CustomerService
+{
+    #[CommandHandler]
+    public function handle(RegisterCustomer $command, CustomerInterface $customerInterface): void
+    {
+        $customerInterface->register($command->customerId, $command->name);
+    }
+
+    #[CommandHandler('customer.register_with_business_interface')]
+    public function handleWithDbalInterface(RegisterCustomer $command, CustomerInterface $customerInterface): void
+    {
+        $customerInterface->register($command->customerId, $command->name);
+    }
+
+    #[QueryHandler('customer.getAllRegistered')]
+    public function getAllRegisteredPersonIds(#[Reference] CustomerRepository $customerRepository): array
+    {
+        return $customerRepository->getAllRegisteredPersonIds();
+    }
+}

--- a/packages/Tempest/tests/Fixture/MultiTenant/MultiTenantEcotoneConfiguration.php
+++ b/packages/Tempest/tests/Fixture/MultiTenant/MultiTenantEcotoneConfiguration.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Ecotone\Tempest\Fixture\MultiTenant;
+
+use Ecotone\Dbal\MultiTenant\MultiTenantConfiguration;
+use Ecotone\Messaging\Attribute\ServiceContext;
+use Ecotone\Tempest\Config\TempestConnectionReference;
+use Tempest\Database\Config\MysqlConfig;
+use Tempest\Database\Config\PostgresConfig;
+
+/**
+ * licence Apache-2.0
+ */
+final class MultiTenantEcotoneConfiguration
+{
+    #[ServiceContext]
+    public function multiTenantConfiguration(): MultiTenantConfiguration
+    {
+        return MultiTenantConfiguration::create(
+            tenantHeaderName: 'tenant',
+            tenantToConnectionMapping: [
+                'tenant_a' => TempestConnectionReference::create('tenant_a', new PostgresConfig(
+                    host: 'database',
+                    port: '5432',
+                    username: 'ecotone',
+                    password: 'secret',
+                    database: 'ecotone',
+                )),
+                'tenant_b' => TempestConnectionReference::create('tenant_b', new MysqlConfig(
+                    host: 'database-mysql',
+                    port: '3306',
+                    username: 'ecotone',
+                    password: 'secret',
+                    database: 'ecotone',
+                )),
+            ],
+        );
+    }
+}

--- a/packages/Tempest/tests/Fixture/MultiTenant/RegisterCustomer.php
+++ b/packages/Tempest/tests/Fixture/MultiTenant/RegisterCustomer.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Ecotone\Tempest\Fixture\MultiTenant;
+
+/**
+ * licence Apache-2.0
+ */
+final class RegisterCustomer
+{
+    public function __construct(
+        public readonly int $customerId,
+        public readonly string $name,
+    ) {}
+}

--- a/packages/Tempest/tests/Fixture/MultiTenant/RegisterCustomer.php
+++ b/packages/Tempest/tests/Fixture/MultiTenant/RegisterCustomer.php
@@ -12,5 +12,6 @@ final class RegisterCustomer
     public function __construct(
         public readonly int $customerId,
         public readonly string $name,
-    ) {}
+    ) {
+    }
 }

--- a/packages/Tempest/tests/Fixture/Order/Order.php
+++ b/packages/Tempest/tests/Fixture/Order/Order.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Ecotone\Tempest\Fixture\Order;
+
+use Ecotone\Modelling\Attribute\Aggregate;
+use Ecotone\Modelling\Attribute\CommandHandler;
+use Ecotone\Modelling\Attribute\IdentifierMethod;
+use Ecotone\Modelling\Attribute\QueryHandler;
+use Tempest\Database\IsDatabaseModel;
+use Tempest\Database\PrimaryKey;
+
+/**
+ * licence Apache-2.0
+ */
+#[Aggregate]
+final class Order
+{
+    use IsDatabaseModel;
+
+    public PrimaryKey $id;
+
+    public string $user_id;
+
+    public int $total_price;
+
+    public bool $is_cancelled;
+
+    #[CommandHandler]
+    public static function place(PlaceOrder $command): self
+    {
+        $order = new self();
+        $order->user_id = $command->userId;
+        $order->total_price = $command->totalPrice;
+        $order->is_cancelled = false;
+        $order->save();
+
+        return $order;
+    }
+
+    #[IdentifierMethod('id')]
+    public function getId(): int
+    {
+        return $this->id->value;
+    }
+
+    #[CommandHandler(routingKey: 'cancel_order')]
+    public function cancel(): void
+    {
+        $this->is_cancelled = true;
+    }
+
+    #[QueryHandler('is_cancelled')]
+    public function isCancelled(): bool
+    {
+        return $this->is_cancelled;
+    }
+}

--- a/packages/Tempest/tests/Fixture/Order/PlaceOrder.php
+++ b/packages/Tempest/tests/Fixture/Order/PlaceOrder.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Ecotone\Tempest\Fixture\Order;
+
+/**
+ * licence Apache-2.0
+ */
+final class PlaceOrder
+{
+    public function __construct(
+        public readonly string $userId,
+        public readonly int $totalPrice,
+    ) {
+    }
+}

--- a/packages/Tempest/tests/Fixture/SharedConnection/InsertThenFailHandler.php
+++ b/packages/Tempest/tests/Fixture/SharedConnection/InsertThenFailHandler.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Ecotone\Tempest\Fixture\SharedConnection;
+
+use Ecotone\Modelling\Attribute\CommandHandler;
+use RuntimeException;
+
+/**
+ * licence Apache-2.0
+ */
+final class InsertThenFailHandler
+{
+    #[CommandHandler('shared_connection.insert_then_fail')]
+    public function insertThenFail(): void
+    {
+        $item = new SharedConnectionItem();
+        $item->name = 'should-be-rolled-back';
+        $item->save();
+
+        throw new RuntimeException('Intentional failure to trigger rollback');
+    }
+}

--- a/packages/Tempest/tests/Fixture/SharedConnection/SharedConnectionConfiguration.php
+++ b/packages/Tempest/tests/Fixture/SharedConnection/SharedConnectionConfiguration.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Ecotone\Tempest\Fixture\SharedConnection;
+
+use Ecotone\Messaging\Attribute\ServiceContext;
+use Ecotone\Tempest\Config\TempestConnectionReference;
+
+/**
+ * licence Apache-2.0
+ */
+final class SharedConnectionConfiguration
+{
+    #[ServiceContext]
+    public function connection(): TempestConnectionReference
+    {
+        return TempestConnectionReference::defaultConnection();
+    }
+}

--- a/packages/Tempest/tests/Fixture/SharedConnection/SharedConnectionItem.php
+++ b/packages/Tempest/tests/Fixture/SharedConnection/SharedConnectionItem.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Ecotone\Tempest\Fixture\SharedConnection;
+
+use Tempest\Database\IsDatabaseModel;
+use Tempest\Database\PrimaryKey;
+
+/**
+ * licence Apache-2.0
+ */
+final class SharedConnectionItem
+{
+    use IsDatabaseModel;
+
+    public PrimaryKey $id;
+    public string $name;
+}

--- a/packages/Tempest/tests/Fixture/TenantSharedConnection/TenantInsertThenFailHandler.php
+++ b/packages/Tempest/tests/Fixture/TenantSharedConnection/TenantInsertThenFailHandler.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Ecotone\Tempest\Fixture\TenantSharedConnection;
+
+use Ecotone\Modelling\Attribute\CommandHandler;
+use RuntimeException;
+use Tempest\Database\IsDatabaseModel;
+use Tempest\Database\PrimaryKey;
+
+/**
+ * licence Apache-2.0
+ */
+final class TenantSharedItem
+{
+    use IsDatabaseModel;
+
+    public PrimaryKey $id;
+    public string $name;
+}
+
+final class TenantInsertThenFailHandler
+{
+    #[CommandHandler('tenant_shared_connection.insert_then_fail')]
+    public function insertThenFail(): void
+    {
+        $item = new TenantSharedItem();
+        $item->name = 'should-be-rolled-back';
+        $item->save();
+
+        throw new RuntimeException('Intentional failure to trigger multi-tenant rollback');
+    }
+}

--- a/packages/Tempest/tests/Fixture/TenantSharedConnection/TenantSharedConnectionConfiguration.php
+++ b/packages/Tempest/tests/Fixture/TenantSharedConnection/TenantSharedConnectionConfiguration.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Test\Ecotone\Tempest\Fixture\MultiTenant;
+namespace Test\Ecotone\Tempest\Fixture\TenantSharedConnection;
 
 use Ecotone\Dbal\MultiTenant\MultiTenantConfiguration;
 use Ecotone\Messaging\Attribute\ServiceContext;
@@ -11,8 +11,14 @@ use Ecotone\Tempest\Config\TempestConnectionReference;
 /**
  * licence Apache-2.0
  */
-final class MultiTenantEcotoneConfiguration
+final class TenantSharedConnectionConfiguration
 {
+    #[ServiceContext]
+    public function defaultConnection(): TempestConnectionReference
+    {
+        return TempestConnectionReference::defaultConnection();
+    }
+
     #[ServiceContext]
     public function multiTenantConfiguration(): MultiTenantConfiguration
     {
@@ -20,7 +26,6 @@ final class MultiTenantEcotoneConfiguration
             tenantHeaderName: 'tenant',
             tenantToConnectionMapping: [
                 'tenant_a' => TempestConnectionReference::create('tenant_a'),
-                'tenant_b' => TempestConnectionReference::create('tenant_b'),
             ],
         );
     }

--- a/packages/Tempest/tests/Fixture/User/MessagingConfiguration.php
+++ b/packages/Tempest/tests/Fixture/User/MessagingConfiguration.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Ecotone\Tempest\Fixture\User;
+
+use Ecotone\Lite\Test\Configuration\InMemoryRepositoryBuilder;
+use Ecotone\Messaging\Attribute\ServiceContext;
+
+/**
+ * licence Apache-2.0
+ */
+final class MessagingConfiguration
+{
+    #[ServiceContext]
+    public function withInMemoryRepository(): InMemoryRepositoryBuilder
+    {
+        return InMemoryRepositoryBuilder::createForAllStateStoredAggregates();
+    }
+}

--- a/packages/Tempest/tests/Fixture/User/User.php
+++ b/packages/Tempest/tests/Fixture/User/User.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Ecotone\Tempest\Fixture\User;
+
+use Ecotone\Modelling\Attribute\Aggregate;
+use Ecotone\Modelling\Attribute\Identifier;
+
+/**
+ * licence Apache-2.0
+ */
+#[Aggregate]
+final class User
+{
+    private function __construct(#[Identifier] private string $userId)
+    {
+    }
+
+    public static function register(string $userId): self
+    {
+        return new self($userId);
+    }
+}

--- a/packages/Tempest/tests/Fixture/User/UserRepository.php
+++ b/packages/Tempest/tests/Fixture/User/UserRepository.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Ecotone\Tempest\Fixture\User;
+
+use Ecotone\Modelling\Attribute\Identifier;
+use Ecotone\Modelling\Attribute\Repository;
+
+/**
+ * licence Apache-2.0
+ */
+interface UserRepository
+{
+    #[Repository]
+    public function save(User $user): void;
+
+    #[Repository]
+    public function getUser(#[Identifier] string $userId): User;
+}

--- a/packages/Tempest/tests/Fixture/User/UserService.php
+++ b/packages/Tempest/tests/Fixture/User/UserService.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Ecotone\Tempest\Fixture\User;
+
+use Ecotone\Modelling\Attribute\CommandHandler;
+
+/**
+ * licence Apache-2.0
+ */
+final class UserService
+{
+    public function __construct(private UserRepository $userRepository)
+    {
+    }
+
+    #[CommandHandler('user.register')]
+    public function register(string $userId): void
+    {
+        $this->userRepository->save(User::register($userId));
+    }
+}

--- a/packages/Tempest/tests/MultiTenant/MultiTenantTest.php
+++ b/packages/Tempest/tests/MultiTenant/MultiTenantTest.php
@@ -1,0 +1,159 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Ecotone\Tempest\MultiTenant;
+
+use Ecotone\Messaging\Config\ModulePackageList;
+use Ecotone\Modelling\CommandBus;
+use Ecotone\Modelling\QueryBus;
+use Ecotone\Tempest\EcotoneConfig;
+use Ecotone\Tempest\EcotoneServiceInitializer;
+use Ecotone\Tempest\MessagingSystemInitializer;
+use PDO;
+use Tempest\Database\Config\MysqlConfig;
+use Tempest\Database\Config\PostgresConfig;
+use Test\Ecotone\Tempest\EcotoneIntegrationTest;
+use Test\Ecotone\Tempest\Fixture\MultiTenant\RegisterCustomer;
+
+/**
+ * licence Apache-2.0
+ * @internal
+ */
+final class MultiTenantTest extends EcotoneIntegrationTest
+{
+    private CommandBus $commandBus;
+    private QueryBus $queryBus;
+
+    protected function ecotoneConfig(): EcotoneConfig
+    {
+        return new EcotoneConfig(
+            namespaces: ['Test\\Ecotone\\Tempest\\Fixture\\MultiTenant\\'],
+            skippedModulePackageNames: ModulePackageList::allPackagesExcept([
+                ModulePackageList::TEMPEST_PACKAGE,
+                ModulePackageList::DBAL_PACKAGE,
+            ]),
+            test: false,
+        );
+    }
+
+    protected function discoverTestLocations(): array
+    {
+        return [
+            ...parent::discoverTestLocations(),
+            new \Tempest\Discovery\DiscoveryLocation(
+                'Test\\Ecotone\\Tempest\\Fixture\\MultiTenant\\',
+                '/data/app/packages/Tempest/tests/Fixture/MultiTenant',
+            ),
+        ];
+    }
+
+    protected function setUp(): void
+    {
+        EcotoneServiceInitializer::clearCache();
+        MessagingSystemInitializer::clearDefinitionHolder();
+
+        $this->setupKernel();
+
+        $this->createPersonsTableForBothTenants();
+
+        $this->commandBus = $this->container->get(CommandBus::class);
+        $this->queryBus = $this->container->get(QueryBus::class);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->dropPersonsTableForBothTenants();
+        parent::tearDown();
+    }
+
+    public function test_run_message_handlers_for_multi_tenant_connection(): void
+    {
+        $this->commandBus->send(new RegisterCustomer(1, 'John Doe'), metadata: ['tenant' => 'tenant_a']);
+        $this->commandBus->send(new RegisterCustomer(2, 'John Doe'), metadata: ['tenant' => 'tenant_a']);
+        $this->commandBus->send(new RegisterCustomer(2, 'John Doe'), metadata: ['tenant' => 'tenant_b']);
+
+        $this->assertSame(
+            [1, 2],
+            $this->queryBus->sendWithRouting('customer.getAllRegistered', metadata: ['tenant' => 'tenant_a']),
+        );
+
+        $this->assertSame(
+            [2],
+            $this->queryBus->sendWithRouting('customer.getAllRegistered', metadata: ['tenant' => 'tenant_b']),
+        );
+    }
+
+    public function test_using_dbal_based_business_interfaces(): void
+    {
+        $this->commandBus->sendWithRouting(
+            'customer.register_with_business_interface',
+            new RegisterCustomer(1, 'John Doe'),
+            metadata: ['tenant' => 'tenant_a'],
+        );
+
+        $this->assertSame(
+            [1],
+            $this->queryBus->sendWithRouting('customer.getAllRegistered', metadata: ['tenant' => 'tenant_a']),
+        );
+
+        $this->assertSame(
+            [],
+            $this->queryBus->sendWithRouting('customer.getAllRegistered', metadata: ['tenant' => 'tenant_b']),
+        );
+    }
+
+    private function createPersonsTableForBothTenants(): void
+    {
+        $this->createPersonsTable($this->postgresConnection());
+        $this->createPersonsTable($this->mysqlConnection());
+    }
+
+    private function dropPersonsTableForBothTenants(): void
+    {
+        $this->postgresConnection()->exec('DROP TABLE IF EXISTS persons');
+        $this->mysqlConnection()->exec('DROP TABLE IF EXISTS persons');
+    }
+
+    private function createPersonsTable(PDO $pdo): void
+    {
+        $pdo->exec('DROP TABLE IF EXISTS persons');
+        $pdo->exec(
+            'CREATE TABLE persons (
+                customer_id INTEGER NOT NULL,
+                name VARCHAR(255),
+                PRIMARY KEY (customer_id)
+            )',
+        );
+    }
+
+    private function postgresConnection(): PDO
+    {
+        return new PDO(
+            (new PostgresConfig(
+                host: 'database',
+                port: '5432',
+                username: 'ecotone',
+                password: 'secret',
+                database: 'ecotone',
+            ))->dsn,
+            'ecotone',
+            'secret',
+        );
+    }
+
+    private function mysqlConnection(): PDO
+    {
+        return new PDO(
+            (new MysqlConfig(
+                host: 'database-mysql',
+                port: '3306',
+                username: 'ecotone',
+                password: 'secret',
+                database: 'ecotone',
+            ))->dsn,
+            'ecotone',
+            'secret',
+        );
+    }
+}

--- a/packages/Tempest/tests/MultiTenant/MultiTenantTest.php
+++ b/packages/Tempest/tests/MultiTenant/MultiTenantTest.php
@@ -11,7 +11,7 @@ use Ecotone\Tempest\EcotoneConfig;
 use Ecotone\Tempest\EcotoneServiceInitializer;
 use Ecotone\Tempest\MessagingSystemInitializer;
 use PDO;
-use Test\Ecotone\Tempest\EcotoneIntegrationTest;
+use Test\Ecotone\Tempest\EcotoneIntegrationTestCase;
 use Test\Ecotone\Tempest\Fixture\MultiTenant\RegisterCustomer;
 use Test\Ecotone\Tempest\TempestDatabaseConfigFactory;
 
@@ -19,7 +19,7 @@ use Test\Ecotone\Tempest\TempestDatabaseConfigFactory;
  * licence Apache-2.0
  * @internal
  */
-final class MultiTenantTest extends EcotoneIntegrationTest
+final class MultiTenantTest extends EcotoneIntegrationTestCase
 {
     private CommandBus $commandBus;
     private QueryBus $queryBus;

--- a/packages/Tempest/tests/MultiTenant/MultiTenantTest.php
+++ b/packages/Tempest/tests/MultiTenant/MultiTenantTest.php
@@ -55,6 +55,23 @@ final class MultiTenantTest extends EcotoneIntegrationTest
 
         $this->setupKernel();
 
+        $this->container->config(new PostgresConfig(
+            host: 'database',
+            port: '5432',
+            username: 'ecotone',
+            password: 'secret',
+            database: 'ecotone',
+            tag: 'tenant_a',
+        ));
+        $this->container->config(new MysqlConfig(
+            host: 'database-mysql',
+            port: '3306',
+            username: 'ecotone',
+            password: 'secret',
+            database: 'ecotone',
+            tag: 'tenant_b',
+        ));
+
         $this->createPersonsTableForBothTenants();
 
         $this->commandBus = $this->container->get(CommandBus::class);

--- a/packages/Tempest/tests/MultiTenant/MultiTenantTest.php
+++ b/packages/Tempest/tests/MultiTenant/MultiTenantTest.php
@@ -11,10 +11,9 @@ use Ecotone\Tempest\EcotoneConfig;
 use Ecotone\Tempest\EcotoneServiceInitializer;
 use Ecotone\Tempest\MessagingSystemInitializer;
 use PDO;
-use Tempest\Database\Config\MysqlConfig;
-use Tempest\Database\Config\PostgresConfig;
 use Test\Ecotone\Tempest\EcotoneIntegrationTest;
 use Test\Ecotone\Tempest\Fixture\MultiTenant\RegisterCustomer;
+use Test\Ecotone\Tempest\TempestDatabaseConfigFactory;
 
 /**
  * licence Apache-2.0
@@ -43,7 +42,7 @@ final class MultiTenantTest extends EcotoneIntegrationTest
             ...parent::discoverTestLocations(),
             new \Tempest\Discovery\DiscoveryLocation(
                 'Test\\Ecotone\\Tempest\\Fixture\\MultiTenant\\',
-                '/data/app/packages/Tempest/tests/Fixture/MultiTenant',
+                \Test\Ecotone\Tempest\TempestTestPaths::fixturePath() . '/MultiTenant',
             ),
         ];
     }
@@ -55,22 +54,8 @@ final class MultiTenantTest extends EcotoneIntegrationTest
 
         $this->setupKernel();
 
-        $this->container->config(new PostgresConfig(
-            host: 'database',
-            port: '5432',
-            username: 'ecotone',
-            password: 'secret',
-            database: 'ecotone',
-            tag: 'tenant_a',
-        ));
-        $this->container->config(new MysqlConfig(
-            host: 'database-mysql',
-            port: '3306',
-            username: 'ecotone',
-            password: 'secret',
-            database: 'ecotone',
-            tag: 'tenant_b',
-        ));
+        $this->container->config(TempestDatabaseConfigFactory::primary('tenant_a'));
+        $this->container->config(TempestDatabaseConfigFactory::secondary('tenant_b'));
 
         $this->createPersonsTableForBothTenants();
 
@@ -146,31 +131,15 @@ final class MultiTenantTest extends EcotoneIntegrationTest
 
     private function postgresConnection(): PDO
     {
-        return new PDO(
-            (new PostgresConfig(
-                host: 'database',
-                port: '5432',
-                username: 'ecotone',
-                password: 'secret',
-                database: 'ecotone',
-            ))->dsn,
-            'ecotone',
-            'secret',
-        );
+        $config = TempestDatabaseConfigFactory::primary();
+
+        return new PDO($config->dsn, $config->username, $config->password);
     }
 
     private function mysqlConnection(): PDO
     {
-        return new PDO(
-            (new MysqlConfig(
-                host: 'database-mysql',
-                port: '3306',
-                username: 'ecotone',
-                password: 'secret',
-                database: 'ecotone',
-            ))->dsn,
-            'ecotone',
-            'secret',
-        );
+        $config = TempestDatabaseConfigFactory::secondary();
+
+        return new PDO($config->dsn, $config->username, $config->password);
     }
 }

--- a/packages/Tempest/tests/Repository/TempestRepositoryIntegrationTest.php
+++ b/packages/Tempest/tests/Repository/TempestRepositoryIntegrationTest.php
@@ -11,7 +11,7 @@ use Ecotone\Tempest\MessagingSystemInitializer;
 use Tempest\Database\Database;
 use Tempest\Database\Query;
 use Tempest\Database\QueryStatements\CreateTableStatement;
-use Test\Ecotone\Tempest\EcotoneIntegrationTest;
+use Test\Ecotone\Tempest\EcotoneIntegrationTestCase;
 use Test\Ecotone\Tempest\Fixture\Order\Order;
 use Test\Ecotone\Tempest\Fixture\Order\PlaceOrder;
 use Test\Ecotone\Tempest\TempestDatabaseConfigFactory;
@@ -21,7 +21,7 @@ use Throwable;
  * licence Apache-2.0
  * @internal
  */
-final class TempestRepositoryIntegrationTest extends EcotoneIntegrationTest
+final class TempestRepositoryIntegrationTest extends EcotoneIntegrationTestCase
 {
     protected function ecotoneConfig(): EcotoneConfig
     {

--- a/packages/Tempest/tests/Repository/TempestRepositoryIntegrationTest.php
+++ b/packages/Tempest/tests/Repository/TempestRepositoryIntegrationTest.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Ecotone\Tempest\Repository;
+
+use Ecotone\Messaging\Config\ModulePackageList;
+use Ecotone\Tempest\EcotoneConfig;
+use Ecotone\Tempest\EcotoneServiceInitializer;
+use Ecotone\Tempest\MessagingSystemInitializer;
+use Tempest\Database\Config\PostgresConfig;
+use Tempest\Database\Database;
+use Tempest\Database\Query;
+use Tempest\Database\QueryStatements\CreateTableStatement;
+use Tempest\Database\QueryStatements\DropTableStatement;
+use Test\Ecotone\Tempest\EcotoneIntegrationTest;
+use Test\Ecotone\Tempest\Fixture\Order\Order;
+use Test\Ecotone\Tempest\Fixture\Order\PlaceOrder;
+
+/**
+ * licence Apache-2.0
+ * @internal
+ */
+final class TempestRepositoryIntegrationTest extends EcotoneIntegrationTest
+{
+    protected function ecotoneConfig(): EcotoneConfig
+    {
+        return new EcotoneConfig(
+            namespaces: ['Test\\Ecotone\\Tempest\\Fixture\\Order\\'],
+            skippedModulePackageNames: ModulePackageList::allPackages(),
+            test: false,
+        );
+    }
+
+    protected function setUp(): void
+    {
+        EcotoneServiceInitializer::clearCache();
+        MessagingSystemInitializer::clearDefinitionHolder();
+
+        $this->setupKernel();
+
+        $postgresConfig = new PostgresConfig(
+            host: 'database',
+            port: '5432',
+            username: 'ecotone',
+            password: 'secret',
+            database: 'ecotone',
+        );
+        $this->container->config($postgresConfig);
+
+        $this->createOrdersTable();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->dropOrdersTable();
+        parent::tearDown();
+    }
+
+    public function test_placing_an_order_with_tempest_model(): void
+    {
+        $commandBus = $this->container->get(\Ecotone\Modelling\CommandBus::class);
+
+        $orderId = $commandBus->send(new PlaceOrder(userId: 'user-1', totalPrice: 100));
+
+        $this->assertIsInt($orderId);
+        $this->assertNotNull(Order::findById($orderId));
+    }
+
+    public function test_state_change_round_trips_through_command_and_query_bus(): void
+    {
+        $commandBus = $this->container->get(\Ecotone\Modelling\CommandBus::class);
+        $queryBus = $this->container->get(\Ecotone\Modelling\QueryBus::class);
+
+        $orderId = $commandBus->send(new PlaceOrder(userId: 'user-1', totalPrice: 100));
+
+        $this->assertFalse(
+            $queryBus->sendWithRouting('is_cancelled', metadata: ['aggregate.id' => $orderId]),
+        );
+
+        $commandBus->sendWithRouting('cancel_order', metadata: ['aggregate.id' => $orderId]);
+
+        $this->assertTrue(
+            $queryBus->sendWithRouting('is_cancelled', metadata: ['aggregate.id' => $orderId]),
+        );
+    }
+
+    private function createOrdersTable(): void
+    {
+        $database = $this->container->get(Database::class);
+
+        $database->execute(
+            new Query('DROP TABLE IF EXISTS orders'),
+        );
+
+        $createSql = (new CreateTableStatement('orders'))
+            ->primary('id')
+            ->string('user_id')
+            ->integer('total_price')
+            ->boolean('is_cancelled')
+            ->compile($database->dialect);
+
+        $database->execute(new Query($createSql));
+    }
+
+    private function dropOrdersTable(): void
+    {
+        try {
+            $database = $this->container->get(Database::class);
+            $database->execute(new Query('DROP TABLE IF EXISTS orders'));
+        } catch (\Throwable) {
+        }
+    }
+}

--- a/packages/Tempest/tests/Repository/TempestRepositoryIntegrationTest.php
+++ b/packages/Tempest/tests/Repository/TempestRepositoryIntegrationTest.php
@@ -8,14 +8,14 @@ use Ecotone\Messaging\Config\ModulePackageList;
 use Ecotone\Tempest\EcotoneConfig;
 use Ecotone\Tempest\EcotoneServiceInitializer;
 use Ecotone\Tempest\MessagingSystemInitializer;
-use Tempest\Database\Config\PostgresConfig;
 use Tempest\Database\Database;
 use Tempest\Database\Query;
 use Tempest\Database\QueryStatements\CreateTableStatement;
-use Tempest\Database\QueryStatements\DropTableStatement;
 use Test\Ecotone\Tempest\EcotoneIntegrationTest;
 use Test\Ecotone\Tempest\Fixture\Order\Order;
 use Test\Ecotone\Tempest\Fixture\Order\PlaceOrder;
+use Test\Ecotone\Tempest\TempestDatabaseConfigFactory;
+use Throwable;
 
 /**
  * licence Apache-2.0
@@ -39,13 +39,7 @@ final class TempestRepositoryIntegrationTest extends EcotoneIntegrationTest
 
         $this->setupKernel();
 
-        $postgresConfig = new PostgresConfig(
-            host: 'database',
-            port: '5432',
-            username: 'ecotone',
-            password: 'secret',
-            database: 'ecotone',
-        );
+        $postgresConfig = TempestDatabaseConfigFactory::primary();
         $this->container->config($postgresConfig);
 
         $this->createOrdersTable();
@@ -108,7 +102,7 @@ final class TempestRepositoryIntegrationTest extends EcotoneIntegrationTest
         try {
             $database = $this->container->get(Database::class);
             $database->execute(new Query('DROP TABLE IF EXISTS orders'));
-        } catch (\Throwable) {
+        } catch (Throwable) {
         }
     }
 }

--- a/packages/Tempest/tests/Repository/TempestRepositoryTest.php
+++ b/packages/Tempest/tests/Repository/TempestRepositoryTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Ecotone\Tempest\Repository;
+
+use DateTime;
+use Ecotone\Tempest\TempestRepository;
+use PHPUnit\Framework\TestCase;
+use Tempest\Database\IsDatabaseModel;
+use Tempest\Database\PrimaryKey;
+
+/**
+ * licence Apache-2.0
+ * @internal
+ */
+final class TempestRepositoryTest extends TestCase
+{
+    public function test_it_does_not_support_non_models(): void
+    {
+        $repository = new TempestRepository();
+
+        $this->assertFalse($repository->canHandle(DateTime::class));
+    }
+
+    public function test_it_does_support_tempest_database_models(): void
+    {
+        $repository = new TempestRepository();
+
+        $modelClass = new class {
+            use IsDatabaseModel;
+
+            public PrimaryKey $id;
+        };
+
+        $this->assertTrue($repository->canHandle($modelClass::class));
+    }
+}

--- a/packages/Tempest/tests/Repository/TempestRepositoryTest.php
+++ b/packages/Tempest/tests/Repository/TempestRepositoryTest.php
@@ -27,7 +27,7 @@ final class TempestRepositoryTest extends TestCase
     {
         $repository = new TempestRepository();
 
-        $modelClass = new class {
+        $modelClass = new class () {
             use IsDatabaseModel;
 
             public PrimaryKey $id;

--- a/packages/Tempest/tests/TempestConfigurationVariableServiceTest.php
+++ b/packages/Tempest/tests/TempestConfigurationVariableServiceTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Ecotone\Tempest;
+
+use Ecotone\Tempest\TempestConfigurationVariableService;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * licence Apache-2.0
+ * @internal
+ */
+final class TempestConfigurationVariableServiceTest extends TestCase
+{
+    public function test_reads_env_variables(): void
+    {
+        putenv('ECOTONE_TEST_VAR=test-value');
+
+        $service = new TempestConfigurationVariableService();
+
+        $this->assertTrue($service->hasName('ECOTONE_TEST_VAR'));
+        $this->assertSame('test-value', $service->getByName('ECOTONE_TEST_VAR'));
+    }
+
+    public function test_returns_false_for_missing_env_variable(): void
+    {
+        $service = new TempestConfigurationVariableService();
+
+        $this->assertFalse($service->hasName('ECOTONE_NONEXISTENT_VAR_XYZ'));
+        $this->assertNull($service->getByName('ECOTONE_NONEXISTENT_VAR_XYZ'));
+    }
+}

--- a/packages/Tempest/tests/TempestDatabaseConfigFactory.php
+++ b/packages/Tempest/tests/TempestDatabaseConfigFactory.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Ecotone\Tempest;
+
+use Tempest\Database\Config\DatabaseConfig;
+use Tempest\Database\Config\MysqlConfig;
+use Tempest\Database\Config\PostgresConfig;
+use UnitEnum;
+
+/**
+ * Builds Tempest DatabaseConfig objects from the DATABASE_DSN / SECONDARY_DATABASE_DSN
+ * environment variables so the tests run both in docker (host: database / database-mysql)
+ * and on CI runners (host: 127.0.0.1), matching the convention used by the other packages.
+ *
+ * licence Apache-2.0
+ */
+final class TempestDatabaseConfigFactory
+{
+    public static function primary(null|string|UnitEnum $tag = null): DatabaseConfig
+    {
+        return self::fromDsn(getenv('DATABASE_DSN') ?: 'pgsql://ecotone:secret@database:5432/ecotone', $tag);
+    }
+
+    public static function secondary(null|string|UnitEnum $tag = null): DatabaseConfig
+    {
+        return self::fromDsn(getenv('SECONDARY_DATABASE_DSN') ?: 'mysql://ecotone:secret@database-mysql:3306/ecotone', $tag);
+    }
+
+    public static function fromDsn(string $dsn, null|string|UnitEnum $tag = null): DatabaseConfig
+    {
+        $parts = parse_url($dsn);
+        $scheme = $parts['scheme'] ?? 'pgsql';
+        $host = $parts['host'] ?? 'localhost';
+        $port = (string) ($parts['port'] ?? ($scheme === 'mysql' ? 3306 : 5432));
+        $username = $parts['user'] ?? 'ecotone';
+        $password = $parts['pass'] ?? 'secret';
+        $database = ltrim($parts['path'] ?? '/ecotone', '/');
+
+        if ($scheme === 'mysql') {
+            return new MysqlConfig(host: $host, port: $port, username: $username, password: $password, database: $database, tag: $tag);
+        }
+
+        return new PostgresConfig(host: $host, port: $port, username: $username, password: $password, database: $database, tag: $tag);
+    }
+}

--- a/packages/Tempest/tests/TempestTestPaths.php
+++ b/packages/Tempest/tests/TempestTestPaths.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Ecotone\Tempest;
+
+/**
+ * licence Apache-2.0
+ */
+final class TempestTestPaths
+{
+    public static function packageRoot(): string
+    {
+        return dirname(__DIR__);
+    }
+
+    public static function appRoot(): string
+    {
+        return self::packageRoot() . '/tests/app';
+    }
+
+    public static function srcPath(): string
+    {
+        return self::packageRoot() . '/src';
+    }
+
+    public static function fixturePath(): string
+    {
+        return self::packageRoot() . '/tests/Fixture';
+    }
+
+    public static function discoveryRoot(): string
+    {
+        $directory = self::packageRoot();
+
+        while ($directory !== dirname($directory)) {
+            if (is_file($directory . '/vendor/composer/installed.json')) {
+                return $directory;
+            }
+
+            $directory = dirname($directory);
+        }
+
+        return self::packageRoot();
+    }
+}

--- a/packages/Tempest/tests/app/composer.json
+++ b/packages/Tempest/tests/app/composer.json
@@ -3,7 +3,7 @@
     "type": "project",
     "autoload": {
         "psr-4": {
-            "App\\": "src/"
+            "App\\Tempest\\": "src/"
         }
     },
     "require": {

--- a/packages/Tempest/tests/app/composer.json
+++ b/packages/Tempest/tests/app/composer.json
@@ -1,0 +1,13 @@
+{
+    "name": "ecotone/tempest-test-app",
+    "type": "project",
+    "autoload": {
+        "psr-4": {
+            "App\\": "src/"
+        }
+    },
+    "require": {
+        "ecotone/tempest": "*",
+        "tempest/framework": "*"
+    }
+}

--- a/packages/Tempest/tests/app/src/AppCommandHandler.php
+++ b/packages/Tempest/tests/app/src/AppCommandHandler.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tempest;
+
+use Ecotone\Modelling\Attribute\CommandHandler;
+use Ecotone\Modelling\Attribute\QueryHandler;
+
+/**
+ * licence Apache-2.0
+ */
+final class AppCommandHandler
+{
+    private bool $handled = false;
+
+    #[CommandHandler('app.ping')]
+    public function ping(): void
+    {
+        $this->handled = true;
+    }
+
+    #[QueryHandler('app.wasHandled')]
+    public function wasHandled(): bool
+    {
+        return $this->handled;
+    }
+}

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -16,6 +16,7 @@
       <directory suffix=".php">packages/PdoEventSourcing/src</directory>
       <directory suffix=".php">packages/JmsConverter/src</directory>
       <directory suffix=".php">packages/Laravel/src</directory>
+      <directory suffix=".php">packages/Tempest/src</directory>
       <directory suffix=".php">packages/Symfony/App</directory>
       <directory suffix=".php">packages/Symfony/DependencyInjection</directory>
       <directory suffix=".php">packages/Symfony/SymfonyBundle</directory>
@@ -54,6 +55,9 @@
     </testsuite>
     <testsuite name="Laravel tests">
       <directory>packages/Laravel/tests</directory>
+    </testsuite>
+    <testsuite name="Tempest tests">
+      <directory>packages/Tempest/tests</directory>
     </testsuite>
     <testsuite name="Symfony tests">
       <directory>packages/Symfony/tests</directory>


### PR DESCRIPTION
## Why is this change proposed?

Tempest is a modern PHP framework (v3.x, PHP 8.4+) gaining adoption, and Ecotone had no first-class integration for it. Developers using Tempest had no way to use CQRS, Event Sourcing, Sagas, or messaging patterns without hand-wiring everything from scratch. This PR adds `ecotone/tempest` — a full framework integration that makes Ecotone available in a Tempest app with zero config, the same way `ecotone/laravel` does for Laravel and `ecotone/symfony-bundle` for Symfony.

## Description of Changes

**New package: `packages/Tempest` (`ecotone/tempest`)**

- **Auto-discovery bootstrap** — `MessagingSystemInitializer` (Tempest `Initializer`) and `EcotoneServiceInitializer` (Tempest `DynamicInitializer`) compile Ecotone lazily on first gateway request. All gateways (`CommandBus`, `QueryBus`, `EventBus`, custom business interfaces) are injectable from Tempest's container with no setup.
- **Zero-config handler discovery** — When `loadAppNamespaces: true` (default), Ecotone auto-derives scan namespaces from Tempest's `Composer->namespaces` (the app's PSR-4 roots), mirroring Laravel's `app/` catalog scan. An `ecotone.config.php` is optional, not required.
- **DBAL connection bridge** — `TempestConnectionReference` wraps the app's Tempest `DatabaseConfig` (Postgres/MySQL/SQLite) as Ecotone's `DbalConnectionFactory`, enabling outbox, event sourcing, dead-letter queues, and DBAL business interfaces off the app's existing DB config.
- **Active-record aggregate repository** — `TempestRepository` lets Tempest `IsDatabaseModel` models be used directly as Ecotone aggregates (`canHandle` / `findBy` / `save`), with a recursive trait check for detection.
- **Multi-tenant DB switching** — `TempestTenantDatabaseSwitcher` + `TempestConnectionModule` integrate `HeaderBasedMultiTenantConnectionFactory` so commands/queries route to the correct tenant database via a message header.
- **Console commands** — `EcotoneConsoleCommandDiscovery` generates `#[ConsoleCommand]` proxy classes for every registered Ecotone command (`ecotone:list`, `ecotone:run`, `ecotone:cache:clear`, etc.) so they appear natively in `./tempest` with no manual wiring.
- **Production hardening** — hash-gated proxy regeneration, PSR-3 logger wiring via Tempest's DynamicInitializer, `ecotone:cache:clear` command, real-boot test proving zero-config works end-to-end.

**Also:** `ModulePackageList::TEMPEST_PACKAGE` added to Ecotone core (mirroring `LARAVEL_PACKAGE`/`SYMFONY_PACKAGE`, `class_exists`-guarded).

---

### Usage

**Install:**
```bash
composer require ecotone/tempest
```

**Zero-config — handlers in `App\` are auto-discovered, gateways are injectable:**
```php
final class OrderController
{
    public function __construct(private CommandBus $commandBus) {}
}
```

**Optional `ecotone.config.php` (service name, licence key, explicit namespaces):**
```php
// app/ecotone.config.php — auto-discovered by Tempest
return new EcotoneConfig(
    serviceName: 'order-service',
    licenceKey: env('ECOTONE_LICENCE_KEY'),
);
```

**DBAL connection — wire the app's DB config as Ecotone's default connection:**
```php
#[ServiceContext]
public function databaseConnection(): TempestConnectionReference
{
    return TempestConnectionReference::defaultConnection();
}
```

**Active-record aggregate — use a Tempest model as an Ecotone aggregate:**
```php
#[Aggregate]
final class Order
{
    use IsDatabaseModel;

    public PrimaryKey $id;
    public string $status;

    #[CommandHandler]
    public static function place(PlaceOrder $command): self
    {
        $order = new self();
        $order->status = 'placed';
        $order->save();
        return $order;
    }

    #[IdentifierMethod('id')]
    public function getId(): int { return $this->id->value; }
}
```

**Multi-tenant routing — route commands to the correct tenant DB via header:**
```php
#[ServiceContext]
public function multiTenant(): MultiTenantConfiguration
{
    return MultiTenantConfiguration::create(
        tenantHeaderName: 'tenant',
        tenantToConnectionMapping: [
            'tenant_a' => TempestConnectionReference::create('tenant_a'),
            'tenant_b' => TempestConnectionReference::create('tenant_b'),
        ],
    );
}

$commandBus->send(new RegisterCustomer(1, 'Alice'), metadata: ['tenant' => 'tenant_a']);
```

---

### Integration architecture

```mermaid
flowchart TD
    A[Tempest boot\nFrameworkKernel] -->|InitializerDiscovery| B[EcotoneServiceInitializer\nDynamicInitializer]
    A -->|DiscoveryDiscovery| C[EcotoneConsoleCommandDiscovery\nDiscovery]
    B -->|first get CommandBus| D[MessagingSystemInitializer\ncompile Ecotone]
    D -->|derives from Composer.namespaces| E[App PSR-4 roots\nApp handler scan]
    D -->|LazyInMemoryContainer| F[ConfiguredMessagingSystem]
    F -->|markCompiled| B
    B -->|DynamicInitializer| G[CommandBus / QueryBus\nEventBus / BusinessInterface\nresolvable from container]
    C -->|ConsoleCommandProxyGenerator| H[ConsoleCommand proxies\necotone:list / ecotone:run]
    D -->|TempestConnectionModule| I[TempestConnectionReference\nDbalConnectionFactory]
    D -->|TempestRepositoryBuilder| J[TempestRepository\nIsDatabaseModel as Aggregate]
```

---

### Use-case scenarios

1. **CQRS + Event Sourcing in a Tempest app** — Install `ecotone/tempest` + `ecotone/pdo-event-sourcing`, define `#[EventSourcingAggregate]` classes and projections, wire the DB via `TempestConnectionReference`. See the included quickstart (`quickstart-examples/Tempest/Projection/DatabaseReadModel`).

2. **Tempest active-record model as a DDD aggregate** — Use `IsDatabaseModel` + `#[Aggregate]` so commands mutate the model through the Command Bus and `TempestRepository` handles persistence automatically. See `quickstart-examples/Tempest/Model`.

3. **Multi-tenant SaaS** — Use `MultiTenantConfiguration` with `TempestConnectionReference` per tenant; a `tenant` message header routes every command/query to the correct database automatically (proven across Postgres + MySQL in tests).

## Pull Request Contribution Terms

- [X] I have read and agree to the contribution terms outlined in [CONTRIBUTING](https://github.com/ecotoneframework/ecotone-dev/blob/main/CONTRIBUTING.md).