### PR TITLE
feat: add ContentType attribute for default message content type

### DIFF
--- a/packages/Ecotone/src/Messaging/Attribute/Endpoint/ContentType.php
+++ b/packages/Ecotone/src/Messaging/Attribute/Endpoint/ContentType.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ecotone\Messaging\Attribute\Endpoint;
+
+use Attribute;
+use Ecotone\Messaging\Conversion\MediaType;
+use Ecotone\Messaging\MessageHeaders;
+
+#[Attribute(Attribute::TARGET_CLASS | Attribute::TARGET_METHOD)]
+/**
+ * licence Apache-2.0
+ */
+class ContentType extends AddHeader
+{
+    public function __construct(string $contentType, private bool $replaceIfExists = false)
+    {
+        MediaType::parseMediaType($contentType);
+
+        parent::__construct(MessageHeaders::CONTENT_TYPE, $contentType);
+    }
+
+    public function shouldReplaceExistingHeader(): bool
+    {
+        return $this->replaceIfExists;
+    }
+}

--- a/packages/Ecotone/src/Messaging/Config/Annotation/ModuleConfiguration/EndpointHeaders/EndpointHeadersInterceptor.php
+++ b/packages/Ecotone/src/Messaging/Config/Annotation/ModuleConfiguration/EndpointHeaders/EndpointHeadersInterceptor.php
@@ -7,6 +7,7 @@ namespace Ecotone\Messaging\Config\Annotation\ModuleConfiguration\EndpointHeader
 use DateTimeImmutable;
 use DateTimeInterface;
 use Ecotone\Messaging\Attribute\Endpoint\AddHeader;
+use Ecotone\Messaging\Attribute\Endpoint\ContentType;
 use Ecotone\Messaging\Attribute\Endpoint\Delayed;
 use Ecotone\Messaging\Attribute\Endpoint\Priority;
 use Ecotone\Messaging\Attribute\Endpoint\RemoveHeader;
@@ -41,7 +42,7 @@ class EndpointHeadersInterceptor implements DefinedObject
 
     }
 
-    public function addMetadata(Message $message, ?AddHeader $addHeader, ?Delayed $delayed, ?Priority $priority, ?TimeToLive $timeToLive, ?RemoveHeader $removeHeader): array
+    public function addMetadata(Message $message, ?AddHeader $addHeader, ?Delayed $delayed, ?Priority $priority, ?TimeToLive $timeToLive, ?RemoveHeader $removeHeader, ?ContentType $contentType): array
     {
         $metadata = [];
 
@@ -53,6 +54,15 @@ class EndpointHeadersInterceptor implements DefinedObject
                     'payload' => $message->getPayload(),
                     'headers' => $message->getHeaders()->headers(),
                 ]);
+            }
+        }
+
+        $isContentTypeHeaderExists = $message->getHeaders()->containsKey(MessageHeaders::CONTENT_TYPE);
+        if ($contentType) {
+            if ($contentType->shouldReplaceExistingHeader() || ! $isContentTypeHeaderExists) {
+                $metadata[MessageHeaders::CONTENT_TYPE] = $contentType->getHeaderValue();
+            } else {
+                $metadata[MessageHeaders::CONTENT_TYPE] = $message->getHeaders()->get(MessageHeaders::CONTENT_TYPE);
             }
         }
 

--- a/packages/Ecotone/tests/Messaging/Unit/Config/Annotation/ModuleConfiguration/ContentTypeAttributeTest.php
+++ b/packages/Ecotone/tests/Messaging/Unit/Config/Annotation/ModuleConfiguration/ContentTypeAttributeTest.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Ecotone\Messaging\Unit\Config\Annotation\ModuleConfiguration;
+
+use Ecotone\Lite\EcotoneLite;
+use Ecotone\Messaging\Attribute\Asynchronous;
+use Ecotone\Messaging\Attribute\Endpoint\ContentType;
+use Ecotone\Messaging\Channel\SimpleMessageChannelBuilder;
+use Ecotone\Messaging\Conversion\MediaType;
+use Ecotone\Messaging\Endpoint\ExecutionPollingMetadata;
+use Ecotone\Messaging\Support\MessageBuilder;
+use Ecotone\Modelling\Attribute\CommandHandler;
+use PHPUnit\Framework\TestCase;
+use Test\Ecotone\Messaging\Fixture\Handler\HeaderConversion\JsonConverter;
+
+/**
+ * licence Apache-2.0
+ * @internal
+ */
+final class ContentTypeAttributeTest extends TestCase
+{
+    public function test_using_provided_content_type_when_message_has_none(): void
+    {
+        $orderService = new class () {
+            public ?array $order = null;
+
+            #[ContentType('application/json')]
+            #[Asynchronous('async')]
+            #[CommandHandler('order.place', endpointId: 'orderPlaceEndpoint')]
+            public function place(array $order): void
+            {
+                $this->order = $order;
+            }
+        };
+
+        $ecotoneLite = EcotoneLite::bootstrapFlowTesting(
+            [get_class($orderService), JsonConverter::class],
+            [$orderService, new JsonConverter()],
+            enableAsynchronousProcessing: [
+                SimpleMessageChannelBuilder::createQueueChannel('async'),
+            ],
+        );
+
+        $ecotoneLite->sendMessageDirectToChannel(
+            'order.place',
+            MessageBuilder::withPayload('{"product":"Book"}')->build(),
+        );
+        $ecotoneLite->run('async', ExecutionPollingMetadata::createWithTestingSetup());
+
+        $this->assertSame(['product' => 'Book'], $orderService->order);
+    }
+
+    public function test_keeping_content_type_from_message_when_already_defined(): void
+    {
+        $orderService = new class () {
+            public ?array $order = null;
+
+            #[ContentType('application/json')]
+            #[Asynchronous('async')]
+            #[CommandHandler('order.place', endpointId: 'orderPlaceEndpoint')]
+            public function place(array $order): void
+            {
+                $this->order = $order;
+            }
+        };
+
+        $ecotoneLite = EcotoneLite::bootstrapFlowTesting(
+            [get_class($orderService), JsonConverter::class],
+            [$orderService, new JsonConverter()],
+            enableAsynchronousProcessing: [
+                SimpleMessageChannelBuilder::createQueueChannel('async'),
+            ],
+        );
+
+        $ecotoneLite->sendMessageDirectToChannel(
+            'order.place',
+            MessageBuilder::withPayload(serialize(['product' => 'Chair']))
+                ->setContentType(MediaType::createApplicationXPHPSerialized())
+                ->build(),
+        );
+        $ecotoneLite->run('async', ExecutionPollingMetadata::createWithTestingSetup());
+
+        $this->assertSame(['product' => 'Chair'], $orderService->order);
+    }
+
+    public function test_replacing_content_type_from_message_when_marked_to_replace_existing_one(): void
+    {
+        $orderService = new class () {
+            public ?array $order = null;
+
+            #[ContentType('application/json', replaceIfExists: true)]
+            #[Asynchronous('async')]
+            #[CommandHandler('order.place', endpointId: 'orderPlaceEndpoint')]
+            public function place(array $order): void
+            {
+                $this->order = $order;
+            }
+        };
+
+        $ecotoneLite = EcotoneLite::bootstrapFlowTesting(
+            [get_class($orderService), JsonConverter::class],
+            [$orderService, new JsonConverter()],
+            enableAsynchronousProcessing: [
+                SimpleMessageChannelBuilder::createQueueChannel('async'),
+            ],
+        );
+
+        $ecotoneLite->sendMessageDirectToChannel(
+            'order.place',
+            MessageBuilder::withPayload('{"product":"Table"}')
+                ->setContentType(MediaType::createApplicationXPHPSerialized())
+                ->build(),
+        );
+        $ecotoneLite->run('async', ExecutionPollingMetadata::createWithTestingSetup());
+
+        $this->assertSame(['product' => 'Table'], $orderService->order);
+    }
+}


### PR DESCRIPTION
## Why is this change proposed?

Resolves #658. When a consumed message carries no `contentType` header — common when messages are produced by non-Ecotone systems (e.g. Kafka records published by other teams' services) — Ecotone assumes `application/x-php` and skips deserialization, failing with `Lack of Media Type Converter for application/x-php:string to <TargetClass>`. There was no declarative way to state "messages arriving at this endpoint are JSON unless stated otherwise"; the only workaround was `#[AddHeader('contentType', ...)]`, which unconditionally overrides and is easy to forget.

## Description of Changes

- New `#[ContentType]` endpoint attribute (extends `AddHeader`, same family as `#[Delayed]`, `#[TimeToLive]`) that sets the `contentType` message header before the endpoint processes the message.
- By default it only fills the header when missing; `replaceIfExists: true` makes it override the incoming one.
- Media type is validated at configuration time — a malformed value fails at bootstrap, not at first message.
- Handled in `EndpointHeadersInterceptor`; works transport-agnostically for any endpoint (Kafka consumers, asynchronous command/event handlers, etc.).

### Usage

```php
final class ScheduleMeetingKafkaConsumer
{
    #[ContentType('application/json')]
    #[KafkaConsumer('kafka_consumer_schedule_meeting', 'testTopic')]
    public function handle(ScheduleMeeting $scheduleMeeting): void
    {
        // message without contentType header is now deserialized as JSON
    }
}
```

```php
#[ContentType('application/json', replaceIfExists: true)]
#[Asynchronous('async')]
#[CommandHandler('order.place')]
public function place(PlaceOrder $order): void
{
    // incoming contentType header is always overridden with application/json
}
```

### Use cases

1. **Interoperability with foreign producers** — a team standardizes on JSON for Kafka topics, but upstream services don't set a `contentType` header. Declaring `#[ContentType('application/json')]` on the consumer makes deserialization work without touching producers.
2. **Mixed sources on one endpoint** — messages from Ecotone services carry proper headers (kept untouched), while legacy publishers send bare payloads (default applies).
3. **Correcting mislabeled payloads** — an upstream system sets a wrong content type; `replaceIfExists: true` enforces the known-correct format.

### Flow

```mermaid
flowchart LR
    A[Message arrives at endpoint] --> B{contentType header present?}
    B -- no --> C[Set header from ContentType attribute]
    B -- yes --> D{replaceIfExists?}
    D -- true --> C
    D -- false --> E[Keep incoming header]
    C --> F[PayloadConverter deserializes to handler parameter type]
    E --> F
```

## Pull Request Contribution Terms

- [X] I have read and agree to the contribution terms outlined in [CONTRIBUTING](https://github.com/ecotoneframework/ecotone-dev/blob/main/CONTRIBUTING.md).