### PR TITLE
Fix tenant-aware connection factory lookup in HeaderBasedMultiTenantConnectionFactory

### DIFF
--- a/packages/Dbal/src/MultiTenant/HeaderBasedMultiTenantConnectionFactory.php
+++ b/packages/Dbal/src/MultiTenant/HeaderBasedMultiTenantConnectionFactory.php
@@ -99,12 +99,12 @@ final class HeaderBasedMultiTenantConnectionFactory implements MultiTenantConnec
         $connectionReference = $this->getCurrentConnectionReferenceOrNull($tenant);
 
         if ($connectionReference === null) {
-            $tenant = $this->getCurrentTenantOrNull();
+            $resolvedTenant = $tenant ?? $this->getCurrentTenantOrNull();
 
-            if ($tenant === null) {
+            if ($resolvedTenant === null) {
                 throw new InvalidArgumentException("Lack of context about tenant in Message Headers. Please add `{$this->tenantHeaderName}` header metadata to your message.");
             } else {
-                throw new InvalidArgumentException("Lack of mapping for tenant `{$tenant}`. Please provide mapping for this tenant or default connection name.");
+                throw new InvalidArgumentException("Lack of mapping for tenant `{$resolvedTenant}`. Please provide mapping for this tenant or default connection name.");
             }
         }
 

--- a/packages/Dbal/src/MultiTenant/HeaderBasedMultiTenantConnectionFactory.php
+++ b/packages/Dbal/src/MultiTenant/HeaderBasedMultiTenantConnectionFactory.php
@@ -68,7 +68,7 @@ final class HeaderBasedMultiTenantConnectionFactory implements MultiTenantConnec
             Assert::notNull($connectionReference, "Lack of context about tenant in Message Headers. Please add `{$this->tenantHeaderName}` header metadata to your message.");
         }
 
-        $connectionFactory = $this->getConnectionFactory();
+        $connectionFactory = $this->getConnectionFactory($tenant);
         Assert::isTrue($connectionFactory instanceof EcotoneManagerRegistryConnectionFactory, 'Connection factory was not registered by `DbalConnection::createForManagerRegistry()`');
 
         /** @var ManagerRegistry $managerRegistry */
@@ -94,9 +94,9 @@ final class HeaderBasedMultiTenantConnectionFactory implements MultiTenantConnec
         return $dbalConnection->getDbalConnection();
     }
 
-    public function getConnectionFactory(): ConnectionFactory
+    public function getConnectionFactory(?string $tenant = null): ConnectionFactory
     {
-        $connectionReference = $this->getCurrentConnectionReferenceOrNull();
+        $connectionReference = $this->getCurrentConnectionReferenceOrNull($tenant);
 
         if ($connectionReference === null) {
             $tenant = $this->getCurrentTenantOrNull();


### PR DESCRIPTION
## Why is this change proposed?

Pass the resolved tenant to `getConnectionFactory()` so the connection factory is looked up using the correct tenant context instead of relying solely on the current execution context.

## Description of Changes

Passing the tenant through ensures consistent tenant resolution and correct connection factory selection.

## Pull Request Contribution Terms

- [x] I have read and agree to the contribution terms outlined in [CONTRIBUTING](https://github.com/ecotoneframework/ecotone-dev/blob/main/CONTRIBUTING.md).