### PR TITLE
Fix scalar message header conversion to nullable enums

### DIFF
--- a/packages/Ecotone/src/Messaging/Conversion/ScalarToEnum/ScalarToEnumConverter.php
+++ b/packages/Ecotone/src/Messaging/Conversion/ScalarToEnum/ScalarToEnumConverter.php
@@ -19,6 +19,10 @@ class ScalarToEnumConverter implements Converter
      */
     public function convert($source, Type $sourceType, MediaType $sourceMediaType, Type $targetType, MediaType $targetMediaType)
     {
+        if ($targetType instanceof Type\UnionType) {
+            $targetType = $targetType->withoutNull();
+        }
+
         $ref = new ReflectionEnum($targetType->toString());
 
         if ($ref->isBacked()) {

--- a/packages/Ecotone/tests/Messaging/Unit/Handler/HeaderConversionTest.php
+++ b/packages/Ecotone/tests/Messaging/Unit/Handler/HeaderConversionTest.php
@@ -5,9 +5,11 @@ declare(strict_types=1);
 namespace Test\Ecotone\Messaging\Unit\Handler;
 
 use Ecotone\Lite\EcotoneLite;
+use Ecotone\Messaging\Attribute\Parameter\Header;
 use Ecotone\Messaging\Channel\SimpleMessageChannelBuilder;
 use Ecotone\Messaging\Config\ServiceConfiguration;
 use Ecotone\Messaging\Conversion\MediaType;
+use Ecotone\Modelling\Attribute\CommandHandler;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Ramsey\Uuid\Uuid;
@@ -104,6 +106,31 @@ final class HeaderConversionTest extends TestCase
         );
     }
 
+    public function test_converting_scalar_header_to_nullable_enum(): void
+    {
+        $handler = new class () {
+            public ?DeliveryMethod $deliveryMethod = null;
+
+            #[CommandHandler('withNullableEnumConversion', endpointId: 'withNullableEnumConversionEndpoint')]
+            public function handle(
+                #[Header('deliveryMethod')] ?DeliveryMethod $deliveryMethod = null
+            ): void {
+                $this->deliveryMethod = $deliveryMethod;
+            }
+        };
+
+        $ecotoneLite = EcotoneLite::bootstrapFlowTesting(
+            [$handler::class],
+            [$handler],
+        );
+
+        $ecotoneLite->sendCommandWithRoutingKey('withNullableEnumConversion', metadata: [
+            'deliveryMethod' => DeliveryMethod::Email->value,
+        ]);
+
+        self::assertSame(DeliveryMethod::Email, $handler->deliveryMethod);
+    }
+
     /**
      * This will change nothing, as it's used for payload, not header conversion.
      * However to be sure that it's not affecting header conversion, it's part of the test scenario
@@ -119,4 +146,9 @@ final class HeaderConversionTest extends TestCase
                 ->withDefaultSerializationMediaType(MediaType::APPLICATION_JSON),
         ];
     }
+}
+
+enum DeliveryMethod: string
+{
+    case Email = 'email';
 }


### PR DESCRIPTION
## Summary

Fix scalar message header conversion for nullable enum handler parameters.

## Problem

When a message handler declares a nullable enum header parameter:

```php
#[Header('deliveryMethod')]
?DeliveryMethod $deliveryMethod = null
```

Ecotone represents the target type as the `DeliveryMethod|null` union.

`ScalarToEnumConverter` correctly recognizes the target as an enum-compatible type, but then passes the complete union type string to `ReflectionEnum`. This results in the following error for a non-null scalar header value:

```text
Class "DeliveryMethod|null" does not exist
```

A missing header or a header with a `null` value is not affected because scalar-to-enum conversion is not required in that case.

## Fix

When the target is a union type, remove `null` before creating `ReflectionEnum` and converting the scalar value to the enum case.

## Commit Structure

1. Add a regression test that reproduces the failure without the fix.
2. Add the minimal fix to `ScalarToEnumConverter`.

## Verification

Before the fix, the regression test fails with:

```text
Class "DeliveryMethod|null" does not exist
```

After the fix:

```text
OK (1 test, 1 assertion)
```

The existing Core test suite also passes.

## Pull Request Contribution Terms

- [X] I have read and agree to the contribution terms outlined in [CONTRIBUTING](https://github.com/ecotoneframework/ecotone-dev/blob/main/CONTRIBUTING.md).