### PR TITLE
fix: support pre-release tags in release pipeline and keep PR benchmarks under 10 minutes

### DIFF
--- a/.github/workflows/benchmark-pr.yml
+++ b/.github/workflows/benchmark-pr.yml
@@ -101,14 +101,29 @@ jobs:
         with:
           ref: main
 
+      - name: Resolve baseline cache key
+        id: baseline_key
+        run: echo "key=phpbench-baseline-$(git rev-parse HEAD)-${{ hashFiles('Monorepo/Benchmark/**', 'phpbench.json') }}" >> "$GITHUB_OUTPUT"
+
+      # Baseline results for a given main commit are identical across PRs, so they are benchmarked
+      # once and reused from cache to keep the workflow duration low
+      - name: Restore baseline benchmark results
+        id: baseline_cache
+        uses: actions/cache@v4
+        with:
+          path: .phpbench
+          key: ${{ steps.baseline_key.outputs.key }}
+
       - name: Install dependencies
+        if: steps.baseline_cache.outputs.cache-hit != 'true'
         run: composer update --${{ matrix.stability }} --prefer-dist --no-interaction --ignore-platform-reqs
 
       - name: Benchmark main as baseline
         id: baseline
+        if: steps.baseline_cache.outputs.cache-hit != 'true'
         continue-on-error: true
         run: |
-          vendor/bin/phpbench run --retry-threshold=5 --tag=main --report=github-report --profile=opcache_enabled
+          vendor/bin/phpbench run --tag=main --report=github-report --profile=opcache_enabled
 
       - uses: actions/checkout@v3
         with:
@@ -121,13 +136,17 @@ jobs:
       - name: Install dependencies
         run: composer update --${{ matrix.stability }} --prefer-dist --no-interaction --ignore-platform-reqs
 
+      - name: Check baseline availability
+        id: baseline_check
+        run: echo "available=$([ -d .phpbench/storage ] && echo true || echo false)" >> "$GITHUB_OUTPUT"
+
       - name: Benchmark PR
         shell: bash
         env:
-          PHPBENCH_REF_OPTION: "${{ steps.baseline.outcome == 'success' && '--ref=main' || '' }}"
+          PHPBENCH_REF_OPTION: "${{ steps.baseline_check.outputs.available == 'true' && '--ref=main' || '' }}"
         run: |
           echo "Baseline: $PHPBENCH_REF_OPTION"
-          vendor/bin/phpbench run --retry-threshold=5 --report=github-report --profile=opcache_enabled $PHPBENCH_REF_OPTION | bin/phpbench-to-md.sh > benchmark.md
+          vendor/bin/phpbench run --report=github-report --profile=opcache_enabled $PHPBENCH_REF_OPTION | bin/phpbench-to-md.sh > benchmark.md
           cat benchmark.md
           echo '## Benchmark' >> "$GITHUB_STEP_SUMMARY"
           cat benchmark.md >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/contribution-check.yml
+++ b/.github/workflows/contribution-check.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/github-script@v3
         with:
           script: |
-            const prBody = context.payload.pull_request.body;
-            if (!prBody.includes("[X] I have read and agree to the contribution terms")) {
-              core.setFailed("Contributor has not agreed to the contribution terms. Please mark the checkout with X to agree to the terms. `[X] I have read and agree to the contribution terms outlined in [CONTRIBUTING](https://github.com/ecotoneframework/ecotone-dev/blob/main/CONTRIBUTING.md)`");
+            const prBody = context.payload.pull_request.body || "";
+            if (!/\[\s*[xX]\s*\] I have read and agree to the contribution terms/.test(prBody)) {
+              core.setFailed("Contributor has not agreed to the contribution terms. Please mark the checkbox with x to agree to the terms. `[x] I have read and agree to the contribution terms outlined in [CONTRIBUTING](https://github.com/ecotoneframework/ecotone-dev/blob/main/CONTRIBUTING.md)`");
             }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,10 +50,10 @@ jobs:
 
       - name: Checkout branch related to tag
         run: |
-          raw=$(git branch -r --contains ${{ github.ref }})
+          raw=$(git branch -r --contains ${{ github.ref }} | head -n1)
           branch=${raw##*/}
           echo "checking out branch $branch for tag ${GITHUB_REF#refs/tags/}"
-          git checkout $branch
+          git checkout "$branch"
 
       - name: Install PHP-CS-Fixer
         run: |
@@ -160,11 +160,13 @@ jobs:
           fetch-depth: '0'
 
       - name: Checkout branch related to tag
+        id: release_branch
         run: |
-          raw=$(git branch -r --contains ${{ github.ref }})
+          raw=$(git branch -r --contains ${{ github.ref }} | head -n1)
           branch=${raw##*/}
           echo "checking out branch $branch for tag ${GITHUB_REF#refs/tags/}"
-          git checkout $branch
+          git checkout "$branch"
+          echo "name=$branch" >> "$GITHUB_OUTPUT"
 
       - name: Replace key.pem with ECOTONE_ENTERPRISE_PUBLIC_KEY
         if: ${{ matrix.package.name == 'ecotone' }}
@@ -175,10 +177,14 @@ jobs:
         run: php bin/strip-monorepo-repositories.php "${{ matrix.package.directory }}"
 
       -
-        uses: "danharrin/monorepo-split-github-action@v2.4.0"
+        uses: "danharrin/monorepo-split-github-action@v2.4.5"
         if: "startsWith(github.ref, 'refs/tags/')"
         with:
           tag: ${GITHUB_REF#refs/tags/}
+
+          # ↓ split commits land on the same branch the tag was created from,
+          # so stable releases from main and pre-releases from other branches do not overwrite each other
+          branch: '${{ steps.release_branch.outputs.name }}'
 
           # ↓ split "packages/easy-coding-standard" directory
           package_directory: '${{ matrix.package.directory }}'

--- a/Monorepo/Benchmark/DbConnectBenchmark.php
+++ b/Monorepo/Benchmark/DbConnectBenchmark.php
@@ -10,7 +10,7 @@ class DbConnectBenchmark
 {
     public function bench_db_connect(): void
     {
-        $connectionFactory = new DbalConnectionFactory('pgsql://ecotone:secret@localhost:5432/ecotone');
+        $connectionFactory = new DbalConnectionFactory(getenv('DATABASE_DSN') ?: 'pgsql://ecotone:secret@localhost:5432/ecotone');
         $connection = $connectionFactory->createContext()->getDbalConnection();
 
         $connection->executeQuery('SELECT 1');

--- a/Monorepo/Benchmark/HighThroughputPublishingBenchmark.php
+++ b/Monorepo/Benchmark/HighThroughputPublishingBenchmark.php
@@ -41,7 +41,7 @@ use PhpBench\Attributes\Warmup;
  * DBAL and Redis confirm deliveries synchronously as part of the send call itself (database statement result
  * and command reply respectively), so the asynchronous scenarios are not supported for them and are not benchmarked.
  */
-#[Warmup(0), Revs(1), Iterations(10)]
+#[Warmup(0), Revs(1), Iterations(2)]
 class HighThroughputPublishingBenchmark
 {
     private const AMOUNT_OF_PUBLISHED_MESSAGES = 1000;

--- a/Monorepo/Benchmark/OutboxRelayBenchmark.php
+++ b/Monorepo/Benchmark/OutboxRelayBenchmark.php
@@ -37,10 +37,10 @@ use PhpBench\Attributes\Warmup;
  * The in-memory target subjects isolate the producing side of the relay; the provider subjects show the full
  * path into real brokers receiving whole batches at once.
  */
-#[Warmup(0), Revs(1), Iterations(5)]
+#[Warmup(0), Revs(1), Iterations(2)]
 class OutboxRelayBenchmark
 {
-    private const AMOUNT_OF_RELAYED_MESSAGES = 10_000;
+    private const AMOUNT_OF_RELAYED_MESSAGES = 1_000;
 
     private const MESSAGE_PAYLOAD = 'benchmark order payload for outbox relay comparison';
 
@@ -126,25 +126,25 @@ class OutboxRelayBenchmark
         $this->drainWholeOutbox();
     }
 
-    #[BeforeMethods('setUpRelayBatchedIntoAmqpTarget'), Iterations(3)]
+    #[BeforeMethods('setUpRelayBatchedIntoAmqpTarget')]
     public function bench_dbal_outbox_drain_batched_into_rabbitmq_target(): void
     {
         $this->drainWholeOutbox();
     }
 
-    #[BeforeMethods('setUpRelayBatchedIntoKafkaTarget'), Iterations(3)]
+    #[BeforeMethods('setUpRelayBatchedIntoKafkaTarget')]
     public function bench_dbal_outbox_drain_batched_into_kafka_target(): void
     {
         $this->drainWholeOutbox();
     }
 
-    #[BeforeMethods('setUpRelayBatchedIntoRedisTarget'), Iterations(3)]
+    #[BeforeMethods('setUpRelayBatchedIntoRedisTarget')]
     public function bench_dbal_outbox_drain_batched_into_redis_target(): void
     {
         $this->drainWholeOutbox();
     }
 
-    #[BeforeMethods('setUpRelayBatchedIntoSqsTarget'), Iterations(3)]
+    #[BeforeMethods('setUpRelayBatchedIntoSqsTarget')]
     public function bench_dbal_outbox_drain_batched_into_sqs_target(): void
     {
         $this->drainWholeOutbox();

--- a/bin/update-required-packages.php
+++ b/bin/update-required-packages.php
@@ -7,6 +7,10 @@ $version = $argv[1];
 if (!$version) {
     throw new \InvalidArgumentException("Pass version to update branch alias");
 }
+if (!preg_match('/^(\d+)\.(\d+)\./', $version, $versionParts)) {
+    throw new \InvalidArgumentException("Version must be in format MAJOR.MINOR.PATCH with optional stability suffix, got: " . $version);
+}
+$branchAlias = $versionParts[1] . '.' . $versionParts[2] . '.x-dev';
 $packageNames = array_map(function ($package) {
     return $package['package'];
 }, $packages);
@@ -14,16 +18,16 @@ $packageNames = array_map(function ($package) {
 foreach ($packages as $package) {
     $composerFile = $package['directory'] . DIRECTORY_SEPARATOR . 'composer.json';
     $composer = json_decode(file_get_contents($composerFile), true);
-    $composer['extra']['branch-alias']['dev-main'] = $version . '-dev';
+    $composer['extra']['branch-alias']['dev-main'] = $branchAlias;
     $releaseTime = (new \DateTimeImmutable('now', new DateTimeZone('UTC')));
     $composer['extra']['release-time'] = $releaseTime->format('Y-m-d H:i:s');
 
-    foreach ($composer['require'] as $requiredPackage => $requiredVersion) {
+    foreach ($composer['require'] ?? [] as $requiredPackage => $requiredVersion) {
         if (in_array($requiredPackage, $packageNames)) {
             $composer['require'][$requiredPackage] = "~" . $version;
         }
     }
-    foreach ($composer['require-dev'] as $requiredPackage => $requiredVersion) {
+    foreach ($composer['require-dev'] ?? [] as $requiredPackage => $requiredVersion) {
         if (in_array($requiredPackage, $packageNames)) {
             $composer['require-dev'][$requiredPackage] = '~' . $version;
         }


### PR DESCRIPTION
## Why is this change proposed?

Ecotone 2.0 will be tested through beta tags (e.g. `2.0.0-beta.1`) released from a dedicated branch, and the release pipeline assumes every release is a stable tag cut from `main`:

- The branch alias written on release (`<tag>-dev`) sorts below a pre-release constraint like `~2.0.0-beta.1`, so split testing and per-package `composer install` would stop resolving the local monorepo packages and fail (verified with `composer update --dry-run`).
- The monorepo split action pushes every release to the read-only repositories' `main` branch, so a beta from a 2.0 branch and the next stable 1.x release would overwrite each other's content there.

Separately, the PR benchmark workflow grew from ~5 to ~50-70 minutes after the high throughput publishing and outbox relay benchmarks were added, making every PR wait on it.

## Description of Changes

**Release pipeline (pre-release support):**
- `bin/update-required-packages.php` writes the branch alias as `MAJOR.MINOR.x-dev` (e.g. `2.0.x-dev`), which satisfies both stable (`~1.326.0`) and pre-release (`~2.0.0-beta.1`) mutual constraints — verified for both flows end-to-end
- `release.yml` forwards the tag's source branch to the split action, so stable releases keep landing on the read-only repos' `main` while pre-releases land on a matching branch
- split action bumped v2.4.0 → v2.4.5 — older versions exit before reaching the create-missing-branch path

**PR benchmarks (~50-70 min → under 10):**
- removed `--retry-threshold=5`: it re-runs any iteration deviating ≥5% from the variant mean in an unbounded loop, and broker-bound subjects have 15-30% natural variance
- `Iterations(2)` for the two new benchmark classes; publishing scenarios keep 1000 messages per iteration, outbox relay works on 1000 messages (forwarding batch size is 100, so the message-by-message vs batched vs single-batch contrast is preserved: measured 4.8s vs 0.2s)
- baseline results for a given `main` commit are cached and reused across PR runs, so the typical run benchmarks only the PR side
- `DbConnectBenchmark` respects `DATABASE_DSN` (previously hardcoded localhost and failed in containerized environments)
- contribution terms check accepts the lowercase `x` GitHub writes when the checkbox is ticked through the UI

Measured full suite: ~3 minutes per pass, was ~25-35. Note: the first run after this merges still benchmarks the old heavy suite as baseline once (~30 min), then the cache takes over.

## Pull Request Contribution Terms

- [x] I have read and agree to the contribution terms outlined in [CONTRIBUTING](https://github.com/ecotoneframework/ecotone-dev/blob/main/CONTRIBUTING.md).
