### PR TITLE
fix: prevent OpenTelemetry scope leaks masking original exceptions

### DIFF
--- a/packages/Ecotone/src/Messaging/Channel/SendingInterceptorAdapter.php
+++ b/packages/Ecotone/src/Messaging/Channel/SendingInterceptorAdapter.php
@@ -49,32 +49,74 @@ abstract class SendingInterceptorAdapter implements MessageChannelInterceptorAda
     public function send(Message $message): void
     {
         $messageToSend = $message;
-        foreach ($this->sortedChannelInterceptors as $channelInterceptor) {
-            $messageToSend = $channelInterceptor->preSend($messageToSend, $this->messageChannel);
-
-            if ($messageToSend === null) {
-                return;
-            }
-        }
-
-        $exception = null;
+        $executedInterceptors = [];
+        $isMessageDropped = false;
         try {
-            $this->messageChannel->send($messageToSend);
-        } catch (Throwable $exception) {
-        } finally {
-            $shouldThrow = $exception !== null;
             foreach ($this->sortedChannelInterceptors as $channelInterceptor) {
-                if ($channelInterceptor->afterSendCompletion($messageToSend, $this->messageChannel, $exception)) {
-                    $shouldThrow = false;
+                $transformedMessage = $channelInterceptor->preSend($messageToSend, $this->messageChannel);
+
+                if ($transformedMessage === null) {
+                    $isMessageDropped = true;
+
+                    break;
+                }
+
+                $messageToSend = $transformedMessage;
+                $executedInterceptors[] = $channelInterceptor;
+            }
+
+            if (! $isMessageDropped) {
+                $this->messageChannel->send($messageToSend);
+            }
+        } catch (Throwable $exception) {
+            $shouldThrow = true;
+            $firstCleanupFailure = null;
+            foreach ($executedInterceptors as $channelInterceptor) {
+                try {
+                    if ($channelInterceptor->afterSendCompletion($messageToSend, $this->messageChannel, $exception)) {
+                        $shouldThrow = false;
+                    }
+                } catch (Throwable $cleanupFailure) {
+                    $firstCleanupFailure ??= $cleanupFailure;
                 }
             }
 
             if ($shouldThrow) {
                 throw $exception;
             }
+
+            $this->executePostSend($messageToSend, $executedInterceptors, $firstCleanupFailure);
+
+            return;
         }
-        foreach ($this->sortedChannelInterceptors as $channelInterceptor) {
-            $channelInterceptor->postSend($messageToSend, $this->messageChannel);
+
+        $firstCleanupFailure = null;
+        foreach ($executedInterceptors as $channelInterceptor) {
+            try {
+                $channelInterceptor->afterSendCompletion($messageToSend, $this->messageChannel, null);
+            } catch (Throwable $cleanupFailure) {
+                $firstCleanupFailure ??= $cleanupFailure;
+            }
+        }
+
+        $this->executePostSend($messageToSend, $executedInterceptors, $firstCleanupFailure);
+    }
+
+    /**
+     * @param ChannelInterceptor[] $executedInterceptors
+     */
+    private function executePostSend(Message $messageToSend, array $executedInterceptors, ?Throwable $firstCleanupFailure): void
+    {
+        foreach ($executedInterceptors as $channelInterceptor) {
+            try {
+                $channelInterceptor->postSend($messageToSend, $this->messageChannel);
+            } catch (Throwable $cleanupFailure) {
+                $firstCleanupFailure ??= $cleanupFailure;
+            }
+        }
+
+        if ($firstCleanupFailure !== null) {
+            throw $firstCleanupFailure;
         }
     }
 

--- a/packages/OpenTelemetry/src/ChannelSendSpan.php
+++ b/packages/OpenTelemetry/src/ChannelSendSpan.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ecotone\OpenTelemetry;
+
+use OpenTelemetry\API\Trace\SpanInterface;
+use OpenTelemetry\API\Trace\StatusCode;
+use OpenTelemetry\Context\ScopeInterface;
+use Throwable;
+
+/**
+ * licence Apache-2.0
+ */
+final class ChannelSendSpan
+{
+    private bool $isClosed = false;
+
+    public function __construct(private SpanInterface $span, private ScopeInterface $scope)
+    {
+    }
+
+    public function closeWithSuccess(): void
+    {
+        $this->close(StatusCode::STATUS_OK, null);
+    }
+
+    public function closeWithFailure(Throwable $exception): void
+    {
+        if ($this->isClosed) {
+            return;
+        }
+
+        $this->span->recordException($exception);
+        $this->close(StatusCode::STATUS_ERROR, $exception->getMessage());
+    }
+
+    private function close(string $statusCode, ?string $statusDescription): void
+    {
+        if ($this->isClosed) {
+            return;
+        }
+        $this->isClosed = true;
+
+        $this->span->setStatus($statusCode, $statusDescription);
+        $this->scope->detach();
+        $this->span->end();
+    }
+}

--- a/packages/OpenTelemetry/src/TracerInterceptor.php
+++ b/packages/OpenTelemetry/src/TracerInterceptor.php
@@ -40,7 +40,7 @@ final class TracerInterceptor
 
         $scope = $parentContext->activate();
         try {
-            $trace = $this->trace(
+            return $this->trace(
                 $message->getHeaders()->containsKey(MessageHeaders::POLLED_CHANNEL_NAME)
                     ? 'Receiving from channel: ' . $message->getHeaders()->get(MessageHeaders::POLLED_CHANNEL_NAME)
                     : ($message->getHeaders()->containsKey(MessageHeaders::INBOUND_REQUEST_CHANNEL)
@@ -50,14 +50,9 @@ final class TracerInterceptor
                 $message,
                 spanKind: SpanKind::KIND_CONSUMER,
             );
-        } catch (Throwable $exception) {
+        } finally {
             $scope->detach();
-
-            throw $exception;
         }
-        $scope->detach();
-
-        return $trace;
     }
 
     public function provideContextForDistributedBus(Message $message): Message
@@ -77,7 +72,14 @@ final class TracerInterceptor
             ->startSpan();
         $spanScope = $span->activate();
 
-        $result = $methodInvocation->proceed();
+        try {
+            $result = $methodInvocation->proceed();
+        } catch (Throwable $exception) {
+            $span->recordException($exception);
+            $this->closeSpan($span, $spanScope, StatusCode::STATUS_ERROR, $exception->getMessage());
+
+            throw $exception;
+        }
 
         $this->closeSpan($span, $spanScope, StatusCode::STATUS_OK, null);
 
@@ -179,9 +181,6 @@ final class TracerInterceptor
 
     private function closeSpan(SpanInterface $span, ScopeInterface $spanScope, string $statusCode, ?string $descriptionStatusCode): void
     {
-        $currentSpan = Span::getCurrent();
-        $currentContext = Context::getCurrent();
-
         $span->setStatus($statusCode, $descriptionStatusCode);
         $spanScope->detach();
         $span->end();

--- a/packages/OpenTelemetry/src/TracingChannelInterceptor.php
+++ b/packages/OpenTelemetry/src/TracingChannelInterceptor.php
@@ -7,7 +7,6 @@ namespace Ecotone\OpenTelemetry;
 use Ecotone\Messaging\Channel\ChannelInterceptor;
 use Ecotone\Messaging\Message;
 use Ecotone\Messaging\MessageChannel;
-use Ecotone\Messaging\MessageHeaders;
 use Ecotone\Messaging\Support\MessageBuilder;
 
 use function json_decode;
@@ -18,7 +17,6 @@ use OpenTelemetry\API\Trace\SpanKind;
 use OpenTelemetry\API\Trace\StatusCode;
 use OpenTelemetry\API\Trace\TracerProviderInterface;
 use OpenTelemetry\Context\Context;
-use OpenTelemetry\SDK\Trace\Span;
 use Throwable;
 
 /**
@@ -27,6 +25,9 @@ use Throwable;
 final class TracingChannelInterceptor implements ChannelInterceptor
 {
     public const TRACING_CARRIER_HEADER = 'ecotoneTracingCarrier';
+
+    /** @var ChannelSendSpan[] */
+    private array $openSpans = [];
 
     public function __construct(private string $channelName, private TracerProviderInterface $tracerProvider)
     {
@@ -38,28 +39,31 @@ final class TracingChannelInterceptor implements ChannelInterceptor
             ->startSpan();
 
         $scope = $span->activate();
+        $this->openSpans[] = new ChannelSendSpan($span, $scope);
+
         $ctx = $span->storeInContext(Context::getCurrent());
         $carrier = [];
         TraceContextPropagator::getInstance()->inject($carrier, null, $ctx);
 
         return MessageBuilder::fromMessage($message)
                 ->setHeader(self::TRACING_CARRIER_HEADER, json_encode($carrier))
-                ->setHeader(MessageHeaders::TEMPORARY_SPAN_CONTEXT_HEADER, $scope)
                 ->build();
     }
 
     public function postSend(Message $message, MessageChannel $messageChannel): void
     {
-        // @TODO Remove header from message after notice are stopped from OpenTelemetry (https://github.com/open-telemetry/opentelemetry-php/issues/1138)
-        $currentContext = $message->getHeaders()->get(MessageHeaders::TEMPORARY_SPAN_CONTEXT_HEADER);
-        //        $currentContext = Context::storage()->scope();
-        $currentRelatedSpan = Span::getCurrent();
-        $currentContext->detach();
-        $currentRelatedSpan->end();
     }
 
     public function afterSendCompletion(Message $message, MessageChannel $messageChannel, ?Throwable $exception): bool
     {
+        $channelSendSpan = array_pop($this->openSpans);
+
+        if ($exception !== null) {
+            $channelSendSpan?->closeWithFailure($exception);
+        } else {
+            $channelSendSpan?->closeWithSuccess();
+        }
+
         return false;
     }
 

--- a/packages/OpenTelemetry/tests/Integration/TracingScopeCleanupTest.php
+++ b/packages/OpenTelemetry/tests/Integration/TracingScopeCleanupTest.php
@@ -1,0 +1,313 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Ecotone\OpenTelemetry\Integration;
+
+use const E_USER_NOTICE;
+
+use Ecotone\Lite\EcotoneLite;
+use Ecotone\Lite\Test\FlowTestSupport;
+use Ecotone\Messaging\Attribute\Asynchronous;
+use Ecotone\Messaging\Channel\AbstractChannelInterceptor;
+use Ecotone\Messaging\Channel\ExceptionalQueueChannel;
+use Ecotone\Messaging\Channel\SimpleChannelInterceptorBuilder;
+use Ecotone\Messaging\Channel\SimpleMessageChannelBuilder;
+use Ecotone\Messaging\Config\ModulePackageList;
+use Ecotone\Messaging\Config\ServiceConfiguration;
+use Ecotone\Messaging\Endpoint\ExecutionPollingMetadata;
+use Ecotone\Messaging\Message;
+use Ecotone\Messaging\MessageChannel;
+use Ecotone\Messaging\Support\MessageBuilder;
+use Ecotone\Modelling\Api\Distribution\DistributedServiceMap;
+use Ecotone\Modelling\Attribute\CommandHandler;
+use Ecotone\Modelling\Attribute\EventHandler;
+use Ecotone\Modelling\EventBus;
+use Ecotone\Test\LicenceTesting;
+use OpenTelemetry\API\Trace\TracerProviderInterface;
+use OpenTelemetry\SDK\Trace\SpanExporter\InMemoryExporter;
+use RuntimeException;
+use Throwable;
+
+/**
+ * licence Apache-2.0
+ * @internal
+ */
+final class TracingScopeCleanupTest extends TracingTestCase
+{
+    public function test_no_scope_detach_notices_when_sending_to_asynchronous_channel_fails(): void
+    {
+        $ecotoneLite = $this->bootstrapWithEventForwardedToSecondChannel(
+            channelsToRegister: [
+                SimpleMessageChannelBuilder::createQueueChannel('async_channel'),
+                ExceptionalQueueChannel::createWithExceptionOnSend('failing_channel'),
+            ],
+        );
+
+        $ecotoneLite->sendCommandWithRoutingKey('user.register', '1');
+
+        [$caughtException, $scopeNotices] = $this->invokeCapturingScopeNotices(
+            fn () => $ecotoneLite->run('async_channel', ExecutionPollingMetadata::createWithTestingSetup())
+        );
+
+        $this->assertNotNull($caughtException);
+        $this->assertStringContainsString('Exception on send', $caughtException->getMessage());
+        $this->assertSame([], $scopeNotices);
+    }
+
+    public function test_no_scope_detach_notices_when_channel_interceptor_fails_before_send(): void
+    {
+        $throwingChannelInterceptor = new class () extends AbstractChannelInterceptor {
+            public function preSend(Message $message, MessageChannel $messageChannel): ?Message
+            {
+                throw new RuntimeException('Exception before send');
+            }
+        };
+
+        $ecotoneLite = $this->bootstrapWithEventForwardedToSecondChannel(
+            channelsToRegister: [
+                SimpleMessageChannelBuilder::createQueueChannel('async_channel'),
+                SimpleMessageChannelBuilder::createQueueChannel('failing_channel'),
+                SimpleChannelInterceptorBuilder::create('failing_channel', 'throwingChannelInterceptor'),
+            ],
+            servicesToRegister: ['throwingChannelInterceptor' => $throwingChannelInterceptor],
+        );
+
+        $ecotoneLite->sendCommandWithRoutingKey('user.register', '1');
+
+        [$caughtException, $scopeNotices] = $this->invokeCapturingScopeNotices(
+            fn () => $ecotoneLite->run('async_channel', ExecutionPollingMetadata::createWithTestingSetup())
+        );
+
+        $this->assertNotNull($caughtException);
+        $this->assertStringContainsString('Exception before send', $caughtException->getMessage());
+        $this->assertSame([], $scopeNotices);
+    }
+
+    public function test_no_scope_detach_notices_when_message_is_filtered_out_after_tracing_started(): void
+    {
+        $filteringChannelInterceptor = new class () extends AbstractChannelInterceptor {
+            public function preSend(Message $message, MessageChannel $messageChannel): ?Message
+            {
+                return null;
+            }
+        };
+
+        $ecotoneLite = $this->bootstrapWithEventForwardedToSecondChannel(
+            channelsToRegister: [
+                SimpleMessageChannelBuilder::createQueueChannel('async_channel'),
+                SimpleMessageChannelBuilder::createQueueChannel('failing_channel'),
+                SimpleChannelInterceptorBuilder::create('failing_channel', 'filteringChannelInterceptor'),
+            ],
+            servicesToRegister: ['filteringChannelInterceptor' => $filteringChannelInterceptor],
+        );
+
+        $ecotoneLite->sendCommandWithRoutingKey('user.register', '1');
+
+        [$caughtException, $scopeNotices] = $this->invokeCapturingScopeNotices(
+            fn () => $ecotoneLite->run('async_channel', ExecutionPollingMetadata::createWithTestingSetup())
+        );
+
+        $this->assertNull($caughtException);
+        $this->assertSame([], $scopeNotices);
+    }
+
+    public function test_no_scope_detach_notices_when_cleanup_of_another_interceptor_fails_after_send_failure(): void
+    {
+        $throwingCleanupInterceptor = new class () extends AbstractChannelInterceptor {
+            public function afterSendCompletion(Message $message, MessageChannel $messageChannel, ?Throwable $exception): bool
+            {
+                if ($exception !== null) {
+                    throw new RuntimeException('Exception during cleanup');
+                }
+
+                return false;
+            }
+        };
+
+        $ecotoneLite = $this->bootstrapWithEventForwardedToSecondChannel(
+            channelsToRegister: [
+                SimpleMessageChannelBuilder::createQueueChannel('async_channel'),
+                ExceptionalQueueChannel::createWithExceptionOnSend('failing_channel'),
+                SimpleChannelInterceptorBuilder::create('failing_channel', 'throwingCleanupInterceptor')->withPrecedence(500),
+            ],
+            servicesToRegister: ['throwingCleanupInterceptor' => $throwingCleanupInterceptor],
+        );
+
+        $ecotoneLite->sendCommandWithRoutingKey('user.register', '1');
+
+        [$caughtException, $scopeNotices] = $this->invokeCapturingScopeNotices(
+            fn () => $ecotoneLite->run('async_channel', ExecutionPollingMetadata::createWithTestingSetup())
+        );
+
+        $this->assertNotNull($caughtException);
+        $this->assertSame([], $scopeNotices);
+    }
+
+    public function test_no_scope_detach_notices_when_post_send_of_another_interceptor_fails(): void
+    {
+        $throwingPostSendInterceptor = new class () extends AbstractChannelInterceptor {
+            public function postSend(Message $message, MessageChannel $messageChannel): void
+            {
+                throw new RuntimeException('Exception after send');
+            }
+        };
+
+        $ecotoneLite = $this->bootstrapWithEventForwardedToSecondChannel(
+            channelsToRegister: [
+                SimpleMessageChannelBuilder::createQueueChannel('async_channel'),
+                SimpleMessageChannelBuilder::createQueueChannel('failing_channel'),
+                SimpleChannelInterceptorBuilder::create('failing_channel', 'throwingPostSendInterceptor')->withPrecedence(500),
+            ],
+            servicesToRegister: ['throwingPostSendInterceptor' => $throwingPostSendInterceptor],
+        );
+
+        $ecotoneLite->sendCommandWithRoutingKey('user.register', '1');
+
+        [$caughtException, $scopeNotices] = $this->invokeCapturingScopeNotices(
+            fn () => $ecotoneLite->run('async_channel', ExecutionPollingMetadata::createWithTestingSetup())
+        );
+
+        $this->assertNotNull($caughtException);
+        $this->assertStringContainsString('Exception after send', $caughtException->getMessage());
+        $this->assertSame([], $scopeNotices);
+    }
+
+    public function test_no_scope_detach_notices_when_interceptor_replaces_message_dropping_framework_headers(): void
+    {
+        $rebuildingChannelInterceptor = new class () extends AbstractChannelInterceptor {
+            public function preSend(Message $message, MessageChannel $messageChannel): ?Message
+            {
+                return MessageBuilder::withPayload($message->getPayload())->build();
+            }
+        };
+
+        $ecotoneLite = $this->bootstrapWithEventForwardedToSecondChannel(
+            channelsToRegister: [
+                SimpleMessageChannelBuilder::createQueueChannel('async_channel'),
+                SimpleMessageChannelBuilder::createQueueChannel('failing_channel'),
+                SimpleChannelInterceptorBuilder::create('failing_channel', 'rebuildingChannelInterceptor'),
+            ],
+            servicesToRegister: ['rebuildingChannelInterceptor' => $rebuildingChannelInterceptor],
+        );
+
+        $ecotoneLite->sendCommandWithRoutingKey('user.register', '1');
+
+        [$caughtException, $scopeNotices] = $this->invokeCapturingScopeNotices(
+            fn () => $ecotoneLite->run('async_channel', ExecutionPollingMetadata::createWithTestingSetup())
+        );
+
+        $this->assertNull($caughtException);
+        $this->assertSame([], $scopeNotices);
+    }
+
+    public function test_no_scope_detach_notices_when_error_channel_send_fails(): void
+    {
+        $userService = new class () {
+            #[Asynchronous('async_channel')]
+            #[CommandHandler('user.register', endpointId: 'userRegisterEndpoint')]
+            public function register(string $userId): void
+            {
+                throw new RuntimeException('Handler failure');
+            }
+        };
+
+        $ecotoneLite = EcotoneLite::bootstrapFlowTesting(
+            [$userService::class],
+            [$userService, TracerProviderInterface::class => TracingTestCase::prepareTracer(new InMemoryExporter())],
+            ServiceConfiguration::createWithDefaults()
+                ->withDefaultErrorChannel('error_channel')
+                ->withSkippedModulePackageNames(ModulePackageList::allPackagesExcept([ModulePackageList::TRACING_PACKAGE, ModulePackageList::ASYNCHRONOUS_PACKAGE]))
+                ->withExtensionObjects([
+                    SimpleMessageChannelBuilder::createQueueChannel('async_channel'),
+                    ExceptionalQueueChannel::createWithExceptionOnSend('error_channel'),
+                ])
+        );
+
+        $ecotoneLite->sendCommandWithRoutingKey('user.register', '1');
+
+        [, $scopeNotices] = $this->invokeCapturingScopeNotices(
+            fn () => $ecotoneLite->run('async_channel', ExecutionPollingMetadata::createWithTestingSetup(failAtError: false))
+        );
+
+        $this->assertSame([], $scopeNotices);
+    }
+
+    public function test_no_scope_detach_notices_when_distributed_bus_send_fails(): void
+    {
+        $ecotoneLite = EcotoneLite::bootstrapFlowTesting(
+            [],
+            [TracerProviderInterface::class => TracingTestCase::prepareTracer(new InMemoryExporter())],
+            ServiceConfiguration::createWithDefaults()
+                ->withServiceName('user_service')
+                ->withSkippedModulePackageNames(ModulePackageList::allPackagesExcept([ModulePackageList::TRACING_PACKAGE, ModulePackageList::ASYNCHRONOUS_PACKAGE]))
+                ->withExtensionObjects([
+                    ExceptionalQueueChannel::createWithExceptionOnSend('distributed_channel'),
+                    DistributedServiceMap::initialize()->withCommandMapping(targetServiceName: 'ticket_service', channelName: 'distributed_channel'),
+                ]),
+            licenceKey: LicenceTesting::VALID_LICENCE,
+        );
+
+        [$caughtException, $scopeNotices] = $this->invokeCapturingScopeNotices(
+            fn () => $ecotoneLite->getDistributedBus()->sendCommand('ticket_service', 'ticket.create', 'User changed billing address')
+        );
+
+        $this->assertNotNull($caughtException);
+        $this->assertStringContainsString('Exception on send', $caughtException->getMessage());
+        $this->assertSame([], $scopeNotices);
+    }
+
+    private function bootstrapWithEventForwardedToSecondChannel(array $channelsToRegister, array $servicesToRegister = []): FlowTestSupport
+    {
+        $userService = new class () {
+            #[Asynchronous('async_channel')]
+            #[CommandHandler('user.register', endpointId: 'userRegisterEndpoint')]
+            public function register(string $userId, EventBus $eventBus): void
+            {
+                $eventBus->publishWithRouting('user.registered', $userId);
+            }
+        };
+        $userNotifier = new class () {
+            #[Asynchronous('failing_channel')]
+            #[EventHandler('user.registered', endpointId: 'userNotifierEndpoint')]
+            public function notify(string $userId): void
+            {
+            }
+        };
+
+        return EcotoneLite::bootstrapFlowTesting(
+            [$userService::class, $userNotifier::class],
+            array_merge(
+                [$userService, $userNotifier, TracerProviderInterface::class => TracingTestCase::prepareTracer(new InMemoryExporter())],
+                $servicesToRegister,
+            ),
+            ServiceConfiguration::createWithDefaults()
+                ->withSkippedModulePackageNames(ModulePackageList::allPackagesExcept([ModulePackageList::TRACING_PACKAGE, ModulePackageList::ASYNCHRONOUS_PACKAGE]))
+                ->withExtensionObjects($channelsToRegister)
+        );
+    }
+
+    /**
+     * @return array{0: ?Throwable, 1: string[]}
+     */
+    private function invokeCapturingScopeNotices(callable $action): array
+    {
+        $scopeNotices = [];
+        set_error_handler(static function (int $errorNumber, string $errorMessage) use (&$scopeNotices): bool {
+            $scopeNotices[] = $errorMessage;
+
+            return true;
+        }, E_USER_NOTICE);
+
+        $caughtException = null;
+        try {
+            $action();
+        } catch (Throwable $exception) {
+            $caughtException = $exception;
+        } finally {
+            restore_error_handler();
+        }
+
+        return [$caughtException, $scopeNotices];
+    }
+}


### PR DESCRIPTION
## Why is this change proposed?

Fixes #419. When a message send failed inside a traced flow (e.g. a broker or database outage while running `ecotone:run`), the OpenTelemetry scope activated in `TracingChannelInterceptor::preSend` was never detached. Every subsequent span closing then triggered `Scope: unexpected call to Scope::detach() for scope #XXXX, scope successfully detached but another scope should have been detached first`. Under Symfony's error handler this notice becomes an `ErrorException` that **replaces the original exception**, so users saw a confusing tracing error instead of the real cause of the failure.

## Description of Changes

- `SendingInterceptorAdapter` now guarantees the channel-interceptor lifecycle: every interceptor whose `preSend` completed receives exactly one `afterSendCompletion` on every path — send success, send failure, failure during another interceptor's `preSend`, and message drop (`preSend` returning `null`, used in production by the collector module)
- Cleanup hooks (`afterSendCompletion`/`postSend`) are individually guarded, so one interceptor failing cannot prevent the others from cleaning up — and the original send exception always takes priority over cleanup failures
- `TracingChannelInterceptor` tracks its open span in a per-channel LIFO stack (new `ChannelSendSpan` with idempotent close) instead of storing the scope object in a temporary message header, so a `preSend` that rebuilds the message can no longer break scope cleanup
- `TracerInterceptor::traceAsynchronousEndpoint` uses `try/finally` for scope detach; `traceDistributedBus` now records the exception and closes its span on failure instead of leaking the scope
- Added `TracingScopeCleanupTest` covering 8 scenarios: channel send failure, interceptor failing before send, message filtered out mid-send, cleanup failure of another interceptor, `postSend` failure, message rebuilt without framework headers, error-channel send failure, and Distributed Bus send failure

### What users experience

Before — real failure hidden behind a tracing notice:

```
ErrorException: User Notice: Scope: unexpected call to Scope::detach() for scope #11818,
scope successfully detached but another scope should have been detached first
```

After — the original exception propagates and the failed send is recorded on the span:

```
RuntimeException: SQLSTATE[08006] Connection refused
```

No configuration changes are needed; existing tracing setups keep working as-is:

```php
#[Asynchronous('orders')]
#[CommandHandler('order.place', endpointId: 'placeOrderEndpoint')]
public function placeOrder(PlaceOrder $command, EventBus $eventBus): void
{
    $eventBus->publish(new OrderWasPlaced($command->orderId));
}
```

### Use case scenarios

1. **Broker outage during event publishing** — an async handler publishes to RabbitMQ/Kafka while the broker is down: the connection exception now reaches the error channel / dead letter intact instead of being replaced by a `Scope::detach()` notice
2. **Error channel on a failing transport** — the consumer routes a failed message to an error channel whose transport is also unavailable: both spans close correctly, no notices
3. **Message filtering/deduplication combined with tracing** — an interceptor drops a message after the tracing span was started: the span is closed instead of leaking into all subsequent traces of the worker process

```mermaid
sequenceDiagram
    participant Consumer as Polling Consumer
    participant Tracer as TracerInterceptor
    participant Adapter as SendingInterceptorAdapter
    participant Tracing as TracingChannelInterceptor
    participant Channel as Message Channel

    Consumer->>Tracer: consume message (activate consumer scope)
    Tracer->>Adapter: handler publishes event
    Adapter->>Tracing: preSend (activate send scope)
    Adapter->>Channel: send
    Channel-->>Adapter: ❌ broker failure
    rect rgb(220, 245, 220)
        Note over Adapter,Tracing: NEW: afterSendCompletion always invoked
        Adapter->>Tracing: afterSendCompletion(exception)
        Tracing->>Tracing: close span, detach scope
    end
    Adapter-->>Tracer: original exception rethrown
    Tracer->>Tracer: finally: detach consumer scope (balanced)
    Tracer-->>Consumer: original exception, no Scope notices
```

## Pull Request Contribution Terms

- [X] I have read and agree to the contribution terms outlined in [CONTRIBUTING](https://github.com/ecotoneframework/ecotone-dev/blob/main/CONTRIBUTING.md).