### PR TITLE
feat: support console formatting, progress bars and command descriptions across frameworks

### DIFF
--- a/packages/Dbal/src/Database/DatabaseSetupModule.php
+++ b/packages/Dbal/src/Database/DatabaseSetupModule.php
@@ -79,7 +79,8 @@ class DatabaseSetupModule implements AnnotationModule
             'ecotone:migration:database:setup',
             DatabaseSetupCommand::class,
             $messagingConfiguration,
-            $interfaceToCallRegistry
+            $interfaceToCallRegistry,
+            'Creates database tables required by Ecotone'
         );
 
         $this->registerConsoleCommand(
@@ -87,7 +88,8 @@ class DatabaseSetupModule implements AnnotationModule
             'ecotone:migration:database:delete',
             DatabaseDeleteCommand::class,
             $messagingConfiguration,
-            $interfaceToCallRegistry
+            $interfaceToCallRegistry,
+            'Drops database tables created by Ecotone'
         );
     }
 
@@ -112,14 +114,16 @@ class DatabaseSetupModule implements AnnotationModule
         string $commandName,
         string $className,
         Configuration $configuration,
-        InterfaceToCallRegistry $interfaceToCallRegistry
+        InterfaceToCallRegistry $interfaceToCallRegistry,
+        string $description = ''
     ): void {
         [$messageHandlerBuilder, $oneTimeCommandConfiguration] = ConsoleCommandModule::prepareConsoleCommandForReference(
             new Reference($className),
             new InterfaceToCallReference($className, $methodName),
             $commandName,
             true,
-            $interfaceToCallRegistry
+            $interfaceToCallRegistry,
+            $description
         );
 
         $configuration

--- a/packages/Dbal/src/Deduplication/DeduplicationModule.php
+++ b/packages/Dbal/src/Deduplication/DeduplicationModule.php
@@ -108,7 +108,8 @@ class DeduplicationModule implements AnnotationModule
             ->registerConsoleCommand(ConsoleCommandConfiguration::create(
                 $inputChannelName,
                 'ecotone:deduplication:remove-expired-messages',
-                []
+                [],
+                'Removes expired message deduplication entries'
             ));
     }
 

--- a/packages/Dbal/src/Recoverability/DbalDeadLetterModule.php
+++ b/packages/Dbal/src/Recoverability/DbalDeadLetterModule.php
@@ -68,12 +68,12 @@ class DbalDeadLetterModule implements AnnotationModule
         }
 
         $messagingConfiguration->registerServiceDefinition(DbalDeadLetterConsoleCommand::class, new Definition(DbalDeadLetterConsoleCommand::class));
-        $this->registerOneTimeCommand('list', self::LIST_COMMAND_NAME, $messagingConfiguration, $interfaceToCallRegistry);
-        $this->registerOneTimeCommand('show', self::SHOW_COMMAND_NAME, $messagingConfiguration, $interfaceToCallRegistry);
-        $this->registerOneTimeCommand('reply', self::REPLAY_COMMAND_NAME, $messagingConfiguration, $interfaceToCallRegistry);
-        $this->registerOneTimeCommand('replyAll', self::REPLAY_ALL_COMMAND_NAME, $messagingConfiguration, $interfaceToCallRegistry);
-        $this->registerOneTimeCommand('delete', self::DELETE_COMMAND_NAME, $messagingConfiguration, $interfaceToCallRegistry);
-        $this->registerOneTimeCommand('help', self::HELP_COMMAND_NAME, $messagingConfiguration, $interfaceToCallRegistry);
+        $this->registerOneTimeCommand('list', self::LIST_COMMAND_NAME, $messagingConfiguration, $interfaceToCallRegistry, 'Lists dead letter messages');
+        $this->registerOneTimeCommand('show', self::SHOW_COMMAND_NAME, $messagingConfiguration, $interfaceToCallRegistry, 'Shows details of given dead letter message');
+        $this->registerOneTimeCommand('reply', self::REPLAY_COMMAND_NAME, $messagingConfiguration, $interfaceToCallRegistry, 'Replays given dead letter message');
+        $this->registerOneTimeCommand('replyAll', self::REPLAY_ALL_COMMAND_NAME, $messagingConfiguration, $interfaceToCallRegistry, 'Replays all dead letter messages');
+        $this->registerOneTimeCommand('delete', self::DELETE_COMMAND_NAME, $messagingConfiguration, $interfaceToCallRegistry, 'Deletes given dead letter message');
+        $this->registerOneTimeCommand('help', self::HELP_COMMAND_NAME, $messagingConfiguration, $interfaceToCallRegistry, 'Shows help for dead letter management commands');
 
         $this->registerGateway(DeadLetterGateway::class, $connectionFactoryReference, false, $messagingConfiguration);
         foreach ($customDeadLetterGateways as $customDeadLetterGateway) {
@@ -96,14 +96,15 @@ class DbalDeadLetterModule implements AnnotationModule
         ];
     }
 
-    private function registerOneTimeCommand(string $methodName, string $commandName, Configuration $configuration, InterfaceToCallRegistry $interfaceToCallRegistry): void
+    private function registerOneTimeCommand(string $methodName, string $commandName, Configuration $configuration, InterfaceToCallRegistry $interfaceToCallRegistry, string $description = ''): void
     {
         [$messageHandlerBuilder, $oneTimeCommandConfiguration] = ConsoleCommandModule::prepareConsoleCommandForReference(
             new Reference(DbalDeadLetterConsoleCommand::class),
             new InterfaceToCallReference(DbalDeadLetterConsoleCommand::class, $methodName),
             $commandName,
             true,
-            $interfaceToCallRegistry
+            $interfaceToCallRegistry,
+            $description
         );
         $configuration
             ->registerMessageHandler($messageHandlerBuilder)

--- a/packages/Ecotone/composer.json
+++ b/packages/Ecotone/composer.json
@@ -64,7 +64,11 @@
         "phpunit/phpunit": "^10.5|^11.0",
         "ramsey/uuid": "^4.0",
         "phpstan/phpstan": "^1.8",
+        "symfony/console": "^6.4|^7.0|^8.0",
         "symfony/expression-language": "^6.4|^7.0|^8.0"
+    },
+    "suggest": {
+        "symfony/console": "Allows using SymfonyConsoleWriter for styled console command output"
     },
     "scripts": {
         "tests:phpstan": "vendor/bin/phpstan",

--- a/packages/Ecotone/src/Lite/Test/Configuration/EcotoneTestSupportModule.php
+++ b/packages/Ecotone/src/Lite/Test/Configuration/EcotoneTestSupportModule.php
@@ -23,6 +23,9 @@ use Ecotone\Messaging\Config\Container\Reference;
 use Ecotone\Messaging\Config\ModulePackageList;
 use Ecotone\Messaging\Config\ModuleReferenceSearchService;
 use Ecotone\Messaging\Config\ServiceConfiguration;
+use Ecotone\Messaging\Console\ConsoleWriter;
+use Ecotone\Messaging\Console\DelegatingConsoleWriter;
+use Ecotone\Messaging\Console\InMemoryConsoleWriter;
 use Ecotone\Messaging\Consumer\ConsumerPositionTracker;
 use Ecotone\Messaging\Consumer\InMemory\InMemoryConsumerPositionTracker;
 use Ecotone\Messaging\Handler\ChannelResolver;
@@ -122,6 +125,17 @@ final class EcotoneTestSupportModule extends NoExternalConfigurationModule imple
         }
 
         $this->registerInMemoryEventStoreIfNeeded($messagingConfiguration, $extensionObjects, $serviceConfiguration);
+
+        $messagingConfiguration->registerServiceDefinition(
+            InMemoryConsoleWriter::class,
+            new Definition(InMemoryConsoleWriter::class)
+        );
+        $messagingConfiguration->registerServiceDefinition(
+            ConsoleWriter::class,
+            new Definition(DelegatingConsoleWriter::class, [
+                new Reference(InMemoryConsoleWriter::class),
+            ])
+        );
 
         $messagingConfiguration->registerServiceDefinition(MessageCollectorHandler::class, new Definition(MessageCollectorHandler::class));
         $this->registerMessageCollector($messagingConfiguration, $interfaceToCallRegistry);

--- a/packages/Ecotone/src/Lite/Test/FlowTestSupport.php
+++ b/packages/Ecotone/src/Lite/Test/FlowTestSupport.php
@@ -9,6 +9,7 @@ use DateTimeInterface;
 use Ecotone\EventSourcing\EventStore;
 use Ecotone\EventSourcing\ProjectionManager;
 use Ecotone\Messaging\Config\ConfiguredMessagingSystem;
+use Ecotone\Messaging\Console\InMemoryConsoleWriter;
 use Ecotone\Messaging\Conversion\MediaType;
 use Ecotone\Messaging\Endpoint\ExecutionPollingMetadata;
 use Ecotone\Messaging\Gateway\MessagingEntrypointService;
@@ -529,6 +530,11 @@ final class FlowTestSupport
     public function getServiceFromContainer(string $serviceName): object
     {
         return $this->configuredMessagingSystem->getServiceFromContainer($serviceName);
+    }
+
+    public function getInMemoryConsoleWriter(): InMemoryConsoleWriter
+    {
+        return $this->configuredMessagingSystem->getServiceFromContainer(InMemoryConsoleWriter::class);
     }
 
     /**

--- a/packages/Ecotone/src/Messaging/Attribute/ConsoleCommand.php
+++ b/packages/Ecotone/src/Messaging/Attribute/ConsoleCommand.php
@@ -12,15 +12,22 @@ use Ecotone\Messaging\Support\Assert;
 class ConsoleCommand
 {
     private string $name;
+    private string $description;
 
-    public function __construct(string $consoleCommandName)
+    public function __construct(string $consoleCommandName, string $description = '')
     {
         Assert::notNullAndEmpty($consoleCommandName, 'Console command name can not be empty string');
         $this->name = $consoleCommandName;
+        $this->description = $description;
     }
 
     public function getName(): string
     {
         return $this->name;
+    }
+
+    public function getDescription(): string
+    {
+        return $this->description;
     }
 }

--- a/packages/Ecotone/src/Messaging/Channel/Manager/ChannelSetupModule.php
+++ b/packages/Ecotone/src/Messaging/Channel/Manager/ChannelSetupModule.php
@@ -66,8 +66,8 @@ class ChannelSetupModule extends NoExternalConfigurationModule implements Annota
         );
 
         // Register console commands
-        $this->registerConsoleCommand('setup', 'ecotone:migration:channel:setup', ChannelSetupCommand::class, $messagingConfiguration, $interfaceToCallRegistry);
-        $this->registerConsoleCommand('delete', 'ecotone:migration:channel:delete', ChannelDeleteCommand::class, $messagingConfiguration, $interfaceToCallRegistry);
+        $this->registerConsoleCommand('setup', 'ecotone:migration:channel:setup', ChannelSetupCommand::class, $messagingConfiguration, $interfaceToCallRegistry, 'Initializes infrastructure of registered message channels');
+        $this->registerConsoleCommand('delete', 'ecotone:migration:channel:delete', ChannelDeleteCommand::class, $messagingConfiguration, $interfaceToCallRegistry, 'Deletes infrastructure of registered message channels');
     }
 
     public function canHandle($extensionObject): bool
@@ -87,14 +87,16 @@ class ChannelSetupModule extends NoExternalConfigurationModule implements Annota
         string $commandName,
         string $className,
         Configuration $configuration,
-        InterfaceToCallRegistry $interfaceToCallRegistry
+        InterfaceToCallRegistry $interfaceToCallRegistry,
+        string $description = ''
     ): void {
         [$messageHandlerBuilder, $oneTimeCommandConfiguration] = ConsoleCommandModule::prepareConsoleCommandForReference(
             new Reference($className),
             new InterfaceToCallReference($className, $methodName),
             $commandName,
             true,
-            $interfaceToCallRegistry
+            $interfaceToCallRegistry,
+            $description
         );
 
         $configuration

--- a/packages/Ecotone/src/Messaging/Config/Annotation/ModuleConfiguration/BasicMessagingModule.php
+++ b/packages/Ecotone/src/Messaging/Config/Annotation/ModuleConfiguration/BasicMessagingModule.php
@@ -18,9 +18,6 @@ use Ecotone\Messaging\Config\LicenceDecider;
 use Ecotone\Messaging\Config\ModulePackageList;
 use Ecotone\Messaging\Config\ModuleReferenceSearchService;
 use Ecotone\Messaging\Config\ServiceConfiguration;
-use Ecotone\Messaging\Console\ConsoleWriter;
-use Ecotone\Messaging\Console\DelegatingConsoleWriter;
-use Ecotone\Messaging\Console\PlainConsoleWriter;
 use Ecotone\Messaging\Conversion\ConversionService;
 use Ecotone\Messaging\Conversion\EnumToScalar\EnumToScalarConverter;
 use Ecotone\Messaging\Conversion\MediaType;
@@ -155,13 +152,6 @@ class BasicMessagingModule extends NoExternalConfigurationModule implements Anno
             new Definition(MessagingEntrypointService::class, [
                 new Reference(ChannelResolver::class),
                 Reference::to(MessageHeadersPropagatorInterceptor::class),
-            ])
-        );
-
-        $messagingConfiguration->registerServiceDefinition(
-            ConsoleWriter::class,
-            new Definition(DelegatingConsoleWriter::class, [
-                new Definition(PlainConsoleWriter::class),
             ])
         );
     }

--- a/packages/Ecotone/src/Messaging/Config/Annotation/ModuleConfiguration/BasicMessagingModule.php
+++ b/packages/Ecotone/src/Messaging/Config/Annotation/ModuleConfiguration/BasicMessagingModule.php
@@ -18,6 +18,9 @@ use Ecotone\Messaging\Config\LicenceDecider;
 use Ecotone\Messaging\Config\ModulePackageList;
 use Ecotone\Messaging\Config\ModuleReferenceSearchService;
 use Ecotone\Messaging\Config\ServiceConfiguration;
+use Ecotone\Messaging\Console\ConsoleWriter;
+use Ecotone\Messaging\Console\DelegatingConsoleWriter;
+use Ecotone\Messaging\Console\PlainConsoleWriter;
 use Ecotone\Messaging\Conversion\ConversionService;
 use Ecotone\Messaging\Conversion\EnumToScalar\EnumToScalarConverter;
 use Ecotone\Messaging\Conversion\MediaType;
@@ -152,6 +155,13 @@ class BasicMessagingModule extends NoExternalConfigurationModule implements Anno
             new Definition(MessagingEntrypointService::class, [
                 new Reference(ChannelResolver::class),
                 Reference::to(MessageHeadersPropagatorInterceptor::class),
+            ])
+        );
+
+        $messagingConfiguration->registerServiceDefinition(
+            ConsoleWriter::class,
+            new Definition(DelegatingConsoleWriter::class, [
+                new Definition(PlainConsoleWriter::class),
             ])
         );
     }

--- a/packages/Ecotone/src/Messaging/Config/Annotation/ModuleConfiguration/ConsoleCommandModule.php
+++ b/packages/Ecotone/src/Messaging/Config/Annotation/ModuleConfiguration/ConsoleCommandModule.php
@@ -63,7 +63,7 @@ final class ConsoleCommandModule extends NoExternalConfigurationModule implement
             $className    = $annotationRegistration->getClassName();
             $methodName               = $annotationRegistration->getMethodName();
 
-            [$messageHandlerBuilder, $oneTimeCommandConfiguration] = self::prepareConsoleCommand($interfaceToCallRegistry, $annotationRegistration, $className, $methodName, $commandName);
+            [$messageHandlerBuilder, $oneTimeCommandConfiguration] = self::prepareConsoleCommand($interfaceToCallRegistry, $annotationRegistration, $className, $methodName, $commandName, $annotation->getDescription());
 
             $messageHandlerBuilders[] = $messageHandlerBuilder;
             $oneTimeConfigurations[]     = $oneTimeCommandConfiguration;
@@ -72,7 +72,7 @@ final class ConsoleCommandModule extends NoExternalConfigurationModule implement
         return new static($messageHandlerBuilders, $oneTimeConfigurations);
     }
 
-    public static function prepareConsoleCommand(InterfaceToCallRegistry $interfaceToCallRegistry, AnnotatedMethod $annotatedMethod, string $className, string $methodName, string $commandName): array
+    public static function prepareConsoleCommand(InterfaceToCallRegistry $interfaceToCallRegistry, AnnotatedMethod $annotatedMethod, string $className, string $methodName, string $commandName, string $description = ''): array
     {
         $parameterConverters = [];
         $parameters          = [];
@@ -85,12 +85,12 @@ final class ConsoleCommandModule extends NoExternalConfigurationModule implement
             ->withEndpointId('ecotone.endpoint.' . $commandName)
             ->withInputChannelName($inputChannel)
             ->withMethodParameterConverters($parameterConverters);
-        $oneTimeCommandConfiguration = ConsoleCommandConfiguration::create($inputChannel, $commandName, $parameters);
+        $oneTimeCommandConfiguration = ConsoleCommandConfiguration::create($inputChannel, $commandName, $parameters, $description);
 
         return [$messageHandlerBuilder, $oneTimeCommandConfiguration];
     }
 
-    public static function prepareConsoleCommandForReference(Reference $reference, InterfaceToCallReference $interfaceToCallReference, string $commandName, bool $discoverableByConsoleCommandAttribute, InterfaceToCallRegistry $interfaceToCallRegistry)
+    public static function prepareConsoleCommandForReference(Reference $reference, InterfaceToCallReference $interfaceToCallReference, string $commandName, bool $discoverableByConsoleCommandAttribute, InterfaceToCallRegistry $interfaceToCallRegistry, string $description = '')
     {
         $className = $interfaceToCallReference->getClassName();
         $methodName = $interfaceToCallReference->getMethodName();
@@ -105,7 +105,7 @@ final class ConsoleCommandModule extends NoExternalConfigurationModule implement
             ->withEndpointAnnotations($discoverableByConsoleCommandAttribute ? [new AttributeDefinition(ConsoleCommand::class, [$commandName])] : [])
             ->withInputChannelName($inputChannel)
             ->withMethodParameterConverters($parameterConverters);
-        $oneTimeCommandConfiguration = ConsoleCommandConfiguration::create($inputChannel, $commandName, $parameters);
+        $oneTimeCommandConfiguration = ConsoleCommandConfiguration::create($inputChannel, $commandName, $parameters, $description);
 
         return [$messageHandlerBuilder, $oneTimeCommandConfiguration];
     }

--- a/packages/Ecotone/src/Messaging/Config/Annotation/ModuleConfiguration/MessagingCommands/MessagingCommandsModule.php
+++ b/packages/Ecotone/src/Messaging/Config/Annotation/ModuleConfiguration/MessagingCommands/MessagingCommandsModule.php
@@ -44,8 +44,8 @@ class MessagingCommandsModule extends NoExternalConfigurationModule implements A
                 ->withInputChannelName(self::ECOTONE_EXECUTE_CONSOLE_COMMAND_EXECUTOR)
         );
 
-        $this->registerConsoleCommand('runAsynchronousEndpointCommand', 'ecotone:run', $messagingConfiguration, $interfaceToCallRegistry);
-        $this->registerConsoleCommand('listAsynchronousEndpointsCommand', 'ecotone:list', $messagingConfiguration, $interfaceToCallRegistry);
+        $this->registerConsoleCommand('runAsynchronousEndpointCommand', 'ecotone:run', $messagingConfiguration, $interfaceToCallRegistry, 'Runs an asynchronous message consumer by name');
+        $this->registerConsoleCommand('listAsynchronousEndpointsCommand', 'ecotone:list', $messagingConfiguration, $interfaceToCallRegistry, 'Lists all registered asynchronous message consumers');
     }
 
     public function canHandle($extensionObject): bool
@@ -53,14 +53,15 @@ class MessagingCommandsModule extends NoExternalConfigurationModule implements A
         return false;
     }
 
-    private function registerConsoleCommand(string $methodName, string $commandName, Configuration $configuration, InterfaceToCallRegistry $interfaceToCallRegistry): void
+    private function registerConsoleCommand(string $methodName, string $commandName, Configuration $configuration, InterfaceToCallRegistry $interfaceToCallRegistry, string $description = ''): void
     {
         [$messageHandlerBuilder, $oneTimeCommandConfiguration] = ConsoleCommandModule::prepareConsoleCommandForReference(
             new Reference(MessagingBaseCommand::class),
             new InterfaceToCallReference(MessagingBaseCommand::class, $methodName),
             $commandName,
             false,
-            $interfaceToCallRegistry
+            $interfaceToCallRegistry,
+            $description
         );
         $configuration
             ->registerMessageHandler($messageHandlerBuilder)

--- a/packages/Ecotone/src/Messaging/Config/ConsoleCommandConfiguration.php
+++ b/packages/Ecotone/src/Messaging/Config/ConsoleCommandConfiguration.php
@@ -21,13 +21,16 @@ class ConsoleCommandConfiguration implements DefinedObject
      */
     private array $parameterNames;
 
+    private string $description;
+
     /**
      * @var ConsoleCommandParameter[] $parameterNames
      */
-    private function __construct(string $channelName, string $name, array $parameterNames)
+    private function __construct(string $channelName, string $name, array $parameterNames, string $description)
     {
         $this->name               = $name;
         $this->channelName = $channelName;
+        $this->description = $description;
         $parameterNames[] = ConsoleCommandParameter::createWithDefaultValue(
             self::HEADER_PARAMETER_NAME,
             '',
@@ -53,14 +56,19 @@ class ConsoleCommandConfiguration implements DefinedObject
     /**
      * @var ConsoleCommandParameter[] $parameterNames
      */
-    public static function create(string $channelName, string $name, array $parameterNames): self
+    public static function create(string $channelName, string $name, array $parameterNames, string $description = ''): self
     {
-        return new self($channelName, $name, $parameterNames);
+        return new self($channelName, $name, $parameterNames, $description);
     }
 
     public function getName(): string
     {
         return $this->name;
+    }
+
+    public function getDescription(): string
+    {
+        return $this->description;
     }
 
     public function getChannelName(): string
@@ -82,6 +90,7 @@ class ConsoleCommandConfiguration implements DefinedObject
             $this->channelName,
             $this->name,
             $this->parameterNames,
+            $this->description,
         ], [self::class, 'create']);
     }
 }

--- a/packages/Ecotone/src/Messaging/Config/Container/Compiler/RegisterSingletonMessagingServices.php
+++ b/packages/Ecotone/src/Messaging/Config/Container/Compiler/RegisterSingletonMessagingServices.php
@@ -14,6 +14,9 @@ use Ecotone\Messaging\Config\MessagingSystemContainer;
 use Ecotone\Messaging\Config\ModulePackageList;
 use Ecotone\Messaging\Config\ServiceCacheConfiguration;
 use Ecotone\Messaging\Config\ServiceConfiguration;
+use Ecotone\Messaging\Console\ConsoleWriter;
+use Ecotone\Messaging\Console\DelegatingConsoleWriter;
+use Ecotone\Messaging\Console\PlainConsoleWriter;
 use Ecotone\Messaging\Handler\Bridge\Bridge;
 use Ecotone\Messaging\Handler\ChannelResolver;
 use Ecotone\Messaging\Handler\Enricher\PropertyEditorAccessor;
@@ -41,6 +44,9 @@ class RegisterSingletonMessagingServices implements CompilerPass
     public function process(ContainerBuilder $builder): void
     {
         $this->registerDefault($builder, Bridge::class, new Definition(Bridge::class));
+        $this->registerDefault($builder, ConsoleWriter::class, new Definition(DelegatingConsoleWriter::class, [
+            new Definition(PlainConsoleWriter::class),
+        ]));
         $this->registerDefault($builder, Reference::toChannel(NullableMessageChannel::CHANNEL_NAME), new Definition(NullableMessageChannel::class));
         $this->registerDefault($builder, EcotoneClockInterface::class, new Definition(
             Clock::class,

--- a/packages/Ecotone/src/Messaging/Console/ConsoleProgressBar.php
+++ b/packages/Ecotone/src/Messaging/Console/ConsoleProgressBar.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ecotone\Messaging\Console;
+
+/**
+ * licence Apache-2.0
+ */
+interface ConsoleProgressBar
+{
+    public function advance(int $steps = 1): void;
+
+    public function finish(): void;
+}

--- a/packages/Ecotone/src/Messaging/Console/ConsoleWriter.php
+++ b/packages/Ecotone/src/Messaging/Console/ConsoleWriter.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ecotone\Messaging\Console;
+
+/**
+ * licence Apache-2.0
+ */
+interface ConsoleWriter
+{
+    public function write(string $message): void;
+
+    public function writeln(string $message = ''): void;
+
+    public function info(string $message): void;
+
+    public function success(string $message): void;
+
+    public function warning(string $message): void;
+
+    public function error(string $message): void;
+
+    /**
+     * @param array<int, string> $columnHeaders
+     * @param array<int, array<int, mixed>> $rows
+     */
+    public function table(array $columnHeaders, array $rows): void;
+
+    public function progressBar(int $maxSteps = 0): ConsoleProgressBar;
+}

--- a/packages/Ecotone/src/Messaging/Console/DelegatingConsoleWriter.php
+++ b/packages/Ecotone/src/Messaging/Console/DelegatingConsoleWriter.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ecotone\Messaging\Console;
+
+/**
+ * licence Apache-2.0
+ */
+final class DelegatingConsoleWriter implements ConsoleWriter
+{
+    public function __construct(private ConsoleWriter $delegate)
+    {
+    }
+
+    public function executeWith(ConsoleWriter $writer, callable $execution): mixed
+    {
+        $previousDelegate = $this->delegate;
+        $this->delegate = $writer;
+        try {
+            return $execution();
+        } finally {
+            $this->delegate = $previousDelegate;
+        }
+    }
+
+    public function write(string $message): void
+    {
+        $this->delegate->write($message);
+    }
+
+    public function writeln(string $message = ''): void
+    {
+        $this->delegate->writeln($message);
+    }
+
+    public function info(string $message): void
+    {
+        $this->delegate->info($message);
+    }
+
+    public function success(string $message): void
+    {
+        $this->delegate->success($message);
+    }
+
+    public function warning(string $message): void
+    {
+        $this->delegate->warning($message);
+    }
+
+    public function error(string $message): void
+    {
+        $this->delegate->error($message);
+    }
+
+    public function table(array $columnHeaders, array $rows): void
+    {
+        $this->delegate->table($columnHeaders, $rows);
+    }
+
+    public function progressBar(int $maxSteps = 0): ConsoleProgressBar
+    {
+        return $this->delegate->progressBar($maxSteps);
+    }
+}

--- a/packages/Ecotone/src/Messaging/Console/InMemoryConsoleProgressBar.php
+++ b/packages/Ecotone/src/Messaging/Console/InMemoryConsoleProgressBar.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ecotone\Messaging\Console;
+
+/**
+ * licence Apache-2.0
+ */
+final class InMemoryConsoleProgressBar implements ConsoleProgressBar
+{
+    private int $currentStep = 0;
+    private bool $isFinished = false;
+
+    public function __construct(private int $maxSteps)
+    {
+    }
+
+    public function advance(int $steps = 1): void
+    {
+        $this->currentStep += $steps;
+    }
+
+    public function finish(): void
+    {
+        $this->isFinished = true;
+    }
+
+    public function getMaxSteps(): int
+    {
+        return $this->maxSteps;
+    }
+
+    public function getCurrentStep(): int
+    {
+        return $this->currentStep;
+    }
+
+    public function isFinished(): bool
+    {
+        return $this->isFinished;
+    }
+}

--- a/packages/Ecotone/src/Messaging/Console/InMemoryConsoleWriter.php
+++ b/packages/Ecotone/src/Messaging/Console/InMemoryConsoleWriter.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ecotone\Messaging\Console;
+
+/**
+ * licence Apache-2.0
+ */
+final class InMemoryConsoleWriter implements ConsoleWriter
+{
+    private string $writtenContent = '';
+    /** @var string[] */
+    private array $infoLines = [];
+    /** @var string[] */
+    private array $successLines = [];
+    /** @var string[] */
+    private array $warningLines = [];
+    /** @var string[] */
+    private array $errorLines = [];
+    /** @var array<int, array{columnHeaders: array<int, string>, rows: array<int, array<int, mixed>>}> */
+    private array $tables = [];
+    /** @var InMemoryConsoleProgressBar[] */
+    private array $progressBars = [];
+
+    public function write(string $message): void
+    {
+        $this->writtenContent .= $message;
+    }
+
+    public function writeln(string $message = ''): void
+    {
+        $this->writtenContent .= $message . PHP_EOL;
+    }
+
+    public function info(string $message): void
+    {
+        $this->infoLines[] = $message;
+    }
+
+    public function success(string $message): void
+    {
+        $this->successLines[] = $message;
+    }
+
+    public function warning(string $message): void
+    {
+        $this->warningLines[] = $message;
+    }
+
+    public function error(string $message): void
+    {
+        $this->errorLines[] = $message;
+    }
+
+    public function table(array $columnHeaders, array $rows): void
+    {
+        $this->tables[] = ['columnHeaders' => $columnHeaders, 'rows' => $rows];
+    }
+
+    public function progressBar(int $maxSteps = 0): ConsoleProgressBar
+    {
+        $progressBar = new InMemoryConsoleProgressBar($maxSteps);
+        $this->progressBars[] = $progressBar;
+
+        return $progressBar;
+    }
+
+    public function getWrittenContent(): string
+    {
+        return $this->writtenContent;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getInfoLines(): array
+    {
+        return $this->infoLines;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getSuccessLines(): array
+    {
+        return $this->successLines;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getWarningLines(): array
+    {
+        return $this->warningLines;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getErrorLines(): array
+    {
+        return $this->errorLines;
+    }
+
+    /**
+     * @return array<int, array{columnHeaders: array<int, string>, rows: array<int, array<int, mixed>>}>
+     */
+    public function getTables(): array
+    {
+        return $this->tables;
+    }
+
+    /**
+     * @return InMemoryConsoleProgressBar[]
+     */
+    public function getProgressBars(): array
+    {
+        return $this->progressBars;
+    }
+}

--- a/packages/Ecotone/src/Messaging/Console/PlainConsoleProgressBar.php
+++ b/packages/Ecotone/src/Messaging/Console/PlainConsoleProgressBar.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ecotone\Messaging\Console;
+
+/**
+ * licence Apache-2.0
+ */
+final class PlainConsoleProgressBar implements ConsoleProgressBar
+{
+    private int $currentStep = 0;
+
+    public function __construct(private ConsoleWriter $writer, private int $maxSteps)
+    {
+    }
+
+    public function advance(int $steps = 1): void
+    {
+        $this->currentStep += $steps;
+        $this->writer->write("\r" . $this->renderProgress());
+    }
+
+    public function finish(): void
+    {
+        if ($this->maxSteps > 0 && $this->currentStep < $this->maxSteps) {
+            $this->currentStep = $this->maxSteps;
+            $this->writer->write("\r" . $this->renderProgress());
+        }
+        $this->writer->writeln();
+    }
+
+    private function renderProgress(): string
+    {
+        return $this->maxSteps > 0
+            ? "{$this->currentStep}/{$this->maxSteps}"
+            : (string) $this->currentStep;
+    }
+}

--- a/packages/Ecotone/src/Messaging/Console/PlainConsoleWriter.php
+++ b/packages/Ecotone/src/Messaging/Console/PlainConsoleWriter.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ecotone\Messaging\Console;
+
+/**
+ * licence Apache-2.0
+ */
+final class PlainConsoleWriter implements ConsoleWriter
+{
+    /**
+     * @param resource|null $stream
+     */
+    public function __construct(private $stream = null)
+    {
+    }
+
+    public function write(string $message): void
+    {
+        fwrite($this->getStream(), $message);
+    }
+
+    public function writeln(string $message = ''): void
+    {
+        $this->write($message . PHP_EOL);
+    }
+
+    public function info(string $message): void
+    {
+        $this->writeln('[INFO] ' . $message);
+    }
+
+    public function success(string $message): void
+    {
+        $this->writeln('[OK] ' . $message);
+    }
+
+    public function warning(string $message): void
+    {
+        $this->writeln('[WARNING] ' . $message);
+    }
+
+    public function error(string $message): void
+    {
+        $this->writeln('[ERROR] ' . $message);
+    }
+
+    public function table(array $columnHeaders, array $rows): void
+    {
+        $columnWidths = $this->resolveColumnWidths($columnHeaders, $rows);
+
+        $this->writeln($this->formatRow($columnHeaders, $columnWidths));
+        foreach ($rows as $row) {
+            $this->writeln($this->formatRow($row, $columnWidths));
+        }
+    }
+
+    public function progressBar(int $maxSteps = 0): ConsoleProgressBar
+    {
+        return new PlainConsoleProgressBar($this, $maxSteps);
+    }
+
+    private function resolveColumnWidths(array $columnHeaders, array $rows): array
+    {
+        $columnWidths = [];
+        foreach (array_merge([$columnHeaders], $rows) as $row) {
+            foreach (array_values($row) as $columnIndex => $value) {
+                $columnWidths[$columnIndex] = max($columnWidths[$columnIndex] ?? 0, strlen((string) $value));
+            }
+        }
+
+        return $columnWidths;
+    }
+
+    private function formatRow(array $row, array $columnWidths): string
+    {
+        $formattedColumns = [];
+        foreach (array_values($row) as $columnIndex => $value) {
+            $formattedColumns[] = str_pad((string) $value, $columnWidths[$columnIndex]);
+        }
+
+        return rtrim(implode(' | ', $formattedColumns));
+    }
+
+    private function getStream()
+    {
+        return $this->stream ?? STDOUT;
+    }
+}

--- a/packages/Ecotone/src/Messaging/Console/SymfonyConsoleProgressBar.php
+++ b/packages/Ecotone/src/Messaging/Console/SymfonyConsoleProgressBar.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ecotone\Messaging\Console;
+
+use Symfony\Component\Console\Helper\ProgressBar;
+
+/**
+ * licence Apache-2.0
+ */
+final class SymfonyConsoleProgressBar implements ConsoleProgressBar
+{
+    public function __construct(private ProgressBar $progressBar)
+    {
+    }
+
+    public function advance(int $steps = 1): void
+    {
+        $this->progressBar->advance($steps);
+    }
+
+    public function finish(): void
+    {
+        $this->progressBar->finish();
+    }
+}

--- a/packages/Ecotone/src/Messaging/Console/SymfonyConsoleWriter.php
+++ b/packages/Ecotone/src/Messaging/Console/SymfonyConsoleWriter.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ecotone\Messaging\Console;
+
+use Symfony\Component\Console\Helper\ProgressBar;
+use Symfony\Component\Console\Helper\Table;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * licence Apache-2.0
+ */
+final class SymfonyConsoleWriter implements ConsoleWriter
+{
+    public function __construct(private OutputInterface $output)
+    {
+    }
+
+    public function write(string $message): void
+    {
+        $this->output->write($message);
+    }
+
+    public function writeln(string $message = ''): void
+    {
+        $this->output->writeln($message);
+    }
+
+    public function info(string $message): void
+    {
+        $this->output->writeln('<fg=cyan>' . $message . '</>');
+    }
+
+    public function success(string $message): void
+    {
+        $this->output->writeln('<fg=green>' . $message . '</>');
+    }
+
+    public function warning(string $message): void
+    {
+        $this->output->writeln('<fg=yellow>' . $message . '</>');
+    }
+
+    public function error(string $message): void
+    {
+        $this->output->writeln('<fg=red>' . $message . '</>');
+    }
+
+    public function table(array $columnHeaders, array $rows): void
+    {
+        $table = new Table($this->output);
+        $table->setHeaders($columnHeaders)
+            ->setRows($rows);
+
+        $table->render();
+    }
+
+    public function progressBar(int $maxSteps = 0): ConsoleProgressBar
+    {
+        return new SymfonyConsoleProgressBar(new ProgressBar($this->output, $maxSteps));
+    }
+}

--- a/packages/Ecotone/src/Projecting/Config/ProjectingConsoleCommands.php
+++ b/packages/Ecotone/src/Projecting/Config/ProjectingConsoleCommands.php
@@ -18,7 +18,7 @@ class ProjectingConsoleCommands
     {
     }
 
-    #[ConsoleCommand('ecotone:projection:init')]
+    #[ConsoleCommand('ecotone:projection:init', 'Initializes given projection or all projections with --all')]
     public function initProjection(?string $name = null, #[ConsoleParameterOption] bool $all = false): void
     {
         if ($name === null) {
@@ -36,7 +36,7 @@ class ProjectingConsoleCommands
         }
     }
 
-    #[ConsoleCommand('ecotone:projection:backfill')]
+    #[ConsoleCommand('ecotone:projection:backfill', 'Prepares given projection to be backfilled with historical events')]
     public function backfillProjection(string $name): void
     {
         if (! $this->registry->has($name)) {
@@ -45,7 +45,7 @@ class ProjectingConsoleCommands
         $this->registry->get($name)->prepareBackfill();
     }
 
-    #[ConsoleCommand('ecotone:projection:rebuild')]
+    #[ConsoleCommand('ecotone:projection:rebuild', 'Prepares given projection to be rebuilt from scratch')]
     public function rebuildProjection(string $name): void
     {
         if (! $this->registry->has($name)) {
@@ -54,7 +54,7 @@ class ProjectingConsoleCommands
         $this->registry->get($name)->prepareRebuild();
     }
 
-    #[ConsoleCommand('ecotone:projection:delete')]
+    #[ConsoleCommand('ecotone:projection:delete', 'Deletes given projection')]
     public function deleteProjection(string $name): void
     {
         if (! $this->registry->has($name)) {

--- a/packages/Ecotone/tests/Messaging/Unit/Config/Annotation/ModuleConfiguration/ConsoleWriterInjectionTest.php
+++ b/packages/Ecotone/tests/Messaging/Unit/Config/Annotation/ModuleConfiguration/ConsoleWriterInjectionTest.php
@@ -41,6 +41,22 @@ final class ConsoleWriterInjectionTest extends TestCase
         $this->assertSame(['Hello John'], $inMemoryWriter->getSuccessLines());
     }
 
+    public function test_console_output_is_collected_in_memory_during_flow_testing(): void
+    {
+        $handler = new class () {
+            #[ConsoleCommand('app:greet')]
+            public function execute(string $name, ConsoleWriter $writer): void
+            {
+                $writer->success('Hello ' . $name);
+            }
+        };
+        $ecotoneLite = EcotoneLite::bootstrapFlowTesting([$handler::class], [$handler]);
+
+        $ecotoneLite->runConsoleCommand('app:greet', ['name' => 'John']);
+
+        $this->assertSame(['Hello John'], $ecotoneLite->getInMemoryConsoleWriter()->getSuccessLines());
+    }
+
     public function test_console_command_handler_can_render_table_and_progress_bar(): void
     {
         $handler = new class () {

--- a/packages/Ecotone/tests/Messaging/Unit/Config/Annotation/ModuleConfiguration/ConsoleWriterInjectionTest.php
+++ b/packages/Ecotone/tests/Messaging/Unit/Config/Annotation/ModuleConfiguration/ConsoleWriterInjectionTest.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Ecotone\Messaging\Unit\Config\Annotation\ModuleConfiguration;
+
+use Ecotone\Lite\EcotoneLite;
+use Ecotone\Messaging\Attribute\ConsoleCommand;
+use Ecotone\Messaging\Console\ConsoleWriter;
+use Ecotone\Messaging\Console\DelegatingConsoleWriter;
+use Ecotone\Messaging\Console\InMemoryConsoleWriter;
+use Exception;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+/**
+ * licence Apache-2.0
+ * @internal
+ */
+final class ConsoleWriterInjectionTest extends TestCase
+{
+    public function test_console_writer_is_injected_into_console_command_handler(): void
+    {
+        $handler = new class () {
+            #[ConsoleCommand('app:greet')]
+            public function execute(string $name, ConsoleWriter $writer): void
+            {
+                $writer->success('Hello ' . $name);
+            }
+        };
+        $ecotoneLite = EcotoneLite::bootstrapFlowTesting([$handler::class], [$handler]);
+
+        $inMemoryWriter = new InMemoryConsoleWriter();
+        /** @var DelegatingConsoleWriter $delegatingWriter */
+        $delegatingWriter = $ecotoneLite->getServiceFromContainer(ConsoleWriter::class);
+        $delegatingWriter->executeWith(
+            $inMemoryWriter,
+            fn () => $ecotoneLite->runConsoleCommand('app:greet', ['name' => 'John'])
+        );
+
+        $this->assertSame(['Hello John'], $inMemoryWriter->getSuccessLines());
+    }
+
+    public function test_console_command_handler_can_render_table_and_progress_bar(): void
+    {
+        $handler = new class () {
+            #[ConsoleCommand('app:report')]
+            public function execute(ConsoleWriter $writer): void
+            {
+                $writer->table(['Name'], [['Order']]);
+                $progressBar = $writer->progressBar(2);
+                $progressBar->advance();
+                $progressBar->advance();
+                $progressBar->finish();
+            }
+        };
+        $ecotoneLite = EcotoneLite::bootstrapFlowTesting([$handler::class], [$handler]);
+
+        $inMemoryWriter = new InMemoryConsoleWriter();
+        /** @var DelegatingConsoleWriter $delegatingWriter */
+        $delegatingWriter = $ecotoneLite->getServiceFromContainer(ConsoleWriter::class);
+        $delegatingWriter->executeWith(
+            $inMemoryWriter,
+            fn () => $ecotoneLite->runConsoleCommand('app:report', [])
+        );
+
+        $this->assertSame([['columnHeaders' => ['Name'], 'rows' => [['Order']]]], $inMemoryWriter->getTables());
+        $progressBar = $inMemoryWriter->getProgressBars()[0];
+        $this->assertSame(2, $progressBar->getCurrentStep());
+        $this->assertSame(2, $progressBar->getMaxSteps());
+        $this->assertTrue($progressBar->isFinished());
+    }
+
+    public function test_previous_writer_is_restored_when_console_command_fails(): void
+    {
+        $handler = new class () {
+            #[ConsoleCommand('app:fail')]
+            public function execute(ConsoleWriter $writer): void
+            {
+                throw new RuntimeException('failure');
+            }
+        };
+        $ecotoneLite = EcotoneLite::bootstrapFlowTesting([$handler::class], [$handler]);
+
+        $commandWriter = new InMemoryConsoleWriter();
+        $restoredWriter = new InMemoryConsoleWriter();
+        /** @var DelegatingConsoleWriter $delegatingWriter */
+        $delegatingWriter = $ecotoneLite->getServiceFromContainer(ConsoleWriter::class);
+
+        $delegatingWriter->executeWith(
+            $restoredWriter,
+            function () use ($delegatingWriter, $commandWriter, $ecotoneLite) {
+                try {
+                    $delegatingWriter->executeWith(
+                        $commandWriter,
+                        fn () => $ecotoneLite->runConsoleCommand('app:fail', [])
+                    );
+                } catch (Exception) {
+                }
+
+                $delegatingWriter->success('after failure');
+            }
+        );
+
+        $this->assertSame([], $commandWriter->getSuccessLines());
+        $this->assertSame(['after failure'], $restoredWriter->getSuccessLines());
+    }
+}

--- a/packages/Ecotone/tests/Messaging/Unit/Console/ConsoleCommandDescriptionTest.php
+++ b/packages/Ecotone/tests/Messaging/Unit/Console/ConsoleCommandDescriptionTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Ecotone\Messaging\Unit\Console;
+
+use Ecotone\Messaging\Attribute\ConsoleCommand;
+use Ecotone\Messaging\Config\ConsoleCommandConfiguration;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * licence Apache-2.0
+ * @internal
+ */
+final class ConsoleCommandDescriptionTest extends TestCase
+{
+    public function test_console_command_attribute_carries_description(): void
+    {
+        $consoleCommand = new ConsoleCommand('app:import', 'Imports orders from given file');
+
+        $this->assertSame('Imports orders from given file', $consoleCommand->getDescription());
+    }
+
+    public function test_console_command_attribute_defaults_to_empty_description(): void
+    {
+        $consoleCommand = new ConsoleCommand('app:import');
+
+        $this->assertSame('', $consoleCommand->getDescription());
+    }
+
+    public function test_configuration_exposes_description_after_container_serialization(): void
+    {
+        $configuration = ConsoleCommandConfiguration::create('channel', 'app:import', [], 'Imports orders from given file');
+
+        $this->assertSame('Imports orders from given file', $configuration->getDescription());
+        $this->assertContains('Imports orders from given file', $configuration->getDefinition()->getArguments());
+    }
+
+    public function test_configuration_defaults_to_empty_description(): void
+    {
+        $configuration = ConsoleCommandConfiguration::create('channel', 'app:import', []);
+
+        $this->assertSame('', $configuration->getDescription());
+    }
+}

--- a/packages/Ecotone/tests/Messaging/Unit/Console/PlainConsoleWriterTest.php
+++ b/packages/Ecotone/tests/Messaging/Unit/Console/PlainConsoleWriterTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Ecotone\Messaging\Unit\Console;
+
+use Ecotone\Messaging\Console\PlainConsoleWriter;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * licence Apache-2.0
+ * @internal
+ */
+final class PlainConsoleWriterTest extends TestCase
+{
+    public function test_writing_semantic_messages_with_level_prefixes(): void
+    {
+        $stream = fopen('php://memory', 'r+');
+        $writer = new PlainConsoleWriter($stream);
+
+        $writer->info('information');
+        $writer->success('done');
+        $writer->warning('careful');
+        $writer->error('failed');
+
+        $this->assertSame(
+            '[INFO] information' . PHP_EOL . '[OK] done' . PHP_EOL . '[WARNING] careful' . PHP_EOL . '[ERROR] failed' . PHP_EOL,
+            $this->readStream($stream)
+        );
+    }
+
+    public function test_rendering_table_with_aligned_columns(): void
+    {
+        $stream = fopen('php://memory', 'r+');
+        $writer = new PlainConsoleWriter($stream);
+
+        $writer->table(['Name', 'Status'], [['orders', 'running'], ['payments', 'stopped']]);
+
+        $this->assertSame(
+            'Name     | Status' . PHP_EOL . 'orders   | running' . PHP_EOL . 'payments | stopped' . PHP_EOL,
+            $this->readStream($stream)
+        );
+    }
+
+    public function test_rendering_progress_bar_up_to_maximum_steps(): void
+    {
+        $stream = fopen('php://memory', 'r+');
+        $writer = new PlainConsoleWriter($stream);
+
+        $progressBar = $writer->progressBar(3);
+        $progressBar->advance();
+        $progressBar->advance(2);
+        $progressBar->finish();
+
+        $this->assertSame("\r1/3\r3/3" . PHP_EOL, $this->readStream($stream));
+    }
+
+    private function readStream($stream): string
+    {
+        rewind($stream);
+
+        return stream_get_contents($stream);
+    }
+}

--- a/packages/Ecotone/tests/Messaging/Unit/Console/SymfonyConsoleWriterTest.php
+++ b/packages/Ecotone/tests/Messaging/Unit/Console/SymfonyConsoleWriterTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Ecotone\Messaging\Unit\Console;
+
+use Ecotone\Messaging\Console\SymfonyConsoleWriter;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Output\BufferedOutput;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * licence Apache-2.0
+ * @internal
+ */
+final class SymfonyConsoleWriterTest extends TestCase
+{
+    public function test_writing_colored_semantic_messages(): void
+    {
+        $output = new BufferedOutput(OutputInterface::VERBOSITY_NORMAL, true);
+        $writer = new SymfonyConsoleWriter($output);
+
+        $writer->info('information');
+        $writer->success('done');
+        $writer->warning('careful');
+        $writer->error('failed');
+
+        $content = $output->fetch();
+        $this->assertStringContainsString("\033[36minformation\033[39m", $content);
+        $this->assertStringContainsString("\033[32mdone\033[39m", $content);
+        $this->assertStringContainsString("\033[33mcareful\033[39m", $content);
+        $this->assertStringContainsString("\033[31mfailed\033[39m", $content);
+    }
+
+    public function test_rendering_table(): void
+    {
+        $output = new BufferedOutput();
+        $writer = new SymfonyConsoleWriter($output);
+
+        $writer->table(['Name', 'Status'], [['orders', 'running']]);
+
+        $content = $output->fetch();
+        $this->assertStringContainsString('Name', $content);
+        $this->assertStringContainsString('orders', $content);
+        $this->assertStringContainsString('running', $content);
+    }
+
+    public function test_rendering_progress_bar(): void
+    {
+        $output = new BufferedOutput();
+        $writer = new SymfonyConsoleWriter($output);
+
+        $progressBar = $writer->progressBar(3);
+        $progressBar->advance();
+        $progressBar->advance(2);
+        $progressBar->finish();
+
+        $this->assertStringContainsString('3/3', $output->fetch());
+    }
+}

--- a/packages/Laravel/src/EcotoneProvider.php
+++ b/packages/Laravel/src/EcotoneProvider.php
@@ -137,7 +137,7 @@ class EcotoneProvider extends ServiceProvider
                     $commandName .= '}';
                 }
 
-                Artisan::command(
+                $artisanCommand = Artisan::command(
                     $commandName,
                     function (ConfiguredMessagingSystem $configuredMessagingSystem) {
                         /** @var ConsoleCommandRunner $consoleCommandRunner */
@@ -162,6 +162,7 @@ class EcotoneProvider extends ServiceProvider
                         return 0;
                     }
                 );
+                $artisanCommand->purpose($oneTimeCommandConfiguration->getDescription());
             }
         }
     }

--- a/packages/Laravel/src/EcotoneProvider.php
+++ b/packages/Laravel/src/EcotoneProvider.php
@@ -10,6 +10,9 @@ use Ecotone\Messaging\Config\MessagingSystemConfiguration;
 use Ecotone\Messaging\Config\ServiceCacheConfiguration;
 use Ecotone\Messaging\Config\ServiceConfiguration;
 use Ecotone\Messaging\ConfigurationVariableService;
+use Ecotone\Messaging\Console\ConsoleWriter;
+use Ecotone\Messaging\Console\DelegatingConsoleWriter;
+use Ecotone\Messaging\Console\SymfonyConsoleWriter;
 use Ecotone\Messaging\Gateway\ConsoleCommandRunner;
 use Ecotone\Messaging\Handler\Recoverability\RetryTemplateBuilder;
 use Ecotone\SymfonyContainer\ContainerCacheLayout;
@@ -143,8 +146,14 @@ class EcotoneProvider extends ServiceProvider
                         /** @var ClosureCommand $self */
                         $self      = $this;
 
+                        /** @var DelegatingConsoleWriter $delegatingWriter */
+                        $delegatingWriter = $configuredMessagingSystem->getServiceFromContainer(ConsoleWriter::class);
+
                         /** @var ConsoleCommandResultSet $result */
-                        $result = $consoleCommandRunner->execute($self->getName(), array_merge($self->arguments(), $self->options()));
+                        $result = $delegatingWriter->executeWith(
+                            new SymfonyConsoleWriter($self->getOutput()),
+                            fn () => $consoleCommandRunner->execute($self->getName(), array_merge($self->arguments(), $self->options()))
+                        );
 
                         if ($result) {
                             $self->table($result->getColumnHeaders(), $result->getRows());

--- a/packages/Laravel/tests/Application/Execution/ConsoleWriterCommandTest.php
+++ b/packages/Laravel/tests/Application/Execution/ConsoleWriterCommandTest.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Ecotone\Laravel\Application\Execution;
+
+use Ecotone\Laravel\EcotoneCacheClear;
+use Ecotone\Laravel\EcotoneProvider;
+use Illuminate\Foundation\Http\Kernel;
+use Illuminate\Foundation\Testing\TestCase;
+use Illuminate\Support\Facades\Artisan;
+use Symfony\Component\Console\Output\BufferedOutput;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * licence Apache-2.0
+ * @internal
+ */
+final class ConsoleWriterCommandTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        putenv('SHELL_VERBOSITY=0');
+        $_ENV['SHELL_VERBOSITY'] = 0;
+        $_SERVER['SHELL_VERBOSITY'] = 0;
+    }
+
+    protected function tearDown(): void
+    {
+        putenv('SHELL_VERBOSITY=-1');
+        $_ENV['SHELL_VERBOSITY'] = -1;
+        $_SERVER['SHELL_VERBOSITY'] = -1;
+
+        parent::tearDown();
+    }
+
+    public function createApplication()
+    {
+        $app = require __DIR__ . '/../bootstrap/app.php';
+
+        $app->make(Kernel::class)->bootstrap();
+
+        EcotoneCacheClear::clearEcotoneCacheDirectories(EcotoneProvider::getCacheDirectoryPath());
+
+        return $app;
+    }
+
+    public function test_console_command_writes_formatted_output_through_artisan(): void
+    {
+        $this->withoutMockingConsoleOutput();
+
+        Artisan::call('console-writer:show', ['name' => 'orders']);
+
+        $output = Artisan::output();
+        $this->assertStringContainsString('Starting orders', $output);
+        $this->assertStringContainsString('Processed orders', $output);
+        $this->assertStringContainsString('Almost done orders', $output);
+        $this->assertStringContainsString('Failed orders', $output);
+        $this->assertStringContainsString('running', $output);
+        $this->assertStringContainsString('2/2', $output);
+    }
+
+    public function test_console_command_writes_colored_output_when_decorated(): void
+    {
+        $this->withoutMockingConsoleOutput();
+
+        $output = new BufferedOutput(OutputInterface::VERBOSITY_NORMAL, true);
+
+        Artisan::call('console-writer:show', ['name' => 'orders'], $output);
+
+        $content = $output->fetch();
+        $this->assertStringContainsString("\033[36mStarting orders\033[39m", $content);
+        $this->assertStringContainsString("\033[32mProcessed orders\033[39m", $content);
+        $this->assertStringContainsString("\033[33mAlmost done orders\033[39m", $content);
+        $this->assertStringContainsString("\033[31mFailed orders\033[39m", $content);
+    }
+}

--- a/packages/Laravel/tests/Application/Execution/ConsoleWriterCommandTest.php
+++ b/packages/Laravel/tests/Application/Execution/ConsoleWriterCommandTest.php
@@ -62,6 +62,14 @@ final class ConsoleWriterCommandTest extends TestCase
         $this->assertStringContainsString('2/2', $output);
     }
 
+    public function test_console_command_description_is_visible_in_artisan(): void
+    {
+        $this->assertSame(
+            'Shows formatted console writer output',
+            Artisan::all()['console-writer:show']->getDescription()
+        );
+    }
+
     public function test_console_command_writes_colored_output_when_decorated(): void
     {
         $this->withoutMockingConsoleOutput();

--- a/packages/Laravel/tests/Fixture/ConsoleWriter/ConsoleWriterCommand.php
+++ b/packages/Laravel/tests/Fixture/ConsoleWriter/ConsoleWriterCommand.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Ecotone\Laravel\Fixture\ConsoleWriter;
+
+use Ecotone\Messaging\Attribute\ConsoleCommand;
+use Ecotone\Messaging\Console\ConsoleWriter;
+
+/**
+ * licence Apache-2.0
+ */
+final class ConsoleWriterCommand
+{
+    #[ConsoleCommand('console-writer:show')]
+    public function execute(string $name, ConsoleWriter $writer): void
+    {
+        $writer->info('Starting ' . $name);
+        $writer->success('Processed ' . $name);
+        $writer->warning('Almost done ' . $name);
+        $writer->error('Failed ' . $name);
+        $writer->table(['Name', 'Status'], [[$name, 'running']]);
+
+        $progressBar = $writer->progressBar(2);
+        $progressBar->advance();
+        $progressBar->advance();
+        $progressBar->finish();
+        $writer->writeln();
+    }
+}

--- a/packages/Laravel/tests/Fixture/ConsoleWriter/ConsoleWriterCommand.php
+++ b/packages/Laravel/tests/Fixture/ConsoleWriter/ConsoleWriterCommand.php
@@ -12,7 +12,7 @@ use Ecotone\Messaging\Console\ConsoleWriter;
  */
 final class ConsoleWriterCommand
 {
-    #[ConsoleCommand('console-writer:show')]
+    #[ConsoleCommand('console-writer:show', 'Shows formatted console writer output')]
     public function execute(string $name, ConsoleWriter $writer): void
     {
         $writer->info('Starting ' . $name);

--- a/packages/PdoEventSourcing/src/Config/EventSourcingModule.php
+++ b/packages/PdoEventSourcing/src/Config/EventSourcingModule.php
@@ -427,7 +427,8 @@ class EventSourcingModule extends NoExternalConfigurationModule
             $eventSourcingConfiguration,
             $configuration,
             self::ECOTONE_ES_DELETE_PROJECTION,
-            [ConsoleCommandParameter::create('name', 'ecotone.eventSourcing.manager.name', false), ConsoleCommandParameter::createWithDefaultValue('deleteEmittedEvents', 'ecotone.eventSourcing.manager.deleteEmittedEvents', true, false, true)]
+            [ConsoleCommandParameter::create('name', 'ecotone.eventSourcing.manager.name', false), ConsoleCommandParameter::createWithDefaultValue('deleteEmittedEvents', 'ecotone.eventSourcing.manager.deleteEmittedEvents', true, false, true)],
+            'Deletes given event sourcing projection'
         );
 
         $this->registerProjectionManagerAction(
@@ -440,7 +441,8 @@ class EventSourcingModule extends NoExternalConfigurationModule
             $eventSourcingConfiguration,
             $configuration,
             self::ECOTONE_ES_RESET_PROJECTION,
-            [ConsoleCommandParameter::create('name', 'ecotone.eventSourcing.manager.name', false)]
+            [ConsoleCommandParameter::create('name', 'ecotone.eventSourcing.manager.name', false)],
+            'Resets given event sourcing projection to be rebuilt from scratch'
         );
 
         $this->registerProjectionManagerAction(
@@ -450,7 +452,8 @@ class EventSourcingModule extends NoExternalConfigurationModule
             $eventSourcingConfiguration,
             $configuration,
             self::ECOTONE_ES_STOP_PROJECTION,
-            [ConsoleCommandParameter::create('name', 'ecotone.eventSourcing.manager.name', false)]
+            [ConsoleCommandParameter::create('name', 'ecotone.eventSourcing.manager.name', false)],
+            'Stops given event sourcing projection'
         );
 
         $this->registerProjectionManagerAction(
@@ -463,7 +466,8 @@ class EventSourcingModule extends NoExternalConfigurationModule
             $eventSourcingConfiguration,
             $configuration,
             self::ECOTONE_ES_INITIALIZE_PROJECTION,
-            [ConsoleCommandParameter::create('name', 'ecotone.eventSourcing.manager.name', false)]
+            [ConsoleCommandParameter::create('name', 'ecotone.eventSourcing.manager.name', false)],
+            'Initializes given event sourcing projection'
         );
 
         $this->registerProjectionManagerAction(
@@ -476,7 +480,8 @@ class EventSourcingModule extends NoExternalConfigurationModule
             $eventSourcingConfiguration,
             $configuration,
             self::ECOTONE_ES_TRIGGER_PROJECTION,
-            [ConsoleCommandParameter::create('name', 'ecotone.eventSourcing.manager.name', false)]
+            [ConsoleCommandParameter::create('name', 'ecotone.eventSourcing.manager.name', false)],
+            'Triggers given event sourcing projection to process events'
         );
 
         $this->registerProjectionManagerAction(
@@ -504,7 +509,7 @@ class EventSourcingModule extends NoExternalConfigurationModule
         );
     }
 
-    private function registerProjectionManagerAction(string $methodName, array $endpointConverters, array $gatewayConverters, EventSourcingConfiguration $eventSourcingConfiguration, Configuration $configuration, ?string $consoleCommandName = null, array $consoleCommandParameters = []): void
+    private function registerProjectionManagerAction(string $methodName, array $endpointConverters, array $gatewayConverters, EventSourcingConfiguration $eventSourcingConfiguration, Configuration $configuration, ?string $consoleCommandName = null, array $consoleCommandParameters = [], string $consoleCommandDescription = ''): void
     {
         $messageHandlerBuilder = ProjectionManagerBuilder::create($methodName, $endpointConverters, $eventSourcingConfiguration);
         $configuration->registerMessageHandler($messageHandlerBuilder);
@@ -518,7 +523,8 @@ class EventSourcingModule extends NoExternalConfigurationModule
                 ConsoleCommandConfiguration::create(
                     $messageHandlerBuilder->getInputMessageChannelName(),
                     $consoleCommandName,
-                    $consoleCommandParameters
+                    $consoleCommandParameters,
+                    $consoleCommandDescription
                 )
             );
         }

--- a/packages/PdoEventSourcing/tests/Integration/AsynchronousEventDrivenProjectionTest.php
+++ b/packages/PdoEventSourcing/tests/Integration/AsynchronousEventDrivenProjectionTest.php
@@ -63,8 +63,8 @@ final class AsynchronousEventDrivenProjectionTest extends EventSourcingMessaging
         $ecotone->run(InProgressTicketList::PROJECTION_CHANNEL);
         $finishTime = microtime(true);
 
-        // less than ~100 ms (however connection and set up might take longer)
-        self::assertLessThan(100, ($finishTime - $currentTime) * 1000);
+        // well below the default 1s polling timeout, proving the run does not wait for it (CI runners can be slow)
+        self::assertLessThan(500, ($finishTime - $currentTime) * 1000);
 
         self::assertEquals([['ticket_id' => '123', 'ticket_type' => 'alert']], $ecotone->sendQueryWithRouting('getInProgressTickets'));
     }

--- a/packages/PdoEventSourcing/tests/Projecting/Global/AsynchronousEventDrivenProjectionTest.php
+++ b/packages/PdoEventSourcing/tests/Projecting/Global/AsynchronousEventDrivenProjectionTest.php
@@ -151,8 +151,8 @@ final class AsynchronousEventDrivenProjectionTest extends ProjectingTestCase
         $ecotone->run($projection::CHANNEL);
         $finishTime = microtime(true);
 
-        // less than ~100 ms (however connection and set up might take longer)
-        self::assertLessThan(100, ($finishTime - $currentTime) * 1000);
+        // well below the default 1s polling timeout, proving the run does not wait for it (CI runners can be slow)
+        self::assertLessThan(500, ($finishTime - $currentTime) * 1000);
 
         self::assertEquals([['ticket_id' => '123', 'ticket_type' => 'alert']], $ecotone->sendQueryWithRouting('getInProgressTickets'));
     }

--- a/packages/PdoEventSourcing/tests/Projecting/Partitioned/AsynchronousEventDrivenProjectionTest.php
+++ b/packages/PdoEventSourcing/tests/Projecting/Partitioned/AsynchronousEventDrivenProjectionTest.php
@@ -148,8 +148,8 @@ final class AsynchronousEventDrivenProjectionTest extends ProjectingTestCase
         $ecotone->run($projection::CHANNEL);
         $finishTime = microtime(true);
 
-        // less than ~100 ms (however connection and set up might take longer)
-        self::assertLessThan(100, ($finishTime - $currentTime) * 1000);
+        // well below the default 1s polling timeout, proving the run does not wait for it (CI runners can be slow)
+        self::assertLessThan(500, ($finishTime - $currentTime) * 1000);
 
         self::assertEquals([['ticket_id' => '123', 'ticket_type' => 'alert']], $ecotone->sendQueryWithRouting('getInProgressTickets'));
     }

--- a/packages/Symfony/DependencyInjection/EcotoneExtension.php
+++ b/packages/Symfony/DependencyInjection/EcotoneExtension.php
@@ -154,6 +154,7 @@ class EcotoneExtension extends Extension
             $definition->addArgument(serialize($oneTimeCommandConfiguration->getParameters()));
             $definition->addArgument(new Reference(ConsoleCommandRunner::class));
             $definition->addArgument(new Reference(ConsoleWriter::class));
+            $definition->addArgument($oneTimeCommandConfiguration->getDescription());
             $definition->addTag('console.command', ['command' => $oneTimeCommandConfiguration->getName()]);
 
             $container->setDefinition($oneTimeCommandConfiguration->getChannelName(), $definition);

--- a/packages/Symfony/DependencyInjection/EcotoneExtension.php
+++ b/packages/Symfony/DependencyInjection/EcotoneExtension.php
@@ -7,6 +7,7 @@ use Ecotone\Messaging\Config\Container\Compiler\ValidityCheckPass;
 use Ecotone\Messaging\Config\MessagingSystemConfiguration;
 use Ecotone\Messaging\Config\ServiceCacheConfiguration;
 use Ecotone\Messaging\Config\ServiceConfiguration;
+use Ecotone\Messaging\Console\ConsoleWriter;
 use Ecotone\Messaging\Gateway\ConsoleCommandRunner;
 use Ecotone\Messaging\Handler\Gateway\ProxyFactory;
 use Ecotone\Messaging\Handler\Recoverability\RetryTemplateBuilder;
@@ -152,6 +153,7 @@ class EcotoneExtension extends Extension
             $definition->addArgument($oneTimeCommandConfiguration->getName());
             $definition->addArgument(serialize($oneTimeCommandConfiguration->getParameters()));
             $definition->addArgument(new Reference(ConsoleCommandRunner::class));
+            $definition->addArgument(new Reference(ConsoleWriter::class));
             $definition->addTag('console.command', ['command' => $oneTimeCommandConfiguration->getName()]);
 
             $container->setDefinition($oneTimeCommandConfiguration->getChannelName(), $definition);

--- a/packages/Symfony/DependencyInjection/MessagingEntrypointCommand.php
+++ b/packages/Symfony/DependencyInjection/MessagingEntrypointCommand.php
@@ -23,16 +23,18 @@ class MessagingEntrypointCommand extends Command
     private array $parameters;
     private ConsoleCommandRunner $consoleCommandRunner;
     private DelegatingConsoleWriter $consoleWriter;
+    private string $commandDescription;
 
     /**
      * @var ConsoleCommandParameter[] $parameters
      */
-    public function __construct(string $name, string $parameters, ConsoleCommandRunner $consoleCommandRunner, DelegatingConsoleWriter $consoleWriter)
+    public function __construct(string $name, string $parameters, ConsoleCommandRunner $consoleCommandRunner, DelegatingConsoleWriter $consoleWriter, string $commandDescription = '')
     {
         $this->name = $name;
         $this->parameters = unserialize($parameters);
         $this->consoleCommandRunner = $consoleCommandRunner;
         $this->consoleWriter = $consoleWriter;
+        $this->commandDescription = $commandDescription;
 
         parent::__construct();
     }
@@ -58,6 +60,7 @@ class MessagingEntrypointCommand extends Command
         }
 
         $this->setName($this->name);
+        $this->setDescription($this->commandDescription);
     }
 
     public function execute(InputInterface $input, OutputInterface $output): int

--- a/packages/Symfony/DependencyInjection/MessagingEntrypointCommand.php
+++ b/packages/Symfony/DependencyInjection/MessagingEntrypointCommand.php
@@ -4,9 +4,10 @@ namespace Ecotone\SymfonyBundle\DependencyInjection;
 
 use Ecotone\Messaging\Config\ConsoleCommandParameter;
 use Ecotone\Messaging\Config\ConsoleCommandResultSet;
+use Ecotone\Messaging\Console\DelegatingConsoleWriter;
+use Ecotone\Messaging\Console\SymfonyConsoleWriter;
 use Ecotone\Messaging\Gateway\ConsoleCommandRunner;
 use Symfony\Component\Console\Command\Command;
-use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -21,15 +22,17 @@ class MessagingEntrypointCommand extends Command
     /** @var ConsoleCommandParameter[] */
     private array $parameters;
     private ConsoleCommandRunner $consoleCommandRunner;
+    private DelegatingConsoleWriter $consoleWriter;
 
     /**
      * @var ConsoleCommandParameter[] $parameters
      */
-    public function __construct(string $name, string $parameters, ConsoleCommandRunner $consoleCommandRunner)
+    public function __construct(string $name, string $parameters, ConsoleCommandRunner $consoleCommandRunner, DelegatingConsoleWriter $consoleWriter)
     {
         $this->name = $name;
         $this->parameters = unserialize($parameters);
         $this->consoleCommandRunner = $consoleCommandRunner;
+        $this->consoleWriter = $consoleWriter;
 
         parent::__construct();
     }
@@ -59,16 +62,16 @@ class MessagingEntrypointCommand extends Command
 
     public function execute(InputInterface $input, OutputInterface $output): int
     {
+        $writer = new SymfonyConsoleWriter($output);
+
         /** @var ConsoleCommandResultSet $result */
-        $result = $this->consoleCommandRunner->execute($this->name, array_merge($input->getArguments(), $input->getOptions()));
+        $result = $this->consoleWriter->executeWith(
+            $writer,
+            fn () => $this->consoleCommandRunner->execute($this->name, array_merge($input->getArguments(), $input->getOptions()))
+        );
 
         if ($result) {
-            $table = new Table($output);
-            $table->setHeaders($result->getColumnHeaders())
-                ->setRows($result->getRows())
-            ;
-
-            $table->render();
+            $writer->table($result->getColumnHeaders(), $result->getRows());
         }
 
         return 0;

--- a/packages/Symfony/tests/Fixture/ConsoleWriter/ConsoleWriterCommand.php
+++ b/packages/Symfony/tests/Fixture/ConsoleWriter/ConsoleWriterCommand.php
@@ -12,7 +12,7 @@ use Ecotone\Messaging\Console\ConsoleWriter;
  */
 class ConsoleWriterCommand
 {
-    #[ConsoleCommand('console-writer:show')]
+    #[ConsoleCommand('console-writer:show', 'Shows formatted console writer output')]
     public function execute(string $name, ConsoleWriter $writer): void
     {
         $writer->info('Starting ' . $name);

--- a/packages/Symfony/tests/Fixture/ConsoleWriter/ConsoleWriterCommand.php
+++ b/packages/Symfony/tests/Fixture/ConsoleWriter/ConsoleWriterCommand.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fixture\ConsoleWriter;
+
+use Ecotone\Messaging\Attribute\ConsoleCommand;
+use Ecotone\Messaging\Console\ConsoleWriter;
+
+/**
+ * licence Apache-2.0
+ */
+class ConsoleWriterCommand
+{
+    #[ConsoleCommand('console-writer:show')]
+    public function execute(string $name, ConsoleWriter $writer): void
+    {
+        $writer->info('Starting ' . $name);
+        $writer->success('Processed ' . $name);
+        $writer->warning('Almost done ' . $name);
+        $writer->error('Failed ' . $name);
+        $writer->table(['Name', 'Status'], [[$name, 'running']]);
+
+        $progressBar = $writer->progressBar(2);
+        $progressBar->advance();
+        $progressBar->advance();
+        $progressBar->finish();
+        $writer->writeln();
+    }
+}

--- a/packages/Symfony/tests/phpunit/ConsoleWriterCommandTest.php
+++ b/packages/Symfony/tests/phpunit/ConsoleWriterCommandTest.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test;
+
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Console\Tester\CommandTester;
+
+/**
+ * licence Apache-2.0
+ * @internal
+ */
+final class ConsoleWriterCommandTest extends KernelTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        self::bootKernel([
+            'environment' => 'test',
+        ]);
+    }
+
+    protected function tearDown(): void
+    {
+        restore_exception_handler();
+
+        parent::tearDown();
+    }
+
+    public function test_console_command_writes_formatted_output_through_symfony_console(): void
+    {
+        $commandTester = $this->prepareCommandTester();
+
+        $commandTester->execute(['name' => 'orders']);
+
+        $commandTester->assertCommandIsSuccessful();
+        $display = $commandTester->getDisplay();
+        $this->assertStringContainsString('Starting orders', $display);
+        $this->assertStringContainsString('Processed orders', $display);
+        $this->assertStringContainsString('Almost done orders', $display);
+        $this->assertStringContainsString('Failed orders', $display);
+        $this->assertStringContainsString('running', $display);
+        $this->assertStringContainsString('2/2', $display);
+    }
+
+    public function test_console_command_writes_colored_output_when_decorated(): void
+    {
+        $commandTester = $this->prepareCommandTester();
+
+        $commandTester->execute(['name' => 'orders'], ['decorated' => true]);
+
+        $display = $commandTester->getDisplay();
+        $this->assertStringContainsString("\033[36mStarting orders\033[39m", $display);
+        $this->assertStringContainsString("\033[32mProcessed orders\033[39m", $display);
+        $this->assertStringContainsString("\033[33mAlmost done orders\033[39m", $display);
+        $this->assertStringContainsString("\033[31mFailed orders\033[39m", $display);
+    }
+
+    private function prepareCommandTester(): CommandTester
+    {
+        $application = new Application(self::$kernel);
+        $command = $application->find('console-writer:show');
+
+        return new CommandTester($command);
+    }
+}

--- a/packages/Symfony/tests/phpunit/ConsoleWriterCommandTest.php
+++ b/packages/Symfony/tests/phpunit/ConsoleWriterCommandTest.php
@@ -59,6 +59,30 @@ final class ConsoleWriterCommandTest extends KernelTestCase
         $this->assertStringContainsString("\033[31mFailed orders\033[39m", $display);
     }
 
+    public function test_console_command_description_is_visible_in_symfony_console(): void
+    {
+        $application = new Application(self::$kernel);
+
+        $this->assertSame(
+            'Shows formatted console writer output',
+            $application->find('console-writer:show')->getDescription()
+        );
+    }
+
+    public function test_built_in_ecotone_commands_have_descriptions(): void
+    {
+        $application = new Application(self::$kernel);
+
+        $this->assertSame(
+            'Lists all registered asynchronous message consumers',
+            $application->find('ecotone:list')->getDescription()
+        );
+        $this->assertSame(
+            'Runs an asynchronous message consumer by name',
+            $application->find('ecotone:run')->getDescription()
+        );
+    }
+
     private function prepareCommandTester(): CommandTester
     {
         $application = new Application(self::$kernel);

--- a/packages/Tempest/src/ConsoleCommandProxyGenerator.php
+++ b/packages/Tempest/src/ConsoleCommandProxyGenerator.php
@@ -14,6 +14,7 @@ use Ecotone\Messaging\Config\ConsoleCommandConfiguration;
 final class ConsoleCommandProxyGenerator
 {
     private const HASH_MARKER_FILE = '.ecotone_hash';
+    private const GENERATOR_VERSION = ':v2';
 
     /**
      * @param ConsoleCommandConfiguration[] $commandConfigurations
@@ -21,6 +22,10 @@ final class ConsoleCommandProxyGenerator
      */
     public function generate(array $commandConfigurations, string $outputDirectory, ?string $configHash = null): array
     {
+        if ($configHash !== null) {
+            $configHash .= self::GENERATOR_VERSION;
+        }
+
         if (! is_dir($outputDirectory)) {
             mkdir($outputDirectory, 0777, true);
         }
@@ -99,7 +104,10 @@ final class ConsoleCommandProxyGenerator
 
             use Ecotone\Messaging\Config\ConfiguredMessagingSystem;
             use Ecotone\Messaging\Config\ConsoleCommandResultSet;
+            use Ecotone\Messaging\Console\ConsoleWriter;
+            use Ecotone\Messaging\Console\DelegatingConsoleWriter;
             use Ecotone\Messaging\Gateway\ConsoleCommandRunner;
+            use Ecotone\Tempest\TempestConsoleWriter;
             use Tempest\Console\Console;
             use Tempest\Console\ConsoleCommand;
             use Tempest\Console\ExitCode;
@@ -128,12 +136,15 @@ final class ConsoleCommandProxyGenerator
                     foreach (\$this->argumentBag->all() as \$arg) {
                         \$allArgs[\$arg->name !== null ? \$arg->name : ''] = \$arg->value;
                     }
-                    \$result = \$runner->execute('{$escapedCommandName}', \$allArgs);
+                    /** @var DelegatingConsoleWriter \$delegatingWriter */
+                    \$delegatingWriter = \$this->messagingSystem->getServiceFromContainer(ConsoleWriter::class);
+                    \$writer = new TempestConsoleWriter(\$this->console);
+                    \$result = \$delegatingWriter->executeWith(
+                        \$writer,
+                        fn () => \$runner->execute('{$escapedCommandName}', \$allArgs)
+                    );
                     if (\$result instanceof ConsoleCommandResultSet) {
-                        \$this->console->writeln(implode(' | ', \$result->getColumnHeaders()));
-                        foreach (\$result->getRows() as \$row) {
-                            \$this->console->writeln(implode(' | ', \$row));
-                        }
+                        \$writer->table(\$result->getColumnHeaders(), \$result->getRows());
                     }
                     return ExitCode::SUCCESS;
                 }

--- a/packages/Tempest/src/ConsoleCommandProxyGenerator.php
+++ b/packages/Tempest/src/ConsoleCommandProxyGenerator.php
@@ -14,7 +14,7 @@ use Ecotone\Messaging\Config\ConsoleCommandConfiguration;
 final class ConsoleCommandProxyGenerator
 {
     private const HASH_MARKER_FILE = '.ecotone_hash';
-    private const GENERATOR_VERSION = ':v2';
+    private const GENERATOR_VERSION = ':v3';
 
     /**
      * @param ConsoleCommandConfiguration[] $commandConfigurations
@@ -86,14 +86,15 @@ final class ConsoleCommandProxyGenerator
         $className = $this->buildClassName($commandName);
         $filePath = $outputDirectory . DIRECTORY_SEPARATOR . $className . '.php';
 
-        file_put_contents($filePath, $this->buildProxyClassCode($className, $commandName));
+        file_put_contents($filePath, $this->buildProxyClassCode($className, $commandName, $configuration->getDescription()));
 
         return $filePath;
     }
 
-    private function buildProxyClassCode(string $className, string $commandName): string
+    private function buildProxyClassCode(string $className, string $commandName, string $description): string
     {
         $escapedCommandName = addslashes($commandName);
+        $escapedDescription = addslashes($description);
 
         return <<<PHP
             <?php
@@ -128,7 +129,7 @@ final class ConsoleCommandProxyGenerator
                 #[Inject]
                 private readonly Console \$console;
 
-                #[ConsoleCommand(name: '{$escapedCommandName}', allowDynamicArguments: true)]
+                #[ConsoleCommand(name: '{$escapedCommandName}', description: '{$escapedDescription}', allowDynamicArguments: true)]
                 public function __invoke(): ExitCode
                 {
                     \$runner = \$this->messagingSystem->getGatewayByName(ConsoleCommandRunner::class);

--- a/packages/Tempest/src/ConsoleCommandProxyGenerator.php
+++ b/packages/Tempest/src/ConsoleCommandProxyGenerator.php
@@ -14,7 +14,6 @@ use Ecotone\Messaging\Config\ConsoleCommandConfiguration;
 final class ConsoleCommandProxyGenerator
 {
     private const HASH_MARKER_FILE = '.ecotone_hash';
-    private const GENERATOR_VERSION = ':v3';
 
     /**
      * @param ConsoleCommandConfiguration[] $commandConfigurations
@@ -22,10 +21,6 @@ final class ConsoleCommandProxyGenerator
      */
     public function generate(array $commandConfigurations, string $outputDirectory, ?string $configHash = null): array
     {
-        if ($configHash !== null) {
-            $configHash .= self::GENERATOR_VERSION;
-        }
-
         if (! is_dir($outputDirectory)) {
             mkdir($outputDirectory, 0777, true);
         }

--- a/packages/Tempest/src/TempestConsoleProgressBar.php
+++ b/packages/Tempest/src/TempestConsoleProgressBar.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ecotone\Tempest;
+
+use Ecotone\Messaging\Console\ConsoleProgressBar;
+use Tempest\Console\Console;
+
+/**
+ * licence Apache-2.0
+ */
+final class TempestConsoleProgressBar implements ConsoleProgressBar
+{
+    private int $currentStep = 0;
+
+    public function __construct(private Console $console, private int $maxSteps)
+    {
+    }
+
+    public function advance(int $steps = 1): void
+    {
+        $this->currentStep += $steps;
+        $this->console->writeRaw("\r" . $this->renderProgress());
+    }
+
+    public function finish(): void
+    {
+        if ($this->maxSteps > 0 && $this->currentStep < $this->maxSteps) {
+            $this->currentStep = $this->maxSteps;
+            $this->console->writeRaw("\r" . $this->renderProgress());
+        }
+        $this->console->writeln();
+    }
+
+    private function renderProgress(): string
+    {
+        return $this->maxSteps > 0
+            ? "{$this->currentStep}/{$this->maxSteps}"
+            : (string) $this->currentStep;
+    }
+}

--- a/packages/Tempest/src/TempestConsoleWriter.php
+++ b/packages/Tempest/src/TempestConsoleWriter.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ecotone\Tempest;
+
+use Ecotone\Messaging\Console\ConsoleProgressBar;
+use Ecotone\Messaging\Console\ConsoleWriter;
+use Tempest\Console\Console;
+
+/**
+ * licence Apache-2.0
+ */
+final class TempestConsoleWriter implements ConsoleWriter
+{
+    public function __construct(private Console $console)
+    {
+    }
+
+    public function write(string $message): void
+    {
+        $this->console->write($message);
+    }
+
+    public function writeln(string $message = ''): void
+    {
+        $this->console->writeln($message);
+    }
+
+    public function info(string $message): void
+    {
+        $this->console->info($message);
+    }
+
+    public function success(string $message): void
+    {
+        $this->console->success($message);
+    }
+
+    public function warning(string $message): void
+    {
+        $this->console->warning($message);
+    }
+
+    public function error(string $message): void
+    {
+        $this->console->error($message);
+    }
+
+    public function table(array $columnHeaders, array $rows): void
+    {
+        $columnWidths = $this->resolveColumnWidths($columnHeaders, $rows);
+
+        $this->console->writeln($this->formatRow($columnHeaders, $columnWidths));
+        foreach ($rows as $row) {
+            $this->console->writeln($this->formatRow($row, $columnWidths));
+        }
+    }
+
+    public function progressBar(int $maxSteps = 0): ConsoleProgressBar
+    {
+        return new TempestConsoleProgressBar($this->console, $maxSteps);
+    }
+
+    private function resolveColumnWidths(array $columnHeaders, array $rows): array
+    {
+        $columnWidths = [];
+        foreach (array_merge([$columnHeaders], $rows) as $row) {
+            foreach (array_values($row) as $columnIndex => $value) {
+                $columnWidths[$columnIndex] = max($columnWidths[$columnIndex] ?? 0, strlen((string) $value));
+            }
+        }
+
+        return $columnWidths;
+    }
+
+    private function formatRow(array $row, array $columnWidths): string
+    {
+        $formattedColumns = [];
+        foreach (array_values($row) as $columnIndex => $value) {
+            $formattedColumns[] = str_pad((string) $value, $columnWidths[$columnIndex]);
+        }
+
+        return rtrim(implode(' | ', $formattedColumns));
+    }
+}

--- a/packages/Tempest/tests/Application/ConsoleCommandProxyTest.php
+++ b/packages/Tempest/tests/Application/ConsoleCommandProxyTest.php
@@ -127,7 +127,9 @@ final class ConsoleCommandProxyTest extends EcotoneIntegrationTestCase
         $fileContent = file_get_contents($generatedClasses[0]);
         $this->assertStringContainsString('Console $console', $fileContent);
         $this->assertStringContainsString('ConsoleCommandResultSet', $fileContent);
-        $this->assertStringContainsString('writeln', $fileContent);
+        $this->assertStringContainsString('TempestConsoleWriter', $fileContent);
+        $this->assertStringContainsString('executeWith', $fileContent);
+        $this->assertStringContainsString('table', $fileContent);
 
         array_map('unlink', $generatedClasses);
         @rmdir($outputDir);

--- a/packages/Tempest/tests/Application/ConsoleWriterCommandTest.php
+++ b/packages/Tempest/tests/Application/ConsoleWriterCommandTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Test\Ecotone\Tempest\Application;
 
+use Tempest\Console\ConsoleConfig;
 use Test\Ecotone\Tempest\EcotoneIntegrationTestCase;
 
 /**
@@ -12,6 +13,18 @@ use Test\Ecotone\Tempest\EcotoneIntegrationTestCase;
  */
 final class ConsoleWriterCommandTest extends EcotoneIntegrationTestCase
 {
+    public function test_console_command_description_is_visible_in_tempest_console(): void
+    {
+        $this->setupKernel();
+
+        $consoleConfig = $this->container->get(ConsoleConfig::class);
+
+        $this->assertSame(
+            'Shows formatted console writer output',
+            $consoleConfig->commands['console-writer:show']->description
+        );
+    }
+
     public function test_console_command_writes_formatted_output_through_tempest_console(): void
     {
         $this->console

--- a/packages/Tempest/tests/Application/ConsoleWriterCommandTest.php
+++ b/packages/Tempest/tests/Application/ConsoleWriterCommandTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Ecotone\Tempest\Application;
+
+use Test\Ecotone\Tempest\EcotoneIntegrationTestCase;
+
+/**
+ * licence Apache-2.0
+ * @internal
+ */
+final class ConsoleWriterCommandTest extends EcotoneIntegrationTestCase
+{
+    public function test_console_command_writes_formatted_output_through_tempest_console(): void
+    {
+        $this->console
+            ->call('console-writer:show', ['name' => 'orders'])
+            ->assertSuccess()
+            ->assertContains('Starting orders')
+            ->assertContains('Processed orders')
+            ->assertContains('Almost done orders')
+            ->assertContains('Failed orders')
+            ->assertContains('running')
+            ->assertContains('2/2');
+    }
+}

--- a/packages/Tempest/tests/Fixture/ConsoleWriter/ConsoleWriterCommand.php
+++ b/packages/Tempest/tests/Fixture/ConsoleWriter/ConsoleWriterCommand.php
@@ -12,7 +12,7 @@ use Ecotone\Messaging\Console\ConsoleWriter;
  */
 final class ConsoleWriterCommand
 {
-    #[ConsoleCommand('console-writer:show')]
+    #[ConsoleCommand('console-writer:show', 'Shows formatted console writer output')]
     public function execute(string $name, ConsoleWriter $writer): void
     {
         $writer->info('Starting ' . $name);

--- a/packages/Tempest/tests/Fixture/ConsoleWriter/ConsoleWriterCommand.php
+++ b/packages/Tempest/tests/Fixture/ConsoleWriter/ConsoleWriterCommand.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Ecotone\Tempest\Fixture\ConsoleWriter;
+
+use Ecotone\Messaging\Attribute\ConsoleCommand;
+use Ecotone\Messaging\Console\ConsoleWriter;
+
+/**
+ * licence Apache-2.0
+ */
+final class ConsoleWriterCommand
+{
+    #[ConsoleCommand('console-writer:show')]
+    public function execute(string $name, ConsoleWriter $writer): void
+    {
+        $writer->info('Starting ' . $name);
+        $writer->success('Processed ' . $name);
+        $writer->warning('Almost done ' . $name);
+        $writer->error('Failed ' . $name);
+        $writer->table(['Name', 'Status'], [[$name, 'running']]);
+
+        $progressBar = $writer->progressBar(2);
+        $progressBar->advance();
+        $progressBar->advance();
+        $progressBar->finish();
+    }
+}


### PR DESCRIPTION
## Why is this change proposed?

Ecotone console command handlers run behind a message channel and have no access to the console that invoked them. The only way to produce output was returning a `ConsoleCommandResultSet`, rendered as a table after the handler finished. Long-running commands could not report progress, and semantic feedback (success, warning, error) was impossible. Commands also appeared in `bin/console list` / `artisan list` / Tempest console without any description.

## Description of Changes

- New `ConsoleWriter` abstraction (`Ecotone\Messaging\Console`) injectable into `#[ConsoleCommand]` handlers by declaring a parameter — supports `write`/`writeln`, colored semantic messages (`info`, `success`, `warning`, `error`), `table` and `progressBar`.
- Each integration binds its native console: Symfony console and Laravel artisan share `SymfonyConsoleWriter` (ANSI colors, Table/ProgressBar helpers), Tempest gets `TempestConsoleWriter` on top of its own console API, Ecotone Lite falls back to plain STDOUT output. `InMemoryConsoleWriter` supports test assertions.
- `#[ConsoleCommand]` accepts an optional description shown in each framework's command listing; built-in `ecotone:*` commands (run, list, migrations, projections, dead letter, deduplication) now ship descriptions.
- `symfony/console` stays out of core requirements (require-dev + suggest only).

Usage:

```php
#[ConsoleCommand('app:import', 'Imports orders from a file')]
public function execute(string $file, ConsoleWriter $writer): void
{
    $writer->info('Importing ' . $file);

    $progressBar = $writer->progressBar(100);
    foreach ($this->orders($file) as $order) {
        $progressBar->advance();
    }
    $progressBar->finish();

    $writer->table(['File', 'Status'], [[$file, 'imported']]);
    $writer->success('Import finished');
}
```

```mermaid
graph TD
    A[Framework console command<br>Symfony / Artisan / Tempest proxy] --> B[DelegatingConsoleWriter<br>delegate swapped to native writer]
    B --> C[ConsoleCommandRunner gateway]
    C --> D[Message channel]
    D --> E["#[ConsoleCommand] handler<br>ConsoleWriter parameter injected"]
    E --> F[Native console output<br>colors, tables, progress]
```

## Pull Request Contribution Terms

- [X] I have read and agree to the contribution terms outlined in [CONTRIBUTING](https://github.com/ecotoneframework/ecotone-dev/blob/main/CONTRIBUTING.md).


