### PR TITLE
fix: executionTimeLimit no longer blocks graceful shutdown

### DIFF
--- a/packages/Amqp/src/AmqpStreamInboundChannelAdapter.php
+++ b/packages/Amqp/src/AmqpStreamInboundChannelAdapter.php
@@ -146,7 +146,9 @@ class AmqpStreamInboundChannelAdapter extends EnqueueInboundChannelAdapter imple
             $this->startStreamConsuming($context, $pollingMetadata->getEndpointId());
 
             // Wait for messages with the specified timeout
-            $timeout = $pollingMetadata->getExecutionTimeLimitInMilliseconds() ?: $this->receiveTimeoutInMilliseconds;
+            $timeout = $pollingMetadata->getExecutionTimeLimitInMilliseconds() > 0
+                ? min($pollingMetadata->getExecutionTimeLimitInMilliseconds(), $this->receiveTimeoutInMilliseconds)
+                : $this->receiveTimeoutInMilliseconds;
             $timeoutInSeconds = $timeout > 0 ? $timeout / 1000.0 : 10.0;
 
             // Keep calling wait() in a loop while the consumer is active

--- a/packages/Dbal/tests/Integration/Consumer/ExecutionTimeLimitReceiveTimeoutTest.php
+++ b/packages/Dbal/tests/Integration/Consumer/ExecutionTimeLimitReceiveTimeoutTest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Ecotone\Dbal\Integration\Consumer;
+
+use Ecotone\Dbal\DbalBackedMessageChannelBuilder;
+use Ecotone\Lite\EcotoneLite;
+use Ecotone\Messaging\Config\ModulePackageList;
+use Ecotone\Messaging\Config\ServiceConfiguration;
+use Ecotone\Messaging\Endpoint\PollingMetadata;
+use Ecotone\Messaging\PollableChannel;
+use Enqueue\Dbal\DbalConnectionFactory;
+use Symfony\Component\Uid\Uuid;
+use Test\Ecotone\Dbal\DbalMessagingTestCase;
+
+/**
+ * Reproduces https://github.com/ecotoneframework/ecotone-dev/issues/440
+ *
+ * @internal
+ */
+final class ExecutionTimeLimitReceiveTimeoutTest extends DbalMessagingTestCase
+{
+    public function test_execution_time_limit_should_not_override_the_configured_receive_timeout_on_empty_queue(): void
+    {
+        $channelName = Uuid::v7()->toRfc4122();
+
+        $ecotoneLite = EcotoneLite::bootstrapFlowTesting(
+            containerOrAvailableServices: [
+                DbalConnectionFactory::class => $this->getConnectionFactory(),
+            ],
+            configuration: ServiceConfiguration::createWithDefaults()
+                ->withSkippedModulePackageNames(ModulePackageList::allPackagesExcept([ModulePackageList::DBAL_PACKAGE]))
+                ->withExtensionObjects([
+                    DbalBackedMessageChannelBuilder::create($channelName)
+                        ->withReceiveTimeout(200),
+                ])
+        );
+
+        /** @var PollableChannel $messageChannel */
+        $messageChannel = $ecotoneLite->getMessageChannel($channelName);
+
+        $startedAt = microtime(true);
+
+        $receivedMessage = $messageChannel->receiveWithTimeout(
+            PollingMetadata::create('consumer')
+                ->setExecutionTimeLimitInMilliseconds(5000)
+        );
+
+        $elapsedInMilliseconds = (microtime(true) - $startedAt) * 1000;
+
+        $this->assertNull($receivedMessage);
+        $this->assertLessThan(
+            2000,
+            $elapsedInMilliseconds,
+            "Receiving blocked for {$elapsedInMilliseconds}ms - the channel's own receiveTimeout (200ms) was overridden by executionTimeLimit (5000ms), preventing the outer consumer loop from checking termination signals / TimeLimitInterceptor in a timely manner."
+        );
+    }
+}

--- a/packages/Dbal/tests/Integration/Consumer/GracefulShutdownOnSignalTest.php
+++ b/packages/Dbal/tests/Integration/Consumer/GracefulShutdownOnSignalTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Ecotone\Dbal\Integration\Consumer;
+
+use Ecotone\Dbal\DbalBackedMessageChannelBuilder;
+use Ecotone\Lite\EcotoneLite;
+use Ecotone\Messaging\Config\ModulePackageList;
+use Ecotone\Messaging\Config\ServiceConfiguration;
+use Ecotone\Messaging\Endpoint\ExecutionPollingMetadata;
+use Enqueue\Dbal\DbalConnectionFactory;
+use Symfony\Component\Uid\Uuid;
+use Test\Ecotone\Dbal\DbalMessagingTestCase;
+
+/**
+ * Reproduces https://github.com/ecotoneframework/ecotone-dev/issues/440
+ *
+ * Mirrors the exact repro steps from the issue: start a consumer with a large
+ * executionTimeLimit (e.g. `--executionTimeLimit 3600000`), send it SIGTERM while
+ * it's idle-polling an empty queue, and expect it to shut down promptly instead of
+ * ignoring the signal until the execution time limit elapses.
+ *
+ * @internal
+ */
+final class GracefulShutdownOnSignalTest extends DbalMessagingTestCase
+{
+    public function test_consumer_stops_promptly_on_sigterm_despite_large_execution_time_limit(): void
+    {
+        if (! extension_loaded('pcntl') || ! extension_loaded('posix')) {
+            self::markTestSkipped('pcntl and posix extensions are required to send a real termination signal.');
+        }
+
+        $channelName = Uuid::v7()->toRfc4122();
+
+        // Spawn an independent OS process (not a fork) to deliver the signal - forking
+        // this PHP process would duplicate the already-open DB connection's socket fd
+        // (opened in DbalMessagingTestCase::setUp()) into the child and corrupt it.
+        $parentPid = posix_getpid();
+        exec(sprintf('(sleep 0.3 && kill -TERM %d) > /dev/null 2>&1 &', $parentPid));
+
+        $ecotoneLite = EcotoneLite::bootstrapFlowTesting(
+            containerOrAvailableServices: [
+                DbalConnectionFactory::class => $this->getConnectionFactory(),
+            ],
+            configuration: ServiceConfiguration::createWithDefaults()
+                ->withSkippedModulePackageNames(ModulePackageList::allPackagesExcept([ModulePackageList::DBAL_PACKAGE]))
+                ->withExtensionObjects([
+                    DbalBackedMessageChannelBuilder::create($channelName)
+                        ->withReceiveTimeout(200),
+                ])
+        );
+
+        $startedAt = microtime(true);
+
+        // Same execution time limit as used in the issue's reproduction steps
+        $ecotoneLite->run(
+            $channelName,
+            ExecutionPollingMetadata::createWithDefaults()
+                ->withExecutionTimeLimitInMilliseconds(3_600_000)
+        );
+
+        $elapsedInMilliseconds = (microtime(true) - $startedAt) * 1000;
+
+        $this->assertLessThan(
+            2000,
+            $elapsedInMilliseconds,
+            "Consumer kept running for {$elapsedInMilliseconds}ms after receiving SIGTERM instead of shutting down promptly - it was blocked inside a single poll call sized off the 3600000ms executionTimeLimit."
+        );
+    }
+}

--- a/packages/Enqueue/src/EnqueueInboundChannelAdapter.php
+++ b/packages/Enqueue/src/EnqueueInboundChannelAdapter.php
@@ -57,7 +57,9 @@ abstract class EnqueueInboundChannelAdapter implements MessagePoller
             );
 
             /** @var EnqueueMessage $message */
-            $timeoutInMilliseconds = $pollingMetadata->getExecutionTimeLimitInMilliseconds() ?: $this->receiveTimeoutInMilliseconds;
+            $timeoutInMilliseconds = $pollingMetadata->getExecutionTimeLimitInMilliseconds() > 0
+                ? min($pollingMetadata->getExecutionTimeLimitInMilliseconds(), $this->receiveTimeoutInMilliseconds)
+                : $this->receiveTimeoutInMilliseconds;
             $message = $consumer->receive($timeoutInMilliseconds);
 
             if (! $message) {

--- a/packages/Kafka/src/Inbound/KafkaInboundChannelAdapter.php
+++ b/packages/Kafka/src/Inbound/KafkaInboundChannelAdapter.php
@@ -47,7 +47,9 @@ final class KafkaInboundChannelAdapter implements MessagePoller
             );
         }
 
-        $timeoutInMilliseconds = $pollingMetadata->getExecutionTimeLimitInMilliseconds() ?: $this->receiveTimeoutInMilliseconds;
+        $timeoutInMilliseconds = $pollingMetadata->getExecutionTimeLimitInMilliseconds() > 0
+            ? min($pollingMetadata->getExecutionTimeLimitInMilliseconds(), $this->receiveTimeoutInMilliseconds)
+            : $this->receiveTimeoutInMilliseconds;
         if ($timeoutInMilliseconds <= self::MINIMUM_REQUIRED_TIME_FOR_LOAD_BALANCING) {
             $timeoutInMilliseconds = self::MINIMUM_REQUIRED_TIME_FOR_LOAD_BALANCING;
         }

--- a/packages/Kafka/tests/Integration/CommitIntervalTest.php
+++ b/packages/Kafka/tests/Integration/CommitIntervalTest.php
@@ -54,7 +54,7 @@ final class CommitIntervalTest extends TestCase
         }
 
         // Run consumer - should process all 5
-        $ecotoneLite->run('kafka_consumer_default', ExecutionPollingMetadata::createWithTestingSetup(amountOfMessagesToHandle: 5, maxExecutionTimeInMilliseconds: 10000));
+        $ecotoneLite->run('kafka_consumer_default', ExecutionPollingMetadata::createWithTestingSetup(amountOfMessagesToHandle: 5, maxExecutionTimeInMilliseconds: 20000));
 
         $messages = $ecotoneLite->sendQueryWithRouting('consumer.getMessages');
         $this->assertCount(5, $messages);
@@ -101,12 +101,12 @@ final class CommitIntervalTest extends TestCase
         }
 
         // configuration of commit will be adjusted to single message being consumed
-        $ecotoneLite->run('kafka_consumer_interval_3_with_failure', ExecutionPollingMetadata::createWithDefaults()->withHandledMessageLimit(15)->withExecutionTimeLimitInMilliseconds(10000));
+        $ecotoneLite->run('kafka_consumer_interval_3_with_failure', ExecutionPollingMetadata::createWithDefaults()->withHandledMessageLimit(15)->withExecutionTimeLimitInMilliseconds(20000));
 
         // should only continue and not re-reprocess
         $ecotoneLite = $this->bootstrapEcotoneLite($topicName, KafkaConsumerWithCommitIntervalAndFailure::class, $consumerInstance);
 
-        $ecotoneLite->run('kafka_consumer_interval_3_with_failure', ExecutionPollingMetadata::createWithDefaults()->withHandledMessageLimit(10)->withExecutionTimeLimitInMilliseconds(10000));
+        $ecotoneLite->run('kafka_consumer_interval_3_with_failure', ExecutionPollingMetadata::createWithDefaults()->withHandledMessageLimit(10)->withExecutionTimeLimitInMilliseconds(20000));
 
         $this->assertEquals([
             'message_1', 'message_2', 'message_3', 'message_4', 'message_5',

--- a/packages/Kafka/tests/Integration/FinalFailureStrategyTest.php
+++ b/packages/Kafka/tests/Integration/FinalFailureStrategyTest.php
@@ -100,7 +100,7 @@ final class FinalFailureStrategyTest extends TestCase
         // Run consumer - should process first message, fail on second, and trigger release
         $ecotoneTestSupport->run('kafka_channel', ExecutionPollingMetadata::createWithTestingSetup(
             amountOfMessagesToHandle: 10,
-            maxExecutionTimeInMilliseconds: 10000,
+            maxExecutionTimeInMilliseconds: 20000,
             failAtError: false
         ));
 
@@ -139,7 +139,7 @@ final class FinalFailureStrategyTest extends TestCase
         // Run consumer - should process first message, fail on second, and trigger release
         $ecotoneTestSupport->run('kafka_channel', ExecutionPollingMetadata::createWithTestingSetup(
             amountOfMessagesToHandle: 10,
-            maxExecutionTimeInMilliseconds: 10000,
+            maxExecutionTimeInMilliseconds: 20000,
             failAtError: false
         ));
 
@@ -228,7 +228,7 @@ final class FinalFailureStrategyTest extends TestCase
         // First run - should process first message (fail and ignore), then process second message (succeed)
         $ecotoneApp->run('kafka_channel', ExecutionPollingMetadata::createWithTestingSetup(
             amountOfMessagesToHandle: 2,
-            maxExecutionTimeInMilliseconds: 10000,
+            maxExecutionTimeInMilliseconds: 20000,
             failAtError: false
         ));
 
@@ -242,7 +242,7 @@ final class FinalFailureStrategyTest extends TestCase
 
         $ecotoneApp->run('kafka_channel', ExecutionPollingMetadata::createWithTestingSetup(
             amountOfMessagesToHandle: 2,
-            maxExecutionTimeInMilliseconds: 10000,
+            maxExecutionTimeInMilliseconds: 20000,
             failAtError: false
         ));
 
@@ -283,7 +283,7 @@ final class FinalFailureStrategyTest extends TestCase
         // First run - should process first message (fail and ignore), then process second message (succeed)
         $ecotoneApp->run('kafka_channel', ExecutionPollingMetadata::createWithTestingSetup(
             amountOfMessagesToHandle: 2,
-            maxExecutionTimeInMilliseconds: 10000,
+            maxExecutionTimeInMilliseconds: 20000,
             failAtError: false
         ));
 
@@ -315,7 +315,7 @@ final class FinalFailureStrategyTest extends TestCase
 
         $ecotoneApp->run('kafka_channel', ExecutionPollingMetadata::createWithTestingSetup(
             amountOfMessagesToHandle: 2,
-            maxExecutionTimeInMilliseconds: 10000,
+            maxExecutionTimeInMilliseconds: 20000,
             failAtError: false
         ));
 

--- a/packages/Kafka/tests/Integration/KafkaMessageChannelTest.php
+++ b/packages/Kafka/tests/Integration/KafkaMessageChannelTest.php
@@ -650,8 +650,11 @@ final class KafkaMessageChannelTest extends TestCase
 
         // Both consumers should receive all events independently
         // Using amountOfMessagesToHandle and maxExecutionTimeInMilliseconds for Kafka consumer group coordination
-        $consumerService1->run($channelName, ExecutionPollingMetadata::createWithTestingSetup(amountOfMessagesToHandle: 10, maxExecutionTimeInMilliseconds: 4000));
-        $consumerService2->run($channelName, ExecutionPollingMetadata::createWithTestingSetup(amountOfMessagesToHandle: 10, maxExecutionTimeInMilliseconds: 4000));
+        // maxExecutionTimeInMilliseconds must comfortably exceed KafkaInboundChannelAdapter::MINIMUM_REQUIRED_TIME_FOR_LOAD_BALANCING (10000ms)
+        // to leave room for more than one poll cycle - each of these consumers is a brand-new consumer group needing to
+        // rebalance before it can receive any of the 3 published events.
+        $consumerService1->run($channelName, ExecutionPollingMetadata::createWithTestingSetup(amountOfMessagesToHandle: 10, maxExecutionTimeInMilliseconds: 20000));
+        $consumerService2->run($channelName, ExecutionPollingMetadata::createWithTestingSetup(amountOfMessagesToHandle: 10, maxExecutionTimeInMilliseconds: 20000));
 
         $this->assertEquals(['event1', 'event2', 'event3'], $consumerService1->sendQueryWithRouting('getConsumed1'));
         $this->assertEquals(['event1', 'event2', 'event3'], $consumerService2->sendQueryWithRouting('getConsumed2'));


### PR DESCRIPTION
## Why is this change proposed?

When a consumer configured with `executionTimeLimit` (e.g. `ecotone:run internal --executionTimeLimit 3600000`) has no messages to process, it fails to respond to SIGTERM/SIGINT/SIGQUIT or even its own time limit in a timely manner. The root cause: DBAL/AMQP/SQS/Redis/Kafka inbound channel adapters used `executionTimeLimit` as the timeout for a *single* blocking broker `receive()` call, fully overriding the channel's normal, short `receiveTimeoutInMilliseconds`. In production this means a consumer with a 1-hour execution time limit sits blocked inside one broker call for up to an hour before ever checking for termination — breaking graceful shutdown in containerized/orchestrated environments (Kubernetes SIGTERM during pod termination, `docker stop`, etc). Fixes #440.

## Description of Changes

- Cap the per-poll receive timeout with `min(executionTimeLimit, receiveTimeoutInMilliseconds)` instead of letting `executionTimeLimit` fully override it, in `EnqueueInboundChannelAdapter` (covers DBAL, SQS, Redis), `AmqpStreamInboundChannelAdapter`, and `KafkaInboundChannelAdapter`.
- This preserves the existing "make tests fast" behavior (`PollingMetadata::withTestingSetup()` intentionally sets a small `executionTimeLimit` to shorten polling in tests) while fixing production runs where `executionTimeLimit` is large.
- Added `ExecutionTimeLimitReceiveTimeoutTest` — a fast, low-level reproduction proving the receive call now respects the channel's configured timeout instead of the execution time limit.
- Added `GracefulShutdownOnSignalTest` — an end-to-end reproduction that sends a real `SIGTERM` to a running consumer (mirroring the issue's exact repro steps) and asserts it shuts down promptly instead of ignoring the signal.
- Bumped `maxExecutionTimeInMilliseconds` in several Kafka tests that consume multiple messages within a single time-bounded `run()` call, from the pre-existing consumer-group rebalancing floor (10000ms) up to 20000ms — those tests had no margin for a second poll cycle and were prone to flaking under load (unrelated to the fix itself, but surfaced while validating it).

No code changes needed for end users — consumers configured with `executionTimeLimit` now behave correctly out of the box:

```php
// php bin/console ecotone:run async --executionTimeLimit 3600000
// Before: SIGTERM ignored for up to 1 hour while the queue is idle.
// After: consumer keeps polling at its normal cadence and responds to
//        SIGTERM/SIGINT/SIGQUIT promptly, regardless of executionTimeLimit.
```

**Use case scenarios:**
1. Running an Ecotone consumer under Kubernetes/Docker with a rolling deploy — the orchestrator sends SIGTERM and expects the process to exit within its grace period; previously a consumer with a large `executionTimeLimit` and no traffic could ignore that signal for the full duration.
2. Long-running batch consumers using `executionTimeLimit` purely as a safety net (e.g., process restarted hourly by a supervisor) — these silently failed to self-terminate on schedule when idle.
3. Local development where `Ctrl+C` (SIGINT) is sent to a running consumer, expecting immediate shutdown.

```mermaid
sequenceDiagram
    participant OS
    participant InterceptedConsumer
    participant SignalInterceptor
    participant Adapter as Inbound Channel Adapter
    participant Broker

    Note over InterceptedConsumer,Broker: Before fix
    InterceptedConsumer->>Adapter: poll (timeout = executionTimeLimit, e.g. 3600000ms)
    Adapter->>Broker: receive(3600000ms)
    OS--)InterceptedConsumer: SIGTERM
    Note right of InterceptedConsumer: signal flagged but not checked -<br/>still blocked inside receive()
    Broker--)Adapter: (nothing, up to 1 hour later)

    Note over InterceptedConsumer,Broker: After fix
    InterceptedConsumer->>Adapter: poll (timeout = min(3600000, 1000)ms)
    Adapter->>Broker: receive(1000ms)
    OS--)InterceptedConsumer: SIGTERM
    Broker--)Adapter: null (timeout)
    Adapter--)InterceptedConsumer: control returns
    InterceptedConsumer->>SignalInterceptor: shouldBeStopped()
    SignalInterceptor--)InterceptedConsumer: true
    InterceptedConsumer->>InterceptedConsumer: graceful shutdown
```

## Pull Request Contribution Terms

- [X] I have read and agree to the contribution terms outlined in [CONTRIBUTING](https://github.com/ecotoneframework/ecotone-dev/blob/main/CONTRIBUTING.md).