### PR TITLE
fix: skip skills split, Discord, and tweet announcements on pre-release tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -178,7 +178,8 @@ jobs:
 
       -
         uses: "danharrin/monorepo-split-github-action@v2.4.5"
-        if: "startsWith(github.ref, 'refs/tags/')"
+        # ↓ skills marketplace is only published on stable releases (tag has no '-' pre-release suffix)
+        if: "startsWith(github.ref, 'refs/tags/') && !(matrix.package.name == 'skills' && contains(github.ref_name, '-'))"
         with:
           tag: ${GITHUB_REF#refs/tags/}
 
@@ -200,6 +201,8 @@ jobs:
   tweet:
     runs-on: ubuntu-latest
     needs: discord-notification
+    # ↓ only announce stable releases (tag has no '-' pre-release suffix)
+    if: "!contains(github.ref_name, '-')"
     steps:
       - uses: Eomm/why-don-t-you-tweet@v1
         with:
@@ -214,6 +217,8 @@ jobs:
   discord-notification:
     runs-on: ubuntu-latest
     needs: split_packages
+    # ↓ only announce stable releases (tag has no '-' pre-release suffix)
+    if: "!contains(github.ref_name, '-')"
     steps:
       - uses: actions/checkout@v4
         with:

--- a/bin/strip-monorepo-repositories.php
+++ b/bin/strip-monorepo-repositories.php
@@ -33,6 +33,24 @@ foreach ($iterator as $file) {
         unset($composer['repositories']);
     }
 
+    // Require entries aliasing a local path package (e.g. "dev-main as 1.999.999") only make
+    // sense while the path repository above is present; without it they'd force installs from
+    // an unstable dev branch instead of the published release the package otherwise resolves to.
+    foreach (['require', 'require-dev'] as $section) {
+        if (!isset($composer[$section])) {
+            continue;
+        }
+
+        $composer[$section] = array_filter(
+            $composer[$section],
+            fn ($constraint) => !str_starts_with($constraint, 'dev-main as ')
+        );
+
+        if (empty($composer[$section])) {
+            unset($composer[$section]);
+        }
+    }
+
     file_put_contents(
         $path,
         json_encode($composer, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE) . "\n"

--- a/bin/strip-monorepo-repositories.php
+++ b/bin/strip-monorepo-repositories.php
@@ -33,24 +33,6 @@ foreach ($iterator as $file) {
         unset($composer['repositories']);
     }
 
-    // Require entries aliasing a local path package (e.g. "dev-main as 1.999.999") only make
-    // sense while the path repository above is present; without it they'd force installs from
-    // an unstable dev branch instead of the published release the package otherwise resolves to.
-    foreach (['require', 'require-dev'] as $section) {
-        if (!isset($composer[$section])) {
-            continue;
-        }
-
-        $composer[$section] = array_filter(
-            $composer[$section],
-            fn ($constraint) => !str_starts_with($constraint, 'dev-main as ')
-        );
-
-        if (empty($composer[$section])) {
-            unset($composer[$section]);
-        }
-    }
-
     file_put_contents(
         $path,
         json_encode($composer, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE) . "\n"

--- a/bin/update-required-packages.php
+++ b/bin/update-required-packages.php
@@ -35,3 +35,37 @@ foreach ($packages as $package) {
 
     file_put_contents($composerFile, json_encode($composer, JSON_PRETTY_PRINT|JSON_UNESCAPED_SLASHES));
 }
+
+// Quickstart examples alias local packages to the path repository ("dev-main as $version") so
+// they resolve against the monorepo's own code instead of Packagist while testing a branch; keep
+// that alias in sync with whatever gets released, same as the sibling package requires above.
+$quickstartDirectory = realpath(__DIR__ . '/../quickstart-examples');
+$iterator = new RecursiveIteratorIterator(
+    new RecursiveCallbackFilterIterator(
+        new RecursiveDirectoryIterator($quickstartDirectory, RecursiveDirectoryIterator::SKIP_DOTS),
+        fn ($current) => $current->getFilename() !== 'vendor'
+    )
+);
+
+foreach ($iterator as $file) {
+    if ($file->getFilename() !== 'composer.json') {
+        continue;
+    }
+
+    $path = $file->getPathname();
+    $composer = json_decode(file_get_contents($path), true);
+    $touched = false;
+
+    foreach (['require', 'require-dev'] as $section) {
+        foreach ($composer[$section] ?? [] as $requiredPackage => $constraint) {
+            if (str_starts_with($constraint, 'dev-main as ')) {
+                $composer[$section][$requiredPackage] = 'dev-main as ' . $version;
+                $touched = true;
+            }
+        }
+    }
+
+    if ($touched) {
+        file_put_contents($path, json_encode($composer, JSON_PRETTY_PRINT|JSON_UNESCAPED_SLASHES) . "\n");
+    }
+}

--- a/bin/update-required-packages.php
+++ b/bin/update-required-packages.php
@@ -36,9 +36,9 @@ foreach ($packages as $package) {
     file_put_contents($composerFile, json_encode($composer, JSON_PRETTY_PRINT|JSON_UNESCAPED_SLASHES));
 }
 
-// Quickstart examples alias local packages to the path repository ("dev-main as $version") so
-// they resolve against the monorepo's own code instead of Packagist while testing a branch; keep
-// that alias in sync with whatever gets released, same as the sibling package requires above.
+// Quickstart examples directly require some local packages (see bin/get-packages) so their tests
+// resolve them from the path repository instead of Packagist; keep those requirements pinned to
+// "~$version" in sync with whatever gets released, same as the sibling package requires above.
 $quickstartDirectory = realpath(__DIR__ . '/../quickstart-examples');
 $iterator = new RecursiveIteratorIterator(
     new RecursiveCallbackFilterIterator(
@@ -57,9 +57,9 @@ foreach ($iterator as $file) {
     $touched = false;
 
     foreach (['require', 'require-dev'] as $section) {
-        foreach ($composer[$section] ?? [] as $requiredPackage => $constraint) {
-            if (str_starts_with($constraint, 'dev-main as ')) {
-                $composer[$section][$requiredPackage] = 'dev-main as ' . $version;
+        foreach ($composer[$section] ?? [] as $requiredPackage => $requiredVersion) {
+            if (in_array($requiredPackage, $packageNames)) {
+                $composer[$section][$requiredPackage] = '~' . $version;
                 $touched = true;
             }
         }

--- a/quickstart-examples/Asynchronous/composer.json
+++ b/quickstart-examples/Asynchronous/composer.json
@@ -22,10 +22,10 @@
         }
     },
     "require": {
-        "ecotone/amqp": "dev-main as 1.999.999",
-        "ecotone/jms-converter": "dev-main as 1.999.999",
+        "ecotone/amqp": "dev-main as 1.326.1",
+        "ecotone/jms-converter": "dev-main as 1.326.1",
         "ecotone/lite-amqp-starter": "^1.0.1",
-        "ecotone/lite-application": "dev-main as 1.999.999"
+        "ecotone/lite-application": "dev-main as 1.326.1"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.6|^10.5|^11.0"

--- a/quickstart-examples/Asynchronous/composer.json
+++ b/quickstart-examples/Asynchronous/composer.json
@@ -22,10 +22,10 @@
         }
     },
     "require": {
-        "ecotone/amqp": "dev-main as 1.326.1",
-        "ecotone/jms-converter": "dev-main as 1.326.1",
+        "ecotone/amqp": "~1.326.1",
+        "ecotone/jms-converter": "~1.326.1",
         "ecotone/lite-amqp-starter": "^1.0.1",
-        "ecotone/lite-application": "dev-main as 1.326.1"
+        "ecotone/lite-application": "~1.326.1"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.6|^10.5|^11.0"

--- a/quickstart-examples/Asynchronous/composer.json
+++ b/quickstart-examples/Asynchronous/composer.json
@@ -22,7 +22,10 @@
         }
     },
     "require": {
-        "ecotone/lite-amqp-starter": "^1.0.1"
+        "ecotone/amqp": "dev-main as 1.999.999",
+        "ecotone/jms-converter": "dev-main as 1.999.999",
+        "ecotone/lite-amqp-starter": "^1.0.1",
+        "ecotone/lite-application": "dev-main as 1.999.999"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.6|^10.5|^11.0"

--- a/quickstart-examples/Asynchronous/composer.json
+++ b/quickstart-examples/Asynchronous/composer.json
@@ -22,10 +22,7 @@
         }
     },
     "require": {
-        "ecotone/amqp": "dev-main as 1.999.999",
-        "ecotone/jms-converter": "dev-main as 1.999.999",
-        "ecotone/lite-amqp-starter": "^1.0.1",
-        "ecotone/lite-application": "dev-main as 1.999.999"
+        "ecotone/lite-amqp-starter": "^1.0.1"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.6|^10.5|^11.0"

--- a/quickstart-examples/AuthoritativeClassmap/composer.json
+++ b/quickstart-examples/AuthoritativeClassmap/composer.json
@@ -25,10 +25,7 @@
         ]
     },
     "require": {
-        "ecotone/amqp": "dev-main as 1.999.999",
-        "ecotone/jms-converter": "dev-main as 1.999.999",
-        "ecotone/lite-amqp-starter": "^1.0.1",
-        "ecotone/lite-application": "dev-main as 1.999.999"
+        "ecotone/lite-amqp-starter": "^1.0.1"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.6|^10.5|^11.0"

--- a/quickstart-examples/AuthoritativeClassmap/composer.json
+++ b/quickstart-examples/AuthoritativeClassmap/composer.json
@@ -25,10 +25,10 @@
         ]
     },
     "require": {
-        "ecotone/amqp": "dev-main as 1.326.1",
-        "ecotone/jms-converter": "dev-main as 1.326.1",
+        "ecotone/amqp": "~1.326.1",
+        "ecotone/jms-converter": "~1.326.1",
         "ecotone/lite-amqp-starter": "^1.0.1",
-        "ecotone/lite-application": "dev-main as 1.326.1"
+        "ecotone/lite-application": "~1.326.1"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.6|^10.5|^11.0"

--- a/quickstart-examples/AuthoritativeClassmap/composer.json
+++ b/quickstart-examples/AuthoritativeClassmap/composer.json
@@ -25,7 +25,10 @@
         ]
     },
     "require": {
-        "ecotone/lite-amqp-starter": "^1.0.1"
+        "ecotone/amqp": "dev-main as 1.999.999",
+        "ecotone/jms-converter": "dev-main as 1.999.999",
+        "ecotone/lite-amqp-starter": "^1.0.1",
+        "ecotone/lite-application": "dev-main as 1.999.999"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.6|^10.5|^11.0"

--- a/quickstart-examples/AuthoritativeClassmap/composer.json
+++ b/quickstart-examples/AuthoritativeClassmap/composer.json
@@ -25,10 +25,10 @@
         ]
     },
     "require": {
-        "ecotone/amqp": "dev-main as 1.999.999",
-        "ecotone/jms-converter": "dev-main as 1.999.999",
+        "ecotone/amqp": "dev-main as 1.326.1",
+        "ecotone/jms-converter": "dev-main as 1.326.1",
         "ecotone/lite-amqp-starter": "^1.0.1",
-        "ecotone/lite-application": "dev-main as 1.999.999"
+        "ecotone/lite-application": "dev-main as 1.326.1"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.6|^10.5|^11.0"

--- a/quickstart-examples/BuildingBlocks/composer.json
+++ b/quickstart-examples/BuildingBlocks/composer.json
@@ -28,11 +28,11 @@
     },
     "require": {
         "beberlei/assert": "^3.3.2",
-        "ecotone/jms-converter": "dev-main as 1.326.1",
-        "ecotone/lite-application": "dev-main as 1.326.1",
+        "ecotone/jms-converter": "~1.326.1",
+        "ecotone/lite-application": "~1.326.1",
         "ecotone/lite-application-starter": "^1.0.1",
         "ecotone/lite-event-sourcing-starter": "^1.0",
-        "ecotone/pdo-event-sourcing": "dev-main as 1.326.1",
+        "ecotone/pdo-event-sourcing": "~1.326.1",
         "moneyphp/money": "^4.1.0",
         "ramsey/uuid": "^4.0"
     },

--- a/quickstart-examples/BuildingBlocks/composer.json
+++ b/quickstart-examples/BuildingBlocks/composer.json
@@ -28,8 +28,11 @@
     },
     "require": {
         "beberlei/assert": "^3.3.2",
+        "ecotone/jms-converter": "dev-main as 1.999.999",
+        "ecotone/lite-application": "dev-main as 1.999.999",
         "ecotone/lite-application-starter": "^1.0.1",
         "ecotone/lite-event-sourcing-starter": "^1.0",
+        "ecotone/pdo-event-sourcing": "dev-main as 1.999.999",
         "moneyphp/money": "^4.1.0",
         "ramsey/uuid": "^4.0"
     },

--- a/quickstart-examples/BuildingBlocks/composer.json
+++ b/quickstart-examples/BuildingBlocks/composer.json
@@ -28,11 +28,11 @@
     },
     "require": {
         "beberlei/assert": "^3.3.2",
-        "ecotone/jms-converter": "dev-main as 1.999.999",
-        "ecotone/lite-application": "dev-main as 1.999.999",
+        "ecotone/jms-converter": "dev-main as 1.326.1",
+        "ecotone/lite-application": "dev-main as 1.326.1",
         "ecotone/lite-application-starter": "^1.0.1",
         "ecotone/lite-event-sourcing-starter": "^1.0",
-        "ecotone/pdo-event-sourcing": "dev-main as 1.999.999",
+        "ecotone/pdo-event-sourcing": "dev-main as 1.326.1",
         "moneyphp/money": "^4.1.0",
         "ramsey/uuid": "^4.0"
     },

--- a/quickstart-examples/BuildingBlocks/composer.json
+++ b/quickstart-examples/BuildingBlocks/composer.json
@@ -28,11 +28,8 @@
     },
     "require": {
         "beberlei/assert": "^3.3.2",
-        "ecotone/jms-converter": "dev-main as 1.999.999",
-        "ecotone/lite-application": "dev-main as 1.999.999",
         "ecotone/lite-application-starter": "^1.0.1",
         "ecotone/lite-event-sourcing-starter": "^1.0",
-        "ecotone/pdo-event-sourcing": "dev-main as 1.999.999",
         "moneyphp/money": "^4.1.0",
         "ramsey/uuid": "^4.0"
     },

--- a/quickstart-examples/BusinessInterface/Asynchronous/composer.json
+++ b/quickstart-examples/BusinessInterface/Asynchronous/composer.json
@@ -22,9 +22,6 @@
         }
     },
     "require": {
-        "ecotone/dbal": "dev-main as 1.999.999",
-        "ecotone/jms-converter": "dev-main as 1.999.999",
-        "ecotone/lite-application": "dev-main as 1.999.999",
         "ecotone/lite-dbal-starter": "^1.0.1",
         "ramsey/uuid": "^4.0"
     },

--- a/quickstart-examples/BusinessInterface/Asynchronous/composer.json
+++ b/quickstart-examples/BusinessInterface/Asynchronous/composer.json
@@ -22,9 +22,9 @@
         }
     },
     "require": {
-        "ecotone/dbal": "dev-main as 1.999.999",
-        "ecotone/jms-converter": "dev-main as 1.999.999",
-        "ecotone/lite-application": "dev-main as 1.999.999",
+        "ecotone/dbal": "dev-main as 1.326.1",
+        "ecotone/jms-converter": "dev-main as 1.326.1",
+        "ecotone/lite-application": "dev-main as 1.326.1",
         "ecotone/lite-dbal-starter": "^1.0.1",
         "ramsey/uuid": "^4.0"
     },

--- a/quickstart-examples/BusinessInterface/Asynchronous/composer.json
+++ b/quickstart-examples/BusinessInterface/Asynchronous/composer.json
@@ -22,6 +22,9 @@
         }
     },
     "require": {
+        "ecotone/dbal": "dev-main as 1.999.999",
+        "ecotone/jms-converter": "dev-main as 1.999.999",
+        "ecotone/lite-application": "dev-main as 1.999.999",
         "ecotone/lite-dbal-starter": "^1.0.1",
         "ramsey/uuid": "^4.0"
     },

--- a/quickstart-examples/BusinessInterface/Asynchronous/composer.json
+++ b/quickstart-examples/BusinessInterface/Asynchronous/composer.json
@@ -22,9 +22,9 @@
         }
     },
     "require": {
-        "ecotone/dbal": "dev-main as 1.326.1",
-        "ecotone/jms-converter": "dev-main as 1.326.1",
-        "ecotone/lite-application": "dev-main as 1.326.1",
+        "ecotone/dbal": "~1.326.1",
+        "ecotone/jms-converter": "~1.326.1",
+        "ecotone/lite-application": "~1.326.1",
         "ecotone/lite-dbal-starter": "^1.0.1",
         "ramsey/uuid": "^4.0"
     },

--- a/quickstart-examples/BusinessInterface/Routing/composer.json
+++ b/quickstart-examples/BusinessInterface/Routing/composer.json
@@ -22,9 +22,6 @@
         }
     },
     "require": {
-        "ecotone/dbal": "dev-main as 1.999.999",
-        "ecotone/jms-converter": "dev-main as 1.999.999",
-        "ecotone/lite-application": "dev-main as 1.999.999",
         "ecotone/lite-dbal-starter": "^1.0.1",
         "ramsey/uuid": "^4.0"
     },

--- a/quickstart-examples/BusinessInterface/Routing/composer.json
+++ b/quickstart-examples/BusinessInterface/Routing/composer.json
@@ -22,9 +22,9 @@
         }
     },
     "require": {
-        "ecotone/dbal": "dev-main as 1.999.999",
-        "ecotone/jms-converter": "dev-main as 1.999.999",
-        "ecotone/lite-application": "dev-main as 1.999.999",
+        "ecotone/dbal": "dev-main as 1.326.1",
+        "ecotone/jms-converter": "dev-main as 1.326.1",
+        "ecotone/lite-application": "dev-main as 1.326.1",
         "ecotone/lite-dbal-starter": "^1.0.1",
         "ramsey/uuid": "^4.0"
     },

--- a/quickstart-examples/BusinessInterface/Routing/composer.json
+++ b/quickstart-examples/BusinessInterface/Routing/composer.json
@@ -22,6 +22,9 @@
         }
     },
     "require": {
+        "ecotone/dbal": "dev-main as 1.999.999",
+        "ecotone/jms-converter": "dev-main as 1.999.999",
+        "ecotone/lite-application": "dev-main as 1.999.999",
         "ecotone/lite-dbal-starter": "^1.0.1",
         "ramsey/uuid": "^4.0"
     },

--- a/quickstart-examples/BusinessInterface/Routing/composer.json
+++ b/quickstart-examples/BusinessInterface/Routing/composer.json
@@ -22,9 +22,9 @@
         }
     },
     "require": {
-        "ecotone/dbal": "dev-main as 1.326.1",
-        "ecotone/jms-converter": "dev-main as 1.326.1",
-        "ecotone/lite-application": "dev-main as 1.326.1",
+        "ecotone/dbal": "~1.326.1",
+        "ecotone/jms-converter": "~1.326.1",
+        "ecotone/lite-application": "~1.326.1",
         "ecotone/lite-dbal-starter": "^1.0.1",
         "ramsey/uuid": "^4.0"
     },

--- a/quickstart-examples/BusinessInterface/ServiceActivator/composer.json
+++ b/quickstart-examples/BusinessInterface/ServiceActivator/composer.json
@@ -22,9 +22,6 @@
         }
     },
     "require": {
-        "ecotone/dbal": "dev-main as 1.999.999",
-        "ecotone/jms-converter": "dev-main as 1.999.999",
-        "ecotone/lite-application": "dev-main as 1.999.999",
         "ecotone/lite-dbal-starter": "^1.0.1",
         "ramsey/uuid": "^4.0"
     },

--- a/quickstart-examples/BusinessInterface/ServiceActivator/composer.json
+++ b/quickstart-examples/BusinessInterface/ServiceActivator/composer.json
@@ -22,9 +22,9 @@
         }
     },
     "require": {
-        "ecotone/dbal": "dev-main as 1.999.999",
-        "ecotone/jms-converter": "dev-main as 1.999.999",
-        "ecotone/lite-application": "dev-main as 1.999.999",
+        "ecotone/dbal": "dev-main as 1.326.1",
+        "ecotone/jms-converter": "dev-main as 1.326.1",
+        "ecotone/lite-application": "dev-main as 1.326.1",
         "ecotone/lite-dbal-starter": "^1.0.1",
         "ramsey/uuid": "^4.0"
     },

--- a/quickstart-examples/BusinessInterface/ServiceActivator/composer.json
+++ b/quickstart-examples/BusinessInterface/ServiceActivator/composer.json
@@ -22,6 +22,9 @@
         }
     },
     "require": {
+        "ecotone/dbal": "dev-main as 1.999.999",
+        "ecotone/jms-converter": "dev-main as 1.999.999",
+        "ecotone/lite-application": "dev-main as 1.999.999",
         "ecotone/lite-dbal-starter": "^1.0.1",
         "ramsey/uuid": "^4.0"
     },

--- a/quickstart-examples/BusinessInterface/ServiceActivator/composer.json
+++ b/quickstart-examples/BusinessInterface/ServiceActivator/composer.json
@@ -22,9 +22,9 @@
         }
     },
     "require": {
-        "ecotone/dbal": "dev-main as 1.326.1",
-        "ecotone/jms-converter": "dev-main as 1.326.1",
-        "ecotone/lite-application": "dev-main as 1.326.1",
+        "ecotone/dbal": "~1.326.1",
+        "ecotone/jms-converter": "~1.326.1",
+        "ecotone/lite-application": "~1.326.1",
         "ecotone/lite-dbal-starter": "^1.0.1",
         "ramsey/uuid": "^4.0"
     },

--- a/quickstart-examples/CQRS/composer.json
+++ b/quickstart-examples/CQRS/composer.json
@@ -22,8 +22,8 @@
         }
     },
     "require": {
-        "ecotone/jms-converter": "dev-main as 1.326.1",
-        "ecotone/lite-application": "dev-main as 1.326.1",
+        "ecotone/jms-converter": "~1.326.1",
+        "ecotone/lite-application": "~1.326.1",
         "ecotone/lite-application-starter": "^1.0.1"
     },
     "require-dev": {

--- a/quickstart-examples/CQRS/composer.json
+++ b/quickstart-examples/CQRS/composer.json
@@ -22,6 +22,8 @@
         }
     },
     "require": {
+        "ecotone/jms-converter": "dev-main as 1.999.999",
+        "ecotone/lite-application": "dev-main as 1.999.999",
         "ecotone/lite-application-starter": "^1.0.1"
     },
     "require-dev": {

--- a/quickstart-examples/CQRS/composer.json
+++ b/quickstart-examples/CQRS/composer.json
@@ -22,8 +22,8 @@
         }
     },
     "require": {
-        "ecotone/jms-converter": "dev-main as 1.999.999",
-        "ecotone/lite-application": "dev-main as 1.999.999",
+        "ecotone/jms-converter": "dev-main as 1.326.1",
+        "ecotone/lite-application": "dev-main as 1.326.1",
         "ecotone/lite-application-starter": "^1.0.1"
     },
     "require-dev": {

--- a/quickstart-examples/CQRS/composer.json
+++ b/quickstart-examples/CQRS/composer.json
@@ -22,8 +22,6 @@
         }
     },
     "require": {
-        "ecotone/jms-converter": "dev-main as 1.999.999",
-        "ecotone/lite-application": "dev-main as 1.999.999",
         "ecotone/lite-application-starter": "^1.0.1"
     },
     "require-dev": {

--- a/quickstart-examples/ConsoleCommand/Laravel/composer.json
+++ b/quickstart-examples/ConsoleCommand/Laravel/composer.json
@@ -22,7 +22,11 @@
         }
     },
     "require": {
+        "ecotone/dbal": "dev-main as 1.999.999",
+        "ecotone/jms-converter": "dev-main as 1.999.999",
+        "ecotone/laravel": "dev-main as 1.999.999",
         "ecotone/laravel-starter": "^1.1.0",
+        "ecotone/lite-application": "dev-main as 1.999.999",
         "ecotone/lite-dbal-starter": "^1.0.1",
         "laravel/laravel": "^12.0"
     },

--- a/quickstart-examples/ConsoleCommand/Laravel/composer.json
+++ b/quickstart-examples/ConsoleCommand/Laravel/composer.json
@@ -22,11 +22,11 @@
         }
     },
     "require": {
-        "ecotone/dbal": "dev-main as 1.999.999",
-        "ecotone/jms-converter": "dev-main as 1.999.999",
-        "ecotone/laravel": "dev-main as 1.999.999",
+        "ecotone/dbal": "dev-main as 1.326.1",
+        "ecotone/jms-converter": "dev-main as 1.326.1",
+        "ecotone/laravel": "dev-main as 1.326.1",
         "ecotone/laravel-starter": "^1.1.0",
-        "ecotone/lite-application": "dev-main as 1.999.999",
+        "ecotone/lite-application": "dev-main as 1.326.1",
         "ecotone/lite-dbal-starter": "^1.0.1",
         "laravel/laravel": "^12.0"
     },

--- a/quickstart-examples/ConsoleCommand/Laravel/composer.json
+++ b/quickstart-examples/ConsoleCommand/Laravel/composer.json
@@ -22,11 +22,11 @@
         }
     },
     "require": {
-        "ecotone/dbal": "dev-main as 1.326.1",
-        "ecotone/jms-converter": "dev-main as 1.326.1",
-        "ecotone/laravel": "dev-main as 1.326.1",
+        "ecotone/dbal": "~1.326.1",
+        "ecotone/jms-converter": "~1.326.1",
+        "ecotone/laravel": "~1.326.1",
         "ecotone/laravel-starter": "^1.1.0",
-        "ecotone/lite-application": "dev-main as 1.326.1",
+        "ecotone/lite-application": "~1.326.1",
         "ecotone/lite-dbal-starter": "^1.0.1",
         "laravel/laravel": "^12.0"
     },

--- a/quickstart-examples/ConsoleCommand/Laravel/composer.json
+++ b/quickstart-examples/ConsoleCommand/Laravel/composer.json
@@ -22,11 +22,7 @@
         }
     },
     "require": {
-        "ecotone/dbal": "dev-main as 1.999.999",
-        "ecotone/jms-converter": "dev-main as 1.999.999",
-        "ecotone/laravel": "dev-main as 1.999.999",
         "ecotone/laravel-starter": "^1.1.0",
-        "ecotone/lite-application": "dev-main as 1.999.999",
         "ecotone/lite-dbal-starter": "^1.0.1",
         "laravel/laravel": "^12.0"
     },

--- a/quickstart-examples/ConsoleCommand/Symfony/composer.json
+++ b/quickstart-examples/ConsoleCommand/Symfony/composer.json
@@ -22,6 +22,9 @@
         }
     },
     "require": {
+        "ecotone/dbal": "dev-main as 1.999.999",
+        "ecotone/jms-converter": "dev-main as 1.999.999",
+        "ecotone/symfony-bundle": "dev-main as 1.999.999",
         "ecotone/symfony-starter": "^1.1.0",
         "symfony/orm-pack": "^2.4",
         "symfony/yaml": "^6.4|^7.0|^8.0"

--- a/quickstart-examples/ConsoleCommand/Symfony/composer.json
+++ b/quickstart-examples/ConsoleCommand/Symfony/composer.json
@@ -22,9 +22,9 @@
         }
     },
     "require": {
-        "ecotone/dbal": "dev-main as 1.326.1",
-        "ecotone/jms-converter": "dev-main as 1.326.1",
-        "ecotone/symfony-bundle": "dev-main as 1.326.1",
+        "ecotone/dbal": "~1.326.1",
+        "ecotone/jms-converter": "~1.326.1",
+        "ecotone/symfony-bundle": "~1.326.1",
         "ecotone/symfony-starter": "^1.1.0",
         "symfony/orm-pack": "^2.4",
         "symfony/yaml": "^6.4|^7.0|^8.0"

--- a/quickstart-examples/ConsoleCommand/Symfony/composer.json
+++ b/quickstart-examples/ConsoleCommand/Symfony/composer.json
@@ -22,9 +22,9 @@
         }
     },
     "require": {
-        "ecotone/dbal": "dev-main as 1.999.999",
-        "ecotone/jms-converter": "dev-main as 1.999.999",
-        "ecotone/symfony-bundle": "dev-main as 1.999.999",
+        "ecotone/dbal": "dev-main as 1.326.1",
+        "ecotone/jms-converter": "dev-main as 1.326.1",
+        "ecotone/symfony-bundle": "dev-main as 1.326.1",
         "ecotone/symfony-starter": "^1.1.0",
         "symfony/orm-pack": "^2.4",
         "symfony/yaml": "^6.4|^7.0|^8.0"

--- a/quickstart-examples/ConsoleCommand/Symfony/composer.json
+++ b/quickstart-examples/ConsoleCommand/Symfony/composer.json
@@ -22,9 +22,6 @@
         }
     },
     "require": {
-        "ecotone/dbal": "dev-main as 1.999.999",
-        "ecotone/jms-converter": "dev-main as 1.999.999",
-        "ecotone/symfony-bundle": "dev-main as 1.999.999",
         "ecotone/symfony-starter": "^1.1.0",
         "symfony/orm-pack": "^2.4",
         "symfony/yaml": "^6.4|^7.0|^8.0"

--- a/quickstart-examples/Conversion/composer.json
+++ b/quickstart-examples/Conversion/composer.json
@@ -22,8 +22,8 @@
         }
     },
     "require": {
-        "ecotone/jms-converter": "dev-main as 1.999.999",
-        "ecotone/lite-application": "dev-main as 1.999.999",
+        "ecotone/jms-converter": "dev-main as 1.326.1",
+        "ecotone/lite-application": "dev-main as 1.326.1",
         "ecotone/lite-application-starter": "^1.0.1",
         "ramsey/uuid": "^4.0"
     },

--- a/quickstart-examples/Conversion/composer.json
+++ b/quickstart-examples/Conversion/composer.json
@@ -22,8 +22,6 @@
         }
     },
     "require": {
-        "ecotone/jms-converter": "dev-main as 1.999.999",
-        "ecotone/lite-application": "dev-main as 1.999.999",
         "ecotone/lite-application-starter": "^1.0.1",
         "ramsey/uuid": "^4.0"
     },

--- a/quickstart-examples/Conversion/composer.json
+++ b/quickstart-examples/Conversion/composer.json
@@ -22,6 +22,8 @@
         }
     },
     "require": {
+        "ecotone/jms-converter": "dev-main as 1.999.999",
+        "ecotone/lite-application": "dev-main as 1.999.999",
         "ecotone/lite-application-starter": "^1.0.1",
         "ramsey/uuid": "^4.0"
     },

--- a/quickstart-examples/Conversion/composer.json
+++ b/quickstart-examples/Conversion/composer.json
@@ -22,8 +22,8 @@
         }
     },
     "require": {
-        "ecotone/jms-converter": "dev-main as 1.326.1",
-        "ecotone/lite-application": "dev-main as 1.326.1",
+        "ecotone/jms-converter": "~1.326.1",
+        "ecotone/lite-application": "~1.326.1",
         "ecotone/lite-application-starter": "^1.0.1",
         "ramsey/uuid": "^4.0"
     },

--- a/quickstart-examples/EmittingEventsFromProjection/composer.json
+++ b/quickstart-examples/EmittingEventsFromProjection/composer.json
@@ -22,10 +22,10 @@
         }
     },
     "require": {
-        "ecotone/jms-converter": "dev-main as 1.999.999",
-        "ecotone/lite-application": "dev-main as 1.999.999",
+        "ecotone/jms-converter": "dev-main as 1.326.1",
+        "ecotone/lite-application": "dev-main as 1.326.1",
         "ecotone/lite-event-sourcing-starter": "^1.0",
-        "ecotone/pdo-event-sourcing": "dev-main as 1.999.999",
+        "ecotone/pdo-event-sourcing": "dev-main as 1.326.1",
         "ramsey/uuid": "^4.0"
     },
     "require-dev": {

--- a/quickstart-examples/EmittingEventsFromProjection/composer.json
+++ b/quickstart-examples/EmittingEventsFromProjection/composer.json
@@ -22,10 +22,10 @@
         }
     },
     "require": {
-        "ecotone/jms-converter": "dev-main as 1.326.1",
-        "ecotone/lite-application": "dev-main as 1.326.1",
+        "ecotone/jms-converter": "~1.326.1",
+        "ecotone/lite-application": "~1.326.1",
         "ecotone/lite-event-sourcing-starter": "^1.0",
-        "ecotone/pdo-event-sourcing": "dev-main as 1.326.1",
+        "ecotone/pdo-event-sourcing": "~1.326.1",
         "ramsey/uuid": "^4.0"
     },
     "require-dev": {

--- a/quickstart-examples/EmittingEventsFromProjection/composer.json
+++ b/quickstart-examples/EmittingEventsFromProjection/composer.json
@@ -22,10 +22,7 @@
         }
     },
     "require": {
-        "ecotone/jms-converter": "dev-main as 1.999.999",
-        "ecotone/lite-application": "dev-main as 1.999.999",
         "ecotone/lite-event-sourcing-starter": "^1.0",
-        "ecotone/pdo-event-sourcing": "dev-main as 1.999.999",
         "ramsey/uuid": "^4.0"
     },
     "require-dev": {

--- a/quickstart-examples/EmittingEventsFromProjection/composer.json
+++ b/quickstart-examples/EmittingEventsFromProjection/composer.json
@@ -22,7 +22,10 @@
         }
     },
     "require": {
+        "ecotone/jms-converter": "dev-main as 1.999.999",
+        "ecotone/lite-application": "dev-main as 1.999.999",
         "ecotone/lite-event-sourcing-starter": "^1.0",
+        "ecotone/pdo-event-sourcing": "dev-main as 1.999.999",
         "ramsey/uuid": "^4.0"
     },
     "require-dev": {

--- a/quickstart-examples/ErrorHandling/composer.json
+++ b/quickstart-examples/ErrorHandling/composer.json
@@ -21,11 +21,7 @@
         }
     },
     "require": {
-        "ecotone/amqp": "dev-main as 1.999.999",
-        "ecotone/dbal": "dev-main as 1.999.999",
-        "ecotone/jms-converter": "dev-main as 1.999.999",
         "ecotone/lite-amqp-starter": "^1.0.1",
-        "ecotone/lite-application": "dev-main as 1.999.999",
         "ecotone/lite-dbal-starter": "^1.0.1",
         "ramsey/uuid": "^4.0"
     },

--- a/quickstart-examples/ErrorHandling/composer.json
+++ b/quickstart-examples/ErrorHandling/composer.json
@@ -21,11 +21,11 @@
         }
     },
     "require": {
-        "ecotone/amqp": "dev-main as 1.999.999",
-        "ecotone/dbal": "dev-main as 1.999.999",
-        "ecotone/jms-converter": "dev-main as 1.999.999",
+        "ecotone/amqp": "dev-main as 1.326.1",
+        "ecotone/dbal": "dev-main as 1.326.1",
+        "ecotone/jms-converter": "dev-main as 1.326.1",
         "ecotone/lite-amqp-starter": "^1.0.1",
-        "ecotone/lite-application": "dev-main as 1.999.999",
+        "ecotone/lite-application": "dev-main as 1.326.1",
         "ecotone/lite-dbal-starter": "^1.0.1",
         "ramsey/uuid": "^4.0"
     },

--- a/quickstart-examples/ErrorHandling/composer.json
+++ b/quickstart-examples/ErrorHandling/composer.json
@@ -21,11 +21,11 @@
         }
     },
     "require": {
-        "ecotone/amqp": "dev-main as 1.326.1",
-        "ecotone/dbal": "dev-main as 1.326.1",
-        "ecotone/jms-converter": "dev-main as 1.326.1",
+        "ecotone/amqp": "~1.326.1",
+        "ecotone/dbal": "~1.326.1",
+        "ecotone/jms-converter": "~1.326.1",
         "ecotone/lite-amqp-starter": "^1.0.1",
-        "ecotone/lite-application": "dev-main as 1.326.1",
+        "ecotone/lite-application": "~1.326.1",
         "ecotone/lite-dbal-starter": "^1.0.1",
         "ramsey/uuid": "^4.0"
     },

--- a/quickstart-examples/ErrorHandling/composer.json
+++ b/quickstart-examples/ErrorHandling/composer.json
@@ -21,7 +21,11 @@
         }
     },
     "require": {
+        "ecotone/amqp": "dev-main as 1.999.999",
+        "ecotone/dbal": "dev-main as 1.999.999",
+        "ecotone/jms-converter": "dev-main as 1.999.999",
         "ecotone/lite-amqp-starter": "^1.0.1",
+        "ecotone/lite-application": "dev-main as 1.999.999",
         "ecotone/lite-dbal-starter": "^1.0.1",
         "ramsey/uuid": "^4.0"
     },

--- a/quickstart-examples/EventHandling/composer.json
+++ b/quickstart-examples/EventHandling/composer.json
@@ -22,8 +22,8 @@
         }
     },
     "require": {
-        "ecotone/jms-converter": "dev-main as 1.326.1",
-        "ecotone/lite-application": "dev-main as 1.326.1",
+        "ecotone/jms-converter": "~1.326.1",
+        "ecotone/lite-application": "~1.326.1",
         "ecotone/lite-application-starter": "^1.0.1"
     },
     "require-dev": {

--- a/quickstart-examples/EventHandling/composer.json
+++ b/quickstart-examples/EventHandling/composer.json
@@ -22,6 +22,8 @@
         }
     },
     "require": {
+        "ecotone/jms-converter": "dev-main as 1.999.999",
+        "ecotone/lite-application": "dev-main as 1.999.999",
         "ecotone/lite-application-starter": "^1.0.1"
     },
     "require-dev": {

--- a/quickstart-examples/EventHandling/composer.json
+++ b/quickstart-examples/EventHandling/composer.json
@@ -22,8 +22,8 @@
         }
     },
     "require": {
-        "ecotone/jms-converter": "dev-main as 1.999.999",
-        "ecotone/lite-application": "dev-main as 1.999.999",
+        "ecotone/jms-converter": "dev-main as 1.326.1",
+        "ecotone/lite-application": "dev-main as 1.326.1",
         "ecotone/lite-application-starter": "^1.0.1"
     },
     "require-dev": {

--- a/quickstart-examples/EventHandling/composer.json
+++ b/quickstart-examples/EventHandling/composer.json
@@ -22,8 +22,6 @@
         }
     },
     "require": {
-        "ecotone/jms-converter": "dev-main as 1.999.999",
-        "ecotone/lite-application": "dev-main as 1.999.999",
         "ecotone/lite-application-starter": "^1.0.1"
     },
     "require-dev": {

--- a/quickstart-examples/EventProjecting/PartitionedProjection/composer.json
+++ b/quickstart-examples/EventProjecting/PartitionedProjection/composer.json
@@ -22,11 +22,11 @@
         }
     },
     "require": {
-        "ecotone/dbal": "dev-main as 1.326.1",
-        "ecotone/jms-converter": "dev-main as 1.326.1",
-        "ecotone/lite-application": "dev-main as 1.326.1",
+        "ecotone/dbal": "~1.326.1",
+        "ecotone/jms-converter": "~1.326.1",
+        "ecotone/lite-application": "~1.326.1",
         "ecotone/lite-event-sourcing-starter": "^1.0",
-        "ecotone/pdo-event-sourcing": "dev-main as 1.326.1",
+        "ecotone/pdo-event-sourcing": "~1.326.1",
         "ramsey/uuid": "^4.0"
     },
     "require-dev": {

--- a/quickstart-examples/EventProjecting/PartitionedProjection/composer.json
+++ b/quickstart-examples/EventProjecting/PartitionedProjection/composer.json
@@ -22,11 +22,11 @@
         }
     },
     "require": {
-        "ecotone/dbal": "dev-main as 1.999.999",
-        "ecotone/jms-converter": "dev-main as 1.999.999",
-        "ecotone/lite-application": "dev-main as 1.999.999",
+        "ecotone/dbal": "dev-main as 1.326.1",
+        "ecotone/jms-converter": "dev-main as 1.326.1",
+        "ecotone/lite-application": "dev-main as 1.326.1",
         "ecotone/lite-event-sourcing-starter": "^1.0",
-        "ecotone/pdo-event-sourcing": "dev-main as 1.999.999",
+        "ecotone/pdo-event-sourcing": "dev-main as 1.326.1",
         "ramsey/uuid": "^4.0"
     },
     "require-dev": {

--- a/quickstart-examples/EventProjecting/PartitionedProjection/composer.json
+++ b/quickstart-examples/EventProjecting/PartitionedProjection/composer.json
@@ -22,8 +22,11 @@
         }
     },
     "require": {
+        "ecotone/dbal": "dev-main as 1.999.999",
+        "ecotone/jms-converter": "dev-main as 1.999.999",
+        "ecotone/lite-application": "dev-main as 1.999.999",
         "ecotone/lite-event-sourcing-starter": "^1.0",
-        "ecotone/dbal": "^1.0",
+        "ecotone/pdo-event-sourcing": "dev-main as 1.999.999",
         "ramsey/uuid": "^4.0"
     },
     "require-dev": {

--- a/quickstart-examples/EventProjecting/PartitionedProjection/composer.json
+++ b/quickstart-examples/EventProjecting/PartitionedProjection/composer.json
@@ -22,11 +22,8 @@
         }
     },
     "require": {
-        "ecotone/dbal": "dev-main as 1.999.999",
-        "ecotone/jms-converter": "dev-main as 1.999.999",
-        "ecotone/lite-application": "dev-main as 1.999.999",
         "ecotone/lite-event-sourcing-starter": "^1.0",
-        "ecotone/pdo-event-sourcing": "dev-main as 1.999.999",
+        "ecotone/dbal": "^1.0",
         "ramsey/uuid": "^4.0"
     },
     "require-dev": {

--- a/quickstart-examples/EventSourcing/composer.json
+++ b/quickstart-examples/EventSourcing/composer.json
@@ -22,10 +22,10 @@
         }
     },
     "require": {
-        "ecotone/jms-converter": "dev-main as 1.999.999",
-        "ecotone/lite-application": "dev-main as 1.999.999",
+        "ecotone/jms-converter": "dev-main as 1.326.1",
+        "ecotone/lite-application": "dev-main as 1.326.1",
         "ecotone/lite-event-sourcing-starter": "^1.0",
-        "ecotone/pdo-event-sourcing": "dev-main as 1.999.999"
+        "ecotone/pdo-event-sourcing": "dev-main as 1.326.1"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.6|^10.5|^11.0"

--- a/quickstart-examples/EventSourcing/composer.json
+++ b/quickstart-examples/EventSourcing/composer.json
@@ -22,10 +22,7 @@
         }
     },
     "require": {
-        "ecotone/jms-converter": "dev-main as 1.999.999",
-        "ecotone/lite-application": "dev-main as 1.999.999",
-        "ecotone/lite-event-sourcing-starter": "^1.0",
-        "ecotone/pdo-event-sourcing": "dev-main as 1.999.999"
+        "ecotone/lite-event-sourcing-starter": "^1.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.6|^10.5|^11.0"

--- a/quickstart-examples/EventSourcing/composer.json
+++ b/quickstart-examples/EventSourcing/composer.json
@@ -22,10 +22,10 @@
         }
     },
     "require": {
-        "ecotone/jms-converter": "dev-main as 1.326.1",
-        "ecotone/lite-application": "dev-main as 1.326.1",
+        "ecotone/jms-converter": "~1.326.1",
+        "ecotone/lite-application": "~1.326.1",
         "ecotone/lite-event-sourcing-starter": "^1.0",
-        "ecotone/pdo-event-sourcing": "dev-main as 1.326.1"
+        "ecotone/pdo-event-sourcing": "~1.326.1"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.6|^10.5|^11.0"

--- a/quickstart-examples/EventSourcing/composer.json
+++ b/quickstart-examples/EventSourcing/composer.json
@@ -22,7 +22,10 @@
         }
     },
     "require": {
-        "ecotone/lite-event-sourcing-starter": "^1.0"
+        "ecotone/jms-converter": "dev-main as 1.999.999",
+        "ecotone/lite-application": "dev-main as 1.999.999",
+        "ecotone/lite-event-sourcing-starter": "^1.0",
+        "ecotone/pdo-event-sourcing": "dev-main as 1.999.999"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.6|^10.5|^11.0"

--- a/quickstart-examples/Laravel/Projection/DatabaseReadModel/composer.json
+++ b/quickstart-examples/Laravel/Projection/DatabaseReadModel/composer.json
@@ -22,13 +22,8 @@
         }
     },
     "require": {
-        "ecotone/dbal": "dev-main as 1.999.999",
-        "ecotone/jms-converter": "dev-main as 1.999.999",
-        "ecotone/laravel": "dev-main as 1.999.999",
         "ecotone/laravel-starter": "^1.1.0",
-        "ecotone/lite-application": "dev-main as 1.999.999",
         "ecotone/lite-event-sourcing-starter": "^1.0",
-        "ecotone/pdo-event-sourcing": "dev-main as 1.999.999",
         "laravel/laravel": "^10.0",
         "ramsey/uuid": "^4.0"
     },

--- a/quickstart-examples/Laravel/Projection/DatabaseReadModel/composer.json
+++ b/quickstart-examples/Laravel/Projection/DatabaseReadModel/composer.json
@@ -22,13 +22,13 @@
         }
     },
     "require": {
-        "ecotone/dbal": "dev-main as 1.326.1",
-        "ecotone/jms-converter": "dev-main as 1.326.1",
-        "ecotone/laravel": "dev-main as 1.326.1",
+        "ecotone/dbal": "~1.326.1",
+        "ecotone/jms-converter": "~1.326.1",
+        "ecotone/laravel": "~1.326.1",
         "ecotone/laravel-starter": "^1.1.0",
-        "ecotone/lite-application": "dev-main as 1.326.1",
+        "ecotone/lite-application": "~1.326.1",
         "ecotone/lite-event-sourcing-starter": "^1.0",
-        "ecotone/pdo-event-sourcing": "dev-main as 1.326.1",
+        "ecotone/pdo-event-sourcing": "~1.326.1",
         "laravel/laravel": "^10.0",
         "ramsey/uuid": "^4.0"
     },

--- a/quickstart-examples/Laravel/Projection/DatabaseReadModel/composer.json
+++ b/quickstart-examples/Laravel/Projection/DatabaseReadModel/composer.json
@@ -22,13 +22,13 @@
         }
     },
     "require": {
-        "ecotone/dbal": "dev-main as 1.999.999",
-        "ecotone/jms-converter": "dev-main as 1.999.999",
-        "ecotone/laravel": "dev-main as 1.999.999",
+        "ecotone/dbal": "dev-main as 1.326.1",
+        "ecotone/jms-converter": "dev-main as 1.326.1",
+        "ecotone/laravel": "dev-main as 1.326.1",
         "ecotone/laravel-starter": "^1.1.0",
-        "ecotone/lite-application": "dev-main as 1.999.999",
+        "ecotone/lite-application": "dev-main as 1.326.1",
         "ecotone/lite-event-sourcing-starter": "^1.0",
-        "ecotone/pdo-event-sourcing": "dev-main as 1.999.999",
+        "ecotone/pdo-event-sourcing": "dev-main as 1.326.1",
         "laravel/laravel": "^10.0",
         "ramsey/uuid": "^4.0"
     },

--- a/quickstart-examples/Laravel/Projection/DatabaseReadModel/composer.json
+++ b/quickstart-examples/Laravel/Projection/DatabaseReadModel/composer.json
@@ -22,8 +22,13 @@
         }
     },
     "require": {
+        "ecotone/dbal": "dev-main as 1.999.999",
+        "ecotone/jms-converter": "dev-main as 1.999.999",
+        "ecotone/laravel": "dev-main as 1.999.999",
         "ecotone/laravel-starter": "^1.1.0",
+        "ecotone/lite-application": "dev-main as 1.999.999",
         "ecotone/lite-event-sourcing-starter": "^1.0",
+        "ecotone/pdo-event-sourcing": "dev-main as 1.999.999",
         "laravel/laravel": "^10.0",
         "ramsey/uuid": "^4.0"
     },

--- a/quickstart-examples/Laravel/Projection/EloquentReadModel/composer.json
+++ b/quickstart-examples/Laravel/Projection/EloquentReadModel/composer.json
@@ -22,13 +22,13 @@
         }
     },
     "require": {
-        "ecotone/dbal": "dev-main as 1.326.1",
-        "ecotone/jms-converter": "dev-main as 1.326.1",
-        "ecotone/laravel": "dev-main as 1.326.1",
+        "ecotone/dbal": "~1.326.1",
+        "ecotone/jms-converter": "~1.326.1",
+        "ecotone/laravel": "~1.326.1",
         "ecotone/laravel-starter": "^1.1.0",
-        "ecotone/lite-application": "dev-main as 1.326.1",
+        "ecotone/lite-application": "~1.326.1",
         "ecotone/lite-event-sourcing-starter": "^1.0",
-        "ecotone/pdo-event-sourcing": "dev-main as 1.326.1",
+        "ecotone/pdo-event-sourcing": "~1.326.1",
         "laravel/laravel": "^10.0",
         "ramsey/uuid": "^4.0",
         "symfony/expression-language": "^8.0"

--- a/quickstart-examples/Laravel/Projection/EloquentReadModel/composer.json
+++ b/quickstart-examples/Laravel/Projection/EloquentReadModel/composer.json
@@ -22,13 +22,8 @@
         }
     },
     "require": {
-        "ecotone/dbal": "dev-main as 1.999.999",
-        "ecotone/jms-converter": "dev-main as 1.999.999",
-        "ecotone/laravel": "dev-main as 1.999.999",
         "ecotone/laravel-starter": "^1.1.0",
-        "ecotone/lite-application": "dev-main as 1.999.999",
         "ecotone/lite-event-sourcing-starter": "^1.0",
-        "ecotone/pdo-event-sourcing": "dev-main as 1.999.999",
         "laravel/laravel": "^10.0",
         "ramsey/uuid": "^4.0",
         "symfony/expression-language": "^8.0"

--- a/quickstart-examples/Laravel/Projection/EloquentReadModel/composer.json
+++ b/quickstart-examples/Laravel/Projection/EloquentReadModel/composer.json
@@ -22,8 +22,13 @@
         }
     },
     "require": {
+        "ecotone/dbal": "dev-main as 1.999.999",
+        "ecotone/jms-converter": "dev-main as 1.999.999",
+        "ecotone/laravel": "dev-main as 1.999.999",
         "ecotone/laravel-starter": "^1.1.0",
+        "ecotone/lite-application": "dev-main as 1.999.999",
         "ecotone/lite-event-sourcing-starter": "^1.0",
+        "ecotone/pdo-event-sourcing": "dev-main as 1.999.999",
         "laravel/laravel": "^10.0",
         "ramsey/uuid": "^4.0",
         "symfony/expression-language": "^8.0"

--- a/quickstart-examples/Laravel/Projection/EloquentReadModel/composer.json
+++ b/quickstart-examples/Laravel/Projection/EloquentReadModel/composer.json
@@ -22,13 +22,13 @@
         }
     },
     "require": {
-        "ecotone/dbal": "dev-main as 1.999.999",
-        "ecotone/jms-converter": "dev-main as 1.999.999",
-        "ecotone/laravel": "dev-main as 1.999.999",
+        "ecotone/dbal": "dev-main as 1.326.1",
+        "ecotone/jms-converter": "dev-main as 1.326.1",
+        "ecotone/laravel": "dev-main as 1.326.1",
         "ecotone/laravel-starter": "^1.1.0",
-        "ecotone/lite-application": "dev-main as 1.999.999",
+        "ecotone/lite-application": "dev-main as 1.326.1",
         "ecotone/lite-event-sourcing-starter": "^1.0",
-        "ecotone/pdo-event-sourcing": "dev-main as 1.999.999",
+        "ecotone/pdo-event-sourcing": "dev-main as 1.326.1",
         "laravel/laravel": "^10.0",
         "ramsey/uuid": "^4.0",
         "symfony/expression-language": "^8.0"

--- a/quickstart-examples/MessageBroker/composer.json
+++ b/quickstart-examples/MessageBroker/composer.json
@@ -17,10 +17,10 @@
         }
     ],
     "require": {
-        "ecotone/amqp": "dev-main as 1.326.1",
-        "ecotone/jms-converter": "dev-main as 1.326.1",
+        "ecotone/amqp": "~1.326.1",
+        "ecotone/jms-converter": "~1.326.1",
         "ecotone/lite-amqp-starter": "^1.0.1",
-        "ecotone/lite-application": "dev-main as 1.326.1",
+        "ecotone/lite-application": "~1.326.1",
         "ramsey/uuid": "^4.0"
     },
     "require-dev": {

--- a/quickstart-examples/MessageBroker/composer.json
+++ b/quickstart-examples/MessageBroker/composer.json
@@ -17,10 +17,10 @@
         }
     ],
     "require": {
-        "ecotone/amqp": "dev-main as 1.999.999",
-        "ecotone/jms-converter": "dev-main as 1.999.999",
+        "ecotone/amqp": "dev-main as 1.326.1",
+        "ecotone/jms-converter": "dev-main as 1.326.1",
         "ecotone/lite-amqp-starter": "^1.0.1",
-        "ecotone/lite-application": "dev-main as 1.999.999",
+        "ecotone/lite-application": "dev-main as 1.326.1",
         "ramsey/uuid": "^4.0"
     },
     "require-dev": {

--- a/quickstart-examples/MessageBroker/composer.json
+++ b/quickstart-examples/MessageBroker/composer.json
@@ -17,7 +17,10 @@
         }
     ],
     "require": {
+        "ecotone/amqp": "dev-main as 1.999.999",
+        "ecotone/jms-converter": "dev-main as 1.999.999",
         "ecotone/lite-amqp-starter": "^1.0.1",
+        "ecotone/lite-application": "dev-main as 1.999.999",
         "ramsey/uuid": "^4.0"
     },
     "require-dev": {

--- a/quickstart-examples/MessageBroker/composer.json
+++ b/quickstart-examples/MessageBroker/composer.json
@@ -17,10 +17,7 @@
         }
     ],
     "require": {
-        "ecotone/amqp": "dev-main as 1.999.999",
-        "ecotone/jms-converter": "dev-main as 1.999.999",
         "ecotone/lite-amqp-starter": "^1.0.1",
-        "ecotone/lite-application": "dev-main as 1.999.999",
         "ramsey/uuid": "^4.0"
     },
     "require-dev": {

--- a/quickstart-examples/Microservices/composer.json
+++ b/quickstart-examples/Microservices/composer.json
@@ -22,10 +22,10 @@
         }
     },
     "require": {
-        "ecotone/amqp": "dev-main as 1.999.999",
-        "ecotone/jms-converter": "dev-main as 1.999.999",
+        "ecotone/amqp": "dev-main as 1.326.1",
+        "ecotone/jms-converter": "dev-main as 1.326.1",
         "ecotone/lite-amqp-starter": "^1.0.1",
-        "ecotone/lite-application": "dev-main as 1.999.999"
+        "ecotone/lite-application": "dev-main as 1.326.1"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.6|^10.5|^11.0"

--- a/quickstart-examples/Microservices/composer.json
+++ b/quickstart-examples/Microservices/composer.json
@@ -22,10 +22,10 @@
         }
     },
     "require": {
-        "ecotone/amqp": "dev-main as 1.326.1",
-        "ecotone/jms-converter": "dev-main as 1.326.1",
+        "ecotone/amqp": "~1.326.1",
+        "ecotone/jms-converter": "~1.326.1",
         "ecotone/lite-amqp-starter": "^1.0.1",
-        "ecotone/lite-application": "dev-main as 1.326.1"
+        "ecotone/lite-application": "~1.326.1"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.6|^10.5|^11.0"

--- a/quickstart-examples/Microservices/composer.json
+++ b/quickstart-examples/Microservices/composer.json
@@ -22,7 +22,10 @@
         }
     },
     "require": {
-        "ecotone/lite-amqp-starter": "^1.0.1"
+        "ecotone/amqp": "dev-main as 1.999.999",
+        "ecotone/jms-converter": "dev-main as 1.999.999",
+        "ecotone/lite-amqp-starter": "^1.0.1",
+        "ecotone/lite-application": "dev-main as 1.999.999"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.6|^10.5|^11.0"

--- a/quickstart-examples/Microservices/composer.json
+++ b/quickstart-examples/Microservices/composer.json
@@ -22,10 +22,7 @@
         }
     },
     "require": {
-        "ecotone/amqp": "dev-main as 1.999.999",
-        "ecotone/jms-converter": "dev-main as 1.999.999",
-        "ecotone/lite-amqp-starter": "^1.0.1",
-        "ecotone/lite-application": "dev-main as 1.999.999"
+        "ecotone/lite-amqp-starter": "^1.0.1"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.6|^10.5|^11.0"

--- a/quickstart-examples/MicroservicesAdvanced/composer.json
+++ b/quickstart-examples/MicroservicesAdvanced/composer.json
@@ -23,8 +23,12 @@
         }
     },
     "require": {
+        "ecotone/amqp": "dev-main as 1.999.999",
+        "ecotone/jms-converter": "dev-main as 1.999.999",
         "ecotone/lite-amqp-starter": "^1.0.1",
+        "ecotone/lite-application": "dev-main as 1.999.999",
         "ecotone/lite-event-sourcing-starter": "^1.0",
+        "ecotone/pdo-event-sourcing": "dev-main as 1.999.999",
         "ramsey/uuid": "^4.0"
     },
     "require-dev": {

--- a/quickstart-examples/MicroservicesAdvanced/composer.json
+++ b/quickstart-examples/MicroservicesAdvanced/composer.json
@@ -23,12 +23,12 @@
         }
     },
     "require": {
-        "ecotone/amqp": "dev-main as 1.999.999",
-        "ecotone/jms-converter": "dev-main as 1.999.999",
+        "ecotone/amqp": "dev-main as 1.326.1",
+        "ecotone/jms-converter": "dev-main as 1.326.1",
         "ecotone/lite-amqp-starter": "^1.0.1",
-        "ecotone/lite-application": "dev-main as 1.999.999",
+        "ecotone/lite-application": "dev-main as 1.326.1",
         "ecotone/lite-event-sourcing-starter": "^1.0",
-        "ecotone/pdo-event-sourcing": "dev-main as 1.999.999",
+        "ecotone/pdo-event-sourcing": "dev-main as 1.326.1",
         "ramsey/uuid": "^4.0"
     },
     "require-dev": {

--- a/quickstart-examples/MicroservicesAdvanced/composer.json
+++ b/quickstart-examples/MicroservicesAdvanced/composer.json
@@ -23,12 +23,8 @@
         }
     },
     "require": {
-        "ecotone/amqp": "dev-main as 1.999.999",
-        "ecotone/jms-converter": "dev-main as 1.999.999",
         "ecotone/lite-amqp-starter": "^1.0.1",
-        "ecotone/lite-application": "dev-main as 1.999.999",
         "ecotone/lite-event-sourcing-starter": "^1.0",
-        "ecotone/pdo-event-sourcing": "dev-main as 1.999.999",
         "ramsey/uuid": "^4.0"
     },
     "require-dev": {

--- a/quickstart-examples/MicroservicesAdvanced/composer.json
+++ b/quickstart-examples/MicroservicesAdvanced/composer.json
@@ -23,12 +23,12 @@
         }
     },
     "require": {
-        "ecotone/amqp": "dev-main as 1.326.1",
-        "ecotone/jms-converter": "dev-main as 1.326.1",
+        "ecotone/amqp": "~1.326.1",
+        "ecotone/jms-converter": "~1.326.1",
         "ecotone/lite-amqp-starter": "^1.0.1",
-        "ecotone/lite-application": "dev-main as 1.326.1",
+        "ecotone/lite-application": "~1.326.1",
         "ecotone/lite-event-sourcing-starter": "^1.0",
-        "ecotone/pdo-event-sourcing": "dev-main as 1.326.1",
+        "ecotone/pdo-event-sourcing": "~1.326.1",
         "ramsey/uuid": "^4.0"
     },
     "require-dev": {

--- a/quickstart-examples/MultiTenant/General/HookIntoTenantSwitch/composer.json
+++ b/quickstart-examples/MultiTenant/General/HookIntoTenantSwitch/composer.json
@@ -24,9 +24,9 @@
     "require": {
         "doctrine/orm": "^3.3",
         "doctrine/persistence": "^4.0",
-        "ecotone/dbal": "dev-main as 1.326.1",
-        "ecotone/jms-converter": "dev-main as 1.326.1",
-        "ecotone/lite-application": "dev-main as 1.326.1",
+        "ecotone/dbal": "~1.326.1",
+        "ecotone/jms-converter": "~1.326.1",
+        "ecotone/lite-application": "~1.326.1",
         "ecotone/lite-dbal-starter": "^1.0.1"
     },
     "require-dev": {

--- a/quickstart-examples/MultiTenant/General/HookIntoTenantSwitch/composer.json
+++ b/quickstart-examples/MultiTenant/General/HookIntoTenantSwitch/composer.json
@@ -24,9 +24,9 @@
     "require": {
         "doctrine/orm": "^3.3",
         "doctrine/persistence": "^4.0",
-        "ecotone/dbal": "dev-main as 1.999.999",
-        "ecotone/jms-converter": "dev-main as 1.999.999",
-        "ecotone/lite-application": "dev-main as 1.999.999",
+        "ecotone/dbal": "dev-main as 1.326.1",
+        "ecotone/jms-converter": "dev-main as 1.326.1",
+        "ecotone/lite-application": "dev-main as 1.326.1",
         "ecotone/lite-dbal-starter": "^1.0.1"
     },
     "require-dev": {

--- a/quickstart-examples/MultiTenant/General/HookIntoTenantSwitch/composer.json
+++ b/quickstart-examples/MultiTenant/General/HookIntoTenantSwitch/composer.json
@@ -24,9 +24,6 @@
     "require": {
         "doctrine/orm": "^3.3",
         "doctrine/persistence": "^4.0",
-        "ecotone/dbal": "dev-main as 1.999.999",
-        "ecotone/jms-converter": "dev-main as 1.999.999",
-        "ecotone/lite-application": "dev-main as 1.999.999",
         "ecotone/lite-dbal-starter": "^1.0.1"
     },
     "require-dev": {

--- a/quickstart-examples/MultiTenant/General/HookIntoTenantSwitch/composer.json
+++ b/quickstart-examples/MultiTenant/General/HookIntoTenantSwitch/composer.json
@@ -24,6 +24,9 @@
     "require": {
         "doctrine/orm": "^3.3",
         "doctrine/persistence": "^4.0",
+        "ecotone/dbal": "dev-main as 1.999.999",
+        "ecotone/jms-converter": "dev-main as 1.999.999",
+        "ecotone/lite-application": "dev-main as 1.999.999",
         "ecotone/lite-dbal-starter": "^1.0.1"
     },
     "require-dev": {

--- a/quickstart-examples/MultiTenant/General/MessageBusForMultipleTenants/composer.json
+++ b/quickstart-examples/MultiTenant/General/MessageBusForMultipleTenants/composer.json
@@ -23,9 +23,9 @@
     },
     "require": {
         "doctrine/orm": "^3.3",
-        "ecotone/dbal": "dev-main as 1.326.1",
-        "ecotone/jms-converter": "dev-main as 1.326.1",
-        "ecotone/lite-application": "dev-main as 1.326.1",
+        "ecotone/dbal": "~1.326.1",
+        "ecotone/jms-converter": "~1.326.1",
+        "ecotone/lite-application": "~1.326.1",
         "ecotone/lite-dbal-starter": "^1.0.1"
     },
     "require-dev": {

--- a/quickstart-examples/MultiTenant/General/MessageBusForMultipleTenants/composer.json
+++ b/quickstart-examples/MultiTenant/General/MessageBusForMultipleTenants/composer.json
@@ -23,6 +23,9 @@
     },
     "require": {
         "doctrine/orm": "^3.3",
+        "ecotone/dbal": "dev-main as 1.999.999",
+        "ecotone/jms-converter": "dev-main as 1.999.999",
+        "ecotone/lite-application": "dev-main as 1.999.999",
         "ecotone/lite-dbal-starter": "^1.0.1"
     },
     "require-dev": {

--- a/quickstart-examples/MultiTenant/General/MessageBusForMultipleTenants/composer.json
+++ b/quickstart-examples/MultiTenant/General/MessageBusForMultipleTenants/composer.json
@@ -23,9 +23,6 @@
     },
     "require": {
         "doctrine/orm": "^3.3",
-        "ecotone/dbal": "dev-main as 1.999.999",
-        "ecotone/jms-converter": "dev-main as 1.999.999",
-        "ecotone/lite-application": "dev-main as 1.999.999",
         "ecotone/lite-dbal-starter": "^1.0.1"
     },
     "require-dev": {

--- a/quickstart-examples/MultiTenant/General/MessageBusForMultipleTenants/composer.json
+++ b/quickstart-examples/MultiTenant/General/MessageBusForMultipleTenants/composer.json
@@ -23,9 +23,9 @@
     },
     "require": {
         "doctrine/orm": "^3.3",
-        "ecotone/dbal": "dev-main as 1.999.999",
-        "ecotone/jms-converter": "dev-main as 1.999.999",
-        "ecotone/lite-application": "dev-main as 1.999.999",
+        "ecotone/dbal": "dev-main as 1.326.1",
+        "ecotone/jms-converter": "dev-main as 1.326.1",
+        "ecotone/lite-application": "dev-main as 1.326.1",
         "ecotone/lite-dbal-starter": "^1.0.1"
     },
     "require-dev": {

--- a/quickstart-examples/MultiTenant/Laravel/Aggregate/composer.json
+++ b/quickstart-examples/MultiTenant/Laravel/Aggregate/composer.json
@@ -22,9 +22,6 @@
         }
     },
     "require": {
-        "ecotone/dbal": "dev-main as 1.999.999",
-        "ecotone/jms-converter": "dev-main as 1.999.999",
-        "ecotone/laravel": "dev-main as 1.999.999",
         "ecotone/laravel-starter": "^1.1.0",
         "laravel/laravel": "^10.0"
     },

--- a/quickstart-examples/MultiTenant/Laravel/Aggregate/composer.json
+++ b/quickstart-examples/MultiTenant/Laravel/Aggregate/composer.json
@@ -22,6 +22,9 @@
         }
     },
     "require": {
+        "ecotone/dbal": "dev-main as 1.999.999",
+        "ecotone/jms-converter": "dev-main as 1.999.999",
+        "ecotone/laravel": "dev-main as 1.999.999",
         "ecotone/laravel-starter": "^1.1.0",
         "laravel/laravel": "^10.0"
     },

--- a/quickstart-examples/MultiTenant/Laravel/Aggregate/composer.json
+++ b/quickstart-examples/MultiTenant/Laravel/Aggregate/composer.json
@@ -22,9 +22,9 @@
         }
     },
     "require": {
-        "ecotone/dbal": "dev-main as 1.999.999",
-        "ecotone/jms-converter": "dev-main as 1.999.999",
-        "ecotone/laravel": "dev-main as 1.999.999",
+        "ecotone/dbal": "dev-main as 1.326.1",
+        "ecotone/jms-converter": "dev-main as 1.326.1",
+        "ecotone/laravel": "dev-main as 1.326.1",
         "ecotone/laravel-starter": "^1.1.0",
         "laravel/laravel": "^10.0"
     },

--- a/quickstart-examples/MultiTenant/Laravel/Aggregate/composer.json
+++ b/quickstart-examples/MultiTenant/Laravel/Aggregate/composer.json
@@ -22,9 +22,9 @@
         }
     },
     "require": {
-        "ecotone/dbal": "dev-main as 1.326.1",
-        "ecotone/jms-converter": "dev-main as 1.326.1",
-        "ecotone/laravel": "dev-main as 1.326.1",
+        "ecotone/dbal": "~1.326.1",
+        "ecotone/jms-converter": "~1.326.1",
+        "ecotone/laravel": "~1.326.1",
         "ecotone/laravel-starter": "^1.1.0",
         "laravel/laravel": "^10.0"
     },

--- a/quickstart-examples/MultiTenant/Laravel/AsynchronousEvents/composer.json
+++ b/quickstart-examples/MultiTenant/Laravel/AsynchronousEvents/composer.json
@@ -22,11 +22,11 @@
         }
     },
     "require": {
-        "ecotone/dbal": "dev-main as 1.999.999",
-        "ecotone/jms-converter": "dev-main as 1.999.999",
-        "ecotone/laravel": "dev-main as 1.999.999",
+        "ecotone/dbal": "dev-main as 1.326.1",
+        "ecotone/jms-converter": "dev-main as 1.326.1",
+        "ecotone/laravel": "dev-main as 1.326.1",
         "ecotone/laravel-starter": "^1.1.0",
-        "ecotone/lite-application": "dev-main as 1.999.999",
+        "ecotone/lite-application": "dev-main as 1.326.1",
         "ecotone/lite-dbal-starter": "^1.0.1",
         "laravel/laravel": "^10.0"
     },

--- a/quickstart-examples/MultiTenant/Laravel/AsynchronousEvents/composer.json
+++ b/quickstart-examples/MultiTenant/Laravel/AsynchronousEvents/composer.json
@@ -22,11 +22,7 @@
         }
     },
     "require": {
-        "ecotone/dbal": "dev-main as 1.999.999",
-        "ecotone/jms-converter": "dev-main as 1.999.999",
-        "ecotone/laravel": "dev-main as 1.999.999",
         "ecotone/laravel-starter": "^1.1.0",
-        "ecotone/lite-application": "dev-main as 1.999.999",
         "ecotone/lite-dbal-starter": "^1.0.1",
         "laravel/laravel": "^10.0"
     },

--- a/quickstart-examples/MultiTenant/Laravel/AsynchronousEvents/composer.json
+++ b/quickstart-examples/MultiTenant/Laravel/AsynchronousEvents/composer.json
@@ -22,7 +22,11 @@
         }
     },
     "require": {
+        "ecotone/dbal": "dev-main as 1.999.999",
+        "ecotone/jms-converter": "dev-main as 1.999.999",
+        "ecotone/laravel": "dev-main as 1.999.999",
         "ecotone/laravel-starter": "^1.1.0",
+        "ecotone/lite-application": "dev-main as 1.999.999",
         "ecotone/lite-dbal-starter": "^1.0.1",
         "laravel/laravel": "^10.0"
     },

--- a/quickstart-examples/MultiTenant/Laravel/AsynchronousEvents/composer.json
+++ b/quickstart-examples/MultiTenant/Laravel/AsynchronousEvents/composer.json
@@ -22,11 +22,11 @@
         }
     },
     "require": {
-        "ecotone/dbal": "dev-main as 1.326.1",
-        "ecotone/jms-converter": "dev-main as 1.326.1",
-        "ecotone/laravel": "dev-main as 1.326.1",
+        "ecotone/dbal": "~1.326.1",
+        "ecotone/jms-converter": "~1.326.1",
+        "ecotone/laravel": "~1.326.1",
         "ecotone/laravel-starter": "^1.1.0",
-        "ecotone/lite-application": "dev-main as 1.326.1",
+        "ecotone/lite-application": "~1.326.1",
         "ecotone/lite-dbal-starter": "^1.0.1",
         "laravel/laravel": "^10.0"
     },

--- a/quickstart-examples/MultiTenant/Laravel/EventSourcing/composer.json
+++ b/quickstart-examples/MultiTenant/Laravel/EventSourcing/composer.json
@@ -22,13 +22,8 @@
         }
     },
     "require": {
-        "ecotone/dbal": "dev-main as 1.999.999",
-        "ecotone/jms-converter": "dev-main as 1.999.999",
-        "ecotone/laravel": "dev-main as 1.999.999",
         "ecotone/laravel-starter": "^1.1.0",
-        "ecotone/lite-application": "dev-main as 1.999.999",
         "ecotone/lite-event-sourcing-starter": "^1.0",
-        "ecotone/pdo-event-sourcing": "dev-main as 1.999.999",
         "laravel/laravel": "^10.0",
         "ramsey/uuid": "^4.0"
     },

--- a/quickstart-examples/MultiTenant/Laravel/EventSourcing/composer.json
+++ b/quickstart-examples/MultiTenant/Laravel/EventSourcing/composer.json
@@ -22,13 +22,13 @@
         }
     },
     "require": {
-        "ecotone/dbal": "dev-main as 1.326.1",
-        "ecotone/jms-converter": "dev-main as 1.326.1",
-        "ecotone/laravel": "dev-main as 1.326.1",
+        "ecotone/dbal": "~1.326.1",
+        "ecotone/jms-converter": "~1.326.1",
+        "ecotone/laravel": "~1.326.1",
         "ecotone/laravel-starter": "^1.1.0",
-        "ecotone/lite-application": "dev-main as 1.326.1",
+        "ecotone/lite-application": "~1.326.1",
         "ecotone/lite-event-sourcing-starter": "^1.0",
-        "ecotone/pdo-event-sourcing": "dev-main as 1.326.1",
+        "ecotone/pdo-event-sourcing": "~1.326.1",
         "laravel/laravel": "^10.0",
         "ramsey/uuid": "^4.0"
     },

--- a/quickstart-examples/MultiTenant/Laravel/EventSourcing/composer.json
+++ b/quickstart-examples/MultiTenant/Laravel/EventSourcing/composer.json
@@ -22,13 +22,13 @@
         }
     },
     "require": {
-        "ecotone/dbal": "dev-main as 1.999.999",
-        "ecotone/jms-converter": "dev-main as 1.999.999",
-        "ecotone/laravel": "dev-main as 1.999.999",
+        "ecotone/dbal": "dev-main as 1.326.1",
+        "ecotone/jms-converter": "dev-main as 1.326.1",
+        "ecotone/laravel": "dev-main as 1.326.1",
         "ecotone/laravel-starter": "^1.1.0",
-        "ecotone/lite-application": "dev-main as 1.999.999",
+        "ecotone/lite-application": "dev-main as 1.326.1",
         "ecotone/lite-event-sourcing-starter": "^1.0",
-        "ecotone/pdo-event-sourcing": "dev-main as 1.999.999",
+        "ecotone/pdo-event-sourcing": "dev-main as 1.326.1",
         "laravel/laravel": "^10.0",
         "ramsey/uuid": "^4.0"
     },

--- a/quickstart-examples/MultiTenant/Laravel/EventSourcing/composer.json
+++ b/quickstart-examples/MultiTenant/Laravel/EventSourcing/composer.json
@@ -22,8 +22,13 @@
         }
     },
     "require": {
+        "ecotone/dbal": "dev-main as 1.999.999",
+        "ecotone/jms-converter": "dev-main as 1.999.999",
+        "ecotone/laravel": "dev-main as 1.999.999",
         "ecotone/laravel-starter": "^1.1.0",
+        "ecotone/lite-application": "dev-main as 1.999.999",
         "ecotone/lite-event-sourcing-starter": "^1.0",
+        "ecotone/pdo-event-sourcing": "dev-main as 1.999.999",
         "laravel/laravel": "^10.0",
         "ramsey/uuid": "^4.0"
     },

--- a/quickstart-examples/MultiTenant/Laravel/Events/composer.json
+++ b/quickstart-examples/MultiTenant/Laravel/Events/composer.json
@@ -22,9 +22,6 @@
         }
     },
     "require": {
-        "ecotone/dbal": "dev-main as 1.999.999",
-        "ecotone/jms-converter": "dev-main as 1.999.999",
-        "ecotone/laravel": "dev-main as 1.999.999",
         "ecotone/laravel-starter": "^1.1.0",
         "laravel/laravel": "^10.0"
     },

--- a/quickstart-examples/MultiTenant/Laravel/Events/composer.json
+++ b/quickstart-examples/MultiTenant/Laravel/Events/composer.json
@@ -22,6 +22,9 @@
         }
     },
     "require": {
+        "ecotone/dbal": "dev-main as 1.999.999",
+        "ecotone/jms-converter": "dev-main as 1.999.999",
+        "ecotone/laravel": "dev-main as 1.999.999",
         "ecotone/laravel-starter": "^1.1.0",
         "laravel/laravel": "^10.0"
     },

--- a/quickstart-examples/MultiTenant/Laravel/Events/composer.json
+++ b/quickstart-examples/MultiTenant/Laravel/Events/composer.json
@@ -22,9 +22,9 @@
         }
     },
     "require": {
-        "ecotone/dbal": "dev-main as 1.999.999",
-        "ecotone/jms-converter": "dev-main as 1.999.999",
-        "ecotone/laravel": "dev-main as 1.999.999",
+        "ecotone/dbal": "dev-main as 1.326.1",
+        "ecotone/jms-converter": "dev-main as 1.326.1",
+        "ecotone/laravel": "dev-main as 1.326.1",
         "ecotone/laravel-starter": "^1.1.0",
         "laravel/laravel": "^10.0"
     },

--- a/quickstart-examples/MultiTenant/Laravel/Events/composer.json
+++ b/quickstart-examples/MultiTenant/Laravel/Events/composer.json
@@ -22,9 +22,9 @@
         }
     },
     "require": {
-        "ecotone/dbal": "dev-main as 1.326.1",
-        "ecotone/jms-converter": "dev-main as 1.326.1",
-        "ecotone/laravel": "dev-main as 1.326.1",
+        "ecotone/dbal": "~1.326.1",
+        "ecotone/jms-converter": "~1.326.1",
+        "ecotone/laravel": "~1.326.1",
         "ecotone/laravel-starter": "^1.1.0",
         "laravel/laravel": "^10.0"
     },

--- a/quickstart-examples/MultiTenant/Laravel/MessageBus/composer.json
+++ b/quickstart-examples/MultiTenant/Laravel/MessageBus/composer.json
@@ -22,9 +22,6 @@
         }
     },
     "require": {
-        "ecotone/dbal": "dev-main as 1.999.999",
-        "ecotone/jms-converter": "dev-main as 1.999.999",
-        "ecotone/laravel": "dev-main as 1.999.999",
         "ecotone/laravel-starter": "^1.1.0",
         "laravel/laravel": "^10.0"
     },

--- a/quickstart-examples/MultiTenant/Laravel/MessageBus/composer.json
+++ b/quickstart-examples/MultiTenant/Laravel/MessageBus/composer.json
@@ -22,6 +22,9 @@
         }
     },
     "require": {
+        "ecotone/dbal": "dev-main as 1.999.999",
+        "ecotone/jms-converter": "dev-main as 1.999.999",
+        "ecotone/laravel": "dev-main as 1.999.999",
         "ecotone/laravel-starter": "^1.1.0",
         "laravel/laravel": "^10.0"
     },

--- a/quickstart-examples/MultiTenant/Laravel/MessageBus/composer.json
+++ b/quickstart-examples/MultiTenant/Laravel/MessageBus/composer.json
@@ -22,9 +22,9 @@
         }
     },
     "require": {
-        "ecotone/dbal": "dev-main as 1.999.999",
-        "ecotone/jms-converter": "dev-main as 1.999.999",
-        "ecotone/laravel": "dev-main as 1.999.999",
+        "ecotone/dbal": "dev-main as 1.326.1",
+        "ecotone/jms-converter": "dev-main as 1.326.1",
+        "ecotone/laravel": "dev-main as 1.326.1",
         "ecotone/laravel-starter": "^1.1.0",
         "laravel/laravel": "^10.0"
     },

--- a/quickstart-examples/MultiTenant/Laravel/MessageBus/composer.json
+++ b/quickstart-examples/MultiTenant/Laravel/MessageBus/composer.json
@@ -22,9 +22,9 @@
         }
     },
     "require": {
-        "ecotone/dbal": "dev-main as 1.326.1",
-        "ecotone/jms-converter": "dev-main as 1.326.1",
-        "ecotone/laravel": "dev-main as 1.326.1",
+        "ecotone/dbal": "~1.326.1",
+        "ecotone/jms-converter": "~1.326.1",
+        "ecotone/laravel": "~1.326.1",
         "ecotone/laravel-starter": "^1.1.0",
         "laravel/laravel": "^10.0"
     },

--- a/quickstart-examples/MultiTenant/Symfony/Aggregate/composer.json
+++ b/quickstart-examples/MultiTenant/Symfony/Aggregate/composer.json
@@ -22,9 +22,9 @@
         }
     },
     "require": {
-        "ecotone/dbal": "dev-main as 1.326.1",
-        "ecotone/jms-converter": "dev-main as 1.326.1",
-        "ecotone/symfony-bundle": "dev-main as 1.326.1",
+        "ecotone/dbal": "~1.326.1",
+        "ecotone/jms-converter": "~1.326.1",
+        "ecotone/symfony-bundle": "~1.326.1",
         "ecotone/symfony-starter": "^1.1.0",
         "symfony/expression-language": "^6.4|^7.0|^8.0",
         "symfony/framework-bundle": "^6.4|^7.0|^8.0",

--- a/quickstart-examples/MultiTenant/Symfony/Aggregate/composer.json
+++ b/quickstart-examples/MultiTenant/Symfony/Aggregate/composer.json
@@ -22,9 +22,9 @@
         }
     },
     "require": {
-        "ecotone/dbal": "dev-main as 1.999.999",
-        "ecotone/jms-converter": "dev-main as 1.999.999",
-        "ecotone/symfony-bundle": "dev-main as 1.999.999",
+        "ecotone/dbal": "dev-main as 1.326.1",
+        "ecotone/jms-converter": "dev-main as 1.326.1",
+        "ecotone/symfony-bundle": "dev-main as 1.326.1",
         "ecotone/symfony-starter": "^1.1.0",
         "symfony/expression-language": "^6.4|^7.0|^8.0",
         "symfony/framework-bundle": "^6.4|^7.0|^8.0",

--- a/quickstart-examples/MultiTenant/Symfony/Aggregate/composer.json
+++ b/quickstart-examples/MultiTenant/Symfony/Aggregate/composer.json
@@ -22,6 +22,9 @@
         }
     },
     "require": {
+        "ecotone/dbal": "dev-main as 1.999.999",
+        "ecotone/jms-converter": "dev-main as 1.999.999",
+        "ecotone/symfony-bundle": "dev-main as 1.999.999",
         "ecotone/symfony-starter": "^1.1.0",
         "symfony/expression-language": "^6.4|^7.0|^8.0",
         "symfony/framework-bundle": "^6.4|^7.0|^8.0",

--- a/quickstart-examples/MultiTenant/Symfony/Aggregate/composer.json
+++ b/quickstart-examples/MultiTenant/Symfony/Aggregate/composer.json
@@ -22,9 +22,6 @@
         }
     },
     "require": {
-        "ecotone/dbal": "dev-main as 1.999.999",
-        "ecotone/jms-converter": "dev-main as 1.999.999",
-        "ecotone/symfony-bundle": "dev-main as 1.999.999",
         "ecotone/symfony-starter": "^1.1.0",
         "symfony/expression-language": "^6.4|^7.0|^8.0",
         "symfony/framework-bundle": "^6.4|^7.0|^8.0",

--- a/quickstart-examples/MultiTenant/Symfony/AsynchronousEvents/composer.json
+++ b/quickstart-examples/MultiTenant/Symfony/AsynchronousEvents/composer.json
@@ -22,9 +22,9 @@
         }
     },
     "require": {
-        "ecotone/dbal": "dev-main as 1.326.1",
-        "ecotone/jms-converter": "dev-main as 1.326.1",
-        "ecotone/symfony-bundle": "dev-main as 1.326.1",
+        "ecotone/dbal": "~1.326.1",
+        "ecotone/jms-converter": "~1.326.1",
+        "ecotone/symfony-bundle": "~1.326.1",
         "ecotone/symfony-starter": "^1.1.0",
         "symfony/expression-language": "^6.4|^7.0|^8.0",
         "symfony/framework-bundle": "^6.4|^7.0|^8.0",

--- a/quickstart-examples/MultiTenant/Symfony/AsynchronousEvents/composer.json
+++ b/quickstart-examples/MultiTenant/Symfony/AsynchronousEvents/composer.json
@@ -22,9 +22,9 @@
         }
     },
     "require": {
-        "ecotone/dbal": "dev-main as 1.999.999",
-        "ecotone/jms-converter": "dev-main as 1.999.999",
-        "ecotone/symfony-bundle": "dev-main as 1.999.999",
+        "ecotone/dbal": "dev-main as 1.326.1",
+        "ecotone/jms-converter": "dev-main as 1.326.1",
+        "ecotone/symfony-bundle": "dev-main as 1.326.1",
         "ecotone/symfony-starter": "^1.1.0",
         "symfony/expression-language": "^6.4|^7.0|^8.0",
         "symfony/framework-bundle": "^6.4|^7.0|^8.0",

--- a/quickstart-examples/MultiTenant/Symfony/AsynchronousEvents/composer.json
+++ b/quickstart-examples/MultiTenant/Symfony/AsynchronousEvents/composer.json
@@ -22,6 +22,9 @@
         }
     },
     "require": {
+        "ecotone/dbal": "dev-main as 1.999.999",
+        "ecotone/jms-converter": "dev-main as 1.999.999",
+        "ecotone/symfony-bundle": "dev-main as 1.999.999",
         "ecotone/symfony-starter": "^1.1.0",
         "symfony/expression-language": "^6.4|^7.0|^8.0",
         "symfony/framework-bundle": "^6.4|^7.0|^8.0",

--- a/quickstart-examples/MultiTenant/Symfony/AsynchronousEvents/composer.json
+++ b/quickstart-examples/MultiTenant/Symfony/AsynchronousEvents/composer.json
@@ -22,9 +22,6 @@
         }
     },
     "require": {
-        "ecotone/dbal": "dev-main as 1.999.999",
-        "ecotone/jms-converter": "dev-main as 1.999.999",
-        "ecotone/symfony-bundle": "dev-main as 1.999.999",
         "ecotone/symfony-starter": "^1.1.0",
         "symfony/expression-language": "^6.4|^7.0|^8.0",
         "symfony/framework-bundle": "^6.4|^7.0|^8.0",

--- a/quickstart-examples/MultiTenant/Symfony/EventSourcing/composer.json
+++ b/quickstart-examples/MultiTenant/Symfony/EventSourcing/composer.json
@@ -22,10 +22,10 @@
         }
     },
     "require": {
-        "ecotone/dbal": "dev-main as 1.326.1",
-        "ecotone/jms-converter": "dev-main as 1.326.1",
-        "ecotone/pdo-event-sourcing": "dev-main as 1.326.1",
-        "ecotone/symfony-bundle": "dev-main as 1.326.1",
+        "ecotone/dbal": "~1.326.1",
+        "ecotone/jms-converter": "~1.326.1",
+        "ecotone/pdo-event-sourcing": "~1.326.1",
+        "ecotone/symfony-bundle": "~1.326.1",
         "ecotone/symfony-starter": "^1.1.0",
         "ramsey/uuid": "^4.0",
         "symfony/expression-language": "^6.4|^7.0|^8.0",

--- a/quickstart-examples/MultiTenant/Symfony/EventSourcing/composer.json
+++ b/quickstart-examples/MultiTenant/Symfony/EventSourcing/composer.json
@@ -22,10 +22,10 @@
         }
     },
     "require": {
-        "ecotone/dbal": "dev-main as 1.999.999",
-        "ecotone/jms-converter": "dev-main as 1.999.999",
-        "ecotone/pdo-event-sourcing": "dev-main as 1.999.999",
-        "ecotone/symfony-bundle": "dev-main as 1.999.999",
+        "ecotone/dbal": "dev-main as 1.326.1",
+        "ecotone/jms-converter": "dev-main as 1.326.1",
+        "ecotone/pdo-event-sourcing": "dev-main as 1.326.1",
+        "ecotone/symfony-bundle": "dev-main as 1.326.1",
         "ecotone/symfony-starter": "^1.1.0",
         "ramsey/uuid": "^4.0",
         "symfony/expression-language": "^6.4|^7.0|^8.0",

--- a/quickstart-examples/MultiTenant/Symfony/EventSourcing/composer.json
+++ b/quickstart-examples/MultiTenant/Symfony/EventSourcing/composer.json
@@ -22,16 +22,13 @@
         }
     },
     "require": {
-        "ecotone/dbal": "dev-main as 1.999.999",
-        "ecotone/jms-converter": "dev-main as 1.999.999",
-        "ecotone/pdo-event-sourcing": "dev-main as 1.999.999",
-        "ecotone/symfony-bundle": "dev-main as 1.999.999",
+        "ecotone/pdo-event-sourcing": "^1.211",
         "ecotone/symfony-starter": "^1.1.0",
-        "ramsey/uuid": "^4.0",
         "symfony/expression-language": "^6.4|^7.0|^8.0",
         "symfony/framework-bundle": "^6.4|^7.0|^8.0",
         "symfony/orm-pack": "^2.4",
-        "symfony/yaml": "^6.4|^7.0|^8.0"
+        "symfony/yaml": "^6.4|^7.0|^8.0",
+        "ramsey/uuid": "^4.0"
     },
     "require-dev": {
         "doctrine/orm": "^2.11|^3.0",

--- a/quickstart-examples/MultiTenant/Symfony/EventSourcing/composer.json
+++ b/quickstart-examples/MultiTenant/Symfony/EventSourcing/composer.json
@@ -22,13 +22,16 @@
         }
     },
     "require": {
-        "ecotone/pdo-event-sourcing": "^1.211",
+        "ecotone/dbal": "dev-main as 1.999.999",
+        "ecotone/jms-converter": "dev-main as 1.999.999",
+        "ecotone/pdo-event-sourcing": "dev-main as 1.999.999",
+        "ecotone/symfony-bundle": "dev-main as 1.999.999",
         "ecotone/symfony-starter": "^1.1.0",
+        "ramsey/uuid": "^4.0",
         "symfony/expression-language": "^6.4|^7.0|^8.0",
         "symfony/framework-bundle": "^6.4|^7.0|^8.0",
         "symfony/orm-pack": "^2.4",
-        "symfony/yaml": "^6.4|^7.0|^8.0",
-        "ramsey/uuid": "^4.0"
+        "symfony/yaml": "^6.4|^7.0|^8.0"
     },
     "require-dev": {
         "doctrine/orm": "^2.11|^3.0",

--- a/quickstart-examples/MultiTenant/Symfony/Events/composer.json
+++ b/quickstart-examples/MultiTenant/Symfony/Events/composer.json
@@ -22,9 +22,9 @@
         }
     },
     "require": {
-        "ecotone/dbal": "dev-main as 1.326.1",
-        "ecotone/jms-converter": "dev-main as 1.326.1",
-        "ecotone/symfony-bundle": "dev-main as 1.326.1",
+        "ecotone/dbal": "~1.326.1",
+        "ecotone/jms-converter": "~1.326.1",
+        "ecotone/symfony-bundle": "~1.326.1",
         "ecotone/symfony-starter": "^1.1.0",
         "symfony/expression-language": "^6.4|^7.0|^8.0",
         "symfony/framework-bundle": "^6.4|^7.0|^8.0",

--- a/quickstart-examples/MultiTenant/Symfony/Events/composer.json
+++ b/quickstart-examples/MultiTenant/Symfony/Events/composer.json
@@ -22,9 +22,9 @@
         }
     },
     "require": {
-        "ecotone/dbal": "dev-main as 1.999.999",
-        "ecotone/jms-converter": "dev-main as 1.999.999",
-        "ecotone/symfony-bundle": "dev-main as 1.999.999",
+        "ecotone/dbal": "dev-main as 1.326.1",
+        "ecotone/jms-converter": "dev-main as 1.326.1",
+        "ecotone/symfony-bundle": "dev-main as 1.326.1",
         "ecotone/symfony-starter": "^1.1.0",
         "symfony/expression-language": "^6.4|^7.0|^8.0",
         "symfony/framework-bundle": "^6.4|^7.0|^8.0",

--- a/quickstart-examples/MultiTenant/Symfony/Events/composer.json
+++ b/quickstart-examples/MultiTenant/Symfony/Events/composer.json
@@ -22,6 +22,9 @@
         }
     },
     "require": {
+        "ecotone/dbal": "dev-main as 1.999.999",
+        "ecotone/jms-converter": "dev-main as 1.999.999",
+        "ecotone/symfony-bundle": "dev-main as 1.999.999",
         "ecotone/symfony-starter": "^1.1.0",
         "symfony/expression-language": "^6.4|^7.0|^8.0",
         "symfony/framework-bundle": "^6.4|^7.0|^8.0",

--- a/quickstart-examples/MultiTenant/Symfony/Events/composer.json
+++ b/quickstart-examples/MultiTenant/Symfony/Events/composer.json
@@ -22,9 +22,6 @@
         }
     },
     "require": {
-        "ecotone/dbal": "dev-main as 1.999.999",
-        "ecotone/jms-converter": "dev-main as 1.999.999",
-        "ecotone/symfony-bundle": "dev-main as 1.999.999",
         "ecotone/symfony-starter": "^1.1.0",
         "symfony/expression-language": "^6.4|^7.0|^8.0",
         "symfony/framework-bundle": "^6.4|^7.0|^8.0",

--- a/quickstart-examples/MultiTenant/Symfony/MessageBus/composer.json
+++ b/quickstart-examples/MultiTenant/Symfony/MessageBus/composer.json
@@ -22,9 +22,9 @@
         }
     },
     "require": {
-        "ecotone/dbal": "dev-main as 1.326.1",
-        "ecotone/jms-converter": "dev-main as 1.326.1",
-        "ecotone/symfony-bundle": "dev-main as 1.326.1",
+        "ecotone/dbal": "~1.326.1",
+        "ecotone/jms-converter": "~1.326.1",
+        "ecotone/symfony-bundle": "~1.326.1",
         "ecotone/symfony-starter": "^1.1.0",
         "symfony/expression-language": "^6.4|^7.0|^8.0",
         "symfony/framework-bundle": "^6.4|^7.0|^8.0",

--- a/quickstart-examples/MultiTenant/Symfony/MessageBus/composer.json
+++ b/quickstart-examples/MultiTenant/Symfony/MessageBus/composer.json
@@ -22,9 +22,9 @@
         }
     },
     "require": {
-        "ecotone/dbal": "dev-main as 1.999.999",
-        "ecotone/jms-converter": "dev-main as 1.999.999",
-        "ecotone/symfony-bundle": "dev-main as 1.999.999",
+        "ecotone/dbal": "dev-main as 1.326.1",
+        "ecotone/jms-converter": "dev-main as 1.326.1",
+        "ecotone/symfony-bundle": "dev-main as 1.326.1",
         "ecotone/symfony-starter": "^1.1.0",
         "symfony/expression-language": "^6.4|^7.0|^8.0",
         "symfony/framework-bundle": "^6.4|^7.0|^8.0",

--- a/quickstart-examples/MultiTenant/Symfony/MessageBus/composer.json
+++ b/quickstart-examples/MultiTenant/Symfony/MessageBus/composer.json
@@ -22,6 +22,9 @@
         }
     },
     "require": {
+        "ecotone/dbal": "dev-main as 1.999.999",
+        "ecotone/jms-converter": "dev-main as 1.999.999",
+        "ecotone/symfony-bundle": "dev-main as 1.999.999",
         "ecotone/symfony-starter": "^1.1.0",
         "symfony/expression-language": "^6.4|^7.0|^8.0",
         "symfony/framework-bundle": "^6.4|^7.0|^8.0",

--- a/quickstart-examples/MultiTenant/Symfony/MessageBus/composer.json
+++ b/quickstart-examples/MultiTenant/Symfony/MessageBus/composer.json
@@ -22,9 +22,6 @@
         }
     },
     "require": {
-        "ecotone/dbal": "dev-main as 1.999.999",
-        "ecotone/jms-converter": "dev-main as 1.999.999",
-        "ecotone/symfony-bundle": "dev-main as 1.999.999",
         "ecotone/symfony-starter": "^1.1.0",
         "symfony/expression-language": "^6.4|^7.0|^8.0",
         "symfony/framework-bundle": "^6.4|^7.0|^8.0",

--- a/quickstart-examples/OutboxPattern/composer.json
+++ b/quickstart-examples/OutboxPattern/composer.json
@@ -22,6 +22,9 @@
         }
     },
     "require": {
+        "ecotone/dbal": "dev-main as 1.999.999",
+        "ecotone/jms-converter": "dev-main as 1.999.999",
+        "ecotone/lite-application": "dev-main as 1.999.999",
         "ecotone/lite-dbal-starter": "^1.0.1"
     },
     "require-dev": {

--- a/quickstart-examples/OutboxPattern/composer.json
+++ b/quickstart-examples/OutboxPattern/composer.json
@@ -22,9 +22,9 @@
         }
     },
     "require": {
-        "ecotone/dbal": "dev-main as 1.326.1",
-        "ecotone/jms-converter": "dev-main as 1.326.1",
-        "ecotone/lite-application": "dev-main as 1.326.1",
+        "ecotone/dbal": "~1.326.1",
+        "ecotone/jms-converter": "~1.326.1",
+        "ecotone/lite-application": "~1.326.1",
         "ecotone/lite-dbal-starter": "^1.0.1"
     },
     "require-dev": {

--- a/quickstart-examples/OutboxPattern/composer.json
+++ b/quickstart-examples/OutboxPattern/composer.json
@@ -22,9 +22,6 @@
         }
     },
     "require": {
-        "ecotone/dbal": "dev-main as 1.999.999",
-        "ecotone/jms-converter": "dev-main as 1.999.999",
-        "ecotone/lite-application": "dev-main as 1.999.999",
         "ecotone/lite-dbal-starter": "^1.0.1"
     },
     "require-dev": {

--- a/quickstart-examples/OutboxPattern/composer.json
+++ b/quickstart-examples/OutboxPattern/composer.json
@@ -22,9 +22,9 @@
         }
     },
     "require": {
-        "ecotone/dbal": "dev-main as 1.999.999",
-        "ecotone/jms-converter": "dev-main as 1.999.999",
-        "ecotone/lite-application": "dev-main as 1.999.999",
+        "ecotone/dbal": "dev-main as 1.326.1",
+        "ecotone/jms-converter": "dev-main as 1.326.1",
+        "ecotone/lite-application": "dev-main as 1.326.1",
         "ecotone/lite-dbal-starter": "^1.0.1"
     },
     "require-dev": {

--- a/quickstart-examples/RefactorToReactiveSystem/composer.json
+++ b/quickstart-examples/RefactorToReactiveSystem/composer.json
@@ -22,9 +22,9 @@
         }
     },
     "require": {
-        "ecotone/dbal": "dev-main as 1.999.999",
-        "ecotone/jms-converter": "dev-main as 1.999.999",
-        "ecotone/lite-application": "dev-main as 1.999.999",
+        "ecotone/dbal": "dev-main as 1.326.1",
+        "ecotone/jms-converter": "dev-main as 1.326.1",
+        "ecotone/lite-application": "dev-main as 1.326.1",
         "ecotone/lite-dbal-starter": "^1.0.1",
         "moneyphp/money": "^4.1.0",
         "ramsey/uuid": "^4.0",

--- a/quickstart-examples/RefactorToReactiveSystem/composer.json
+++ b/quickstart-examples/RefactorToReactiveSystem/composer.json
@@ -22,10 +22,13 @@
         }
     },
     "require": {
+        "ecotone/dbal": "dev-main as 1.999.999",
+        "ecotone/jms-converter": "dev-main as 1.999.999",
+        "ecotone/lite-application": "dev-main as 1.999.999",
         "ecotone/lite-dbal-starter": "^1.0.1",
         "moneyphp/money": "^4.1.0",
-        "symfony/http-foundation": "^6.4|^7.0|^8.0",
-        "ramsey/uuid": "^4.0"
+        "ramsey/uuid": "^4.0",
+        "symfony/http-foundation": "^6.4|^7.0|^8.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.6|^10.5|^11.0"

--- a/quickstart-examples/RefactorToReactiveSystem/composer.json
+++ b/quickstart-examples/RefactorToReactiveSystem/composer.json
@@ -22,13 +22,10 @@
         }
     },
     "require": {
-        "ecotone/dbal": "dev-main as 1.999.999",
-        "ecotone/jms-converter": "dev-main as 1.999.999",
-        "ecotone/lite-application": "dev-main as 1.999.999",
         "ecotone/lite-dbal-starter": "^1.0.1",
         "moneyphp/money": "^4.1.0",
-        "ramsey/uuid": "^4.0",
-        "symfony/http-foundation": "^6.4|^7.0|^8.0"
+        "symfony/http-foundation": "^6.4|^7.0|^8.0",
+        "ramsey/uuid": "^4.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.6|^10.5|^11.0"

--- a/quickstart-examples/RefactorToReactiveSystem/composer.json
+++ b/quickstart-examples/RefactorToReactiveSystem/composer.json
@@ -22,9 +22,9 @@
         }
     },
     "require": {
-        "ecotone/dbal": "dev-main as 1.326.1",
-        "ecotone/jms-converter": "dev-main as 1.326.1",
-        "ecotone/lite-application": "dev-main as 1.326.1",
+        "ecotone/dbal": "~1.326.1",
+        "ecotone/jms-converter": "~1.326.1",
+        "ecotone/lite-application": "~1.326.1",
         "ecotone/lite-dbal-starter": "^1.0.1",
         "moneyphp/money": "^4.1.0",
         "ramsey/uuid": "^4.0",

--- a/quickstart-examples/Schedule/composer.json
+++ b/quickstart-examples/Schedule/composer.json
@@ -22,6 +22,9 @@
         }
     },
     "require": {
+        "ecotone/dbal": "dev-main as 1.999.999",
+        "ecotone/jms-converter": "dev-main as 1.999.999",
+        "ecotone/lite-application": "dev-main as 1.999.999",
         "ecotone/lite-dbal-starter": "^1.0.1"
     },
     "require-dev": {

--- a/quickstart-examples/Schedule/composer.json
+++ b/quickstart-examples/Schedule/composer.json
@@ -22,9 +22,9 @@
         }
     },
     "require": {
-        "ecotone/dbal": "dev-main as 1.326.1",
-        "ecotone/jms-converter": "dev-main as 1.326.1",
-        "ecotone/lite-application": "dev-main as 1.326.1",
+        "ecotone/dbal": "~1.326.1",
+        "ecotone/jms-converter": "~1.326.1",
+        "ecotone/lite-application": "~1.326.1",
         "ecotone/lite-dbal-starter": "^1.0.1"
     },
     "require-dev": {

--- a/quickstart-examples/Schedule/composer.json
+++ b/quickstart-examples/Schedule/composer.json
@@ -22,9 +22,6 @@
         }
     },
     "require": {
-        "ecotone/dbal": "dev-main as 1.999.999",
-        "ecotone/jms-converter": "dev-main as 1.999.999",
-        "ecotone/lite-application": "dev-main as 1.999.999",
         "ecotone/lite-dbal-starter": "^1.0.1"
     },
     "require-dev": {

--- a/quickstart-examples/Schedule/composer.json
+++ b/quickstart-examples/Schedule/composer.json
@@ -22,9 +22,9 @@
         }
     },
     "require": {
-        "ecotone/dbal": "dev-main as 1.999.999",
-        "ecotone/jms-converter": "dev-main as 1.999.999",
-        "ecotone/lite-application": "dev-main as 1.999.999",
+        "ecotone/dbal": "dev-main as 1.326.1",
+        "ecotone/jms-converter": "dev-main as 1.326.1",
+        "ecotone/lite-application": "dev-main as 1.326.1",
         "ecotone/lite-dbal-starter": "^1.0.1"
     },
     "require-dev": {

--- a/quickstart-examples/StatefulProjection/composer.json
+++ b/quickstart-examples/StatefulProjection/composer.json
@@ -22,10 +22,10 @@
         }
     },
     "require": {
-        "ecotone/jms-converter": "dev-main as 1.999.999",
-        "ecotone/lite-application": "dev-main as 1.999.999",
+        "ecotone/jms-converter": "dev-main as 1.326.1",
+        "ecotone/lite-application": "dev-main as 1.326.1",
         "ecotone/lite-event-sourcing-starter": "^1.0",
-        "ecotone/pdo-event-sourcing": "dev-main as 1.999.999",
+        "ecotone/pdo-event-sourcing": "dev-main as 1.326.1",
         "ramsey/uuid": "^4.0"
     },
     "require-dev": {

--- a/quickstart-examples/StatefulProjection/composer.json
+++ b/quickstart-examples/StatefulProjection/composer.json
@@ -22,10 +22,10 @@
         }
     },
     "require": {
-        "ecotone/jms-converter": "dev-main as 1.326.1",
-        "ecotone/lite-application": "dev-main as 1.326.1",
+        "ecotone/jms-converter": "~1.326.1",
+        "ecotone/lite-application": "~1.326.1",
         "ecotone/lite-event-sourcing-starter": "^1.0",
-        "ecotone/pdo-event-sourcing": "dev-main as 1.326.1",
+        "ecotone/pdo-event-sourcing": "~1.326.1",
         "ramsey/uuid": "^4.0"
     },
     "require-dev": {

--- a/quickstart-examples/StatefulProjection/composer.json
+++ b/quickstart-examples/StatefulProjection/composer.json
@@ -22,10 +22,7 @@
         }
     },
     "require": {
-        "ecotone/jms-converter": "dev-main as 1.999.999",
-        "ecotone/lite-application": "dev-main as 1.999.999",
         "ecotone/lite-event-sourcing-starter": "^1.0",
-        "ecotone/pdo-event-sourcing": "dev-main as 1.999.999",
         "ramsey/uuid": "^4.0"
     },
     "require-dev": {

--- a/quickstart-examples/StatefulProjection/composer.json
+++ b/quickstart-examples/StatefulProjection/composer.json
@@ -22,7 +22,10 @@
         }
     },
     "require": {
+        "ecotone/jms-converter": "dev-main as 1.999.999",
+        "ecotone/lite-application": "dev-main as 1.999.999",
         "ecotone/lite-event-sourcing-starter": "^1.0",
+        "ecotone/pdo-event-sourcing": "dev-main as 1.999.999",
         "ramsey/uuid": "^4.0"
     },
     "require-dev": {

--- a/quickstart-examples/Symfony/Projection/DatabaseReadModel/composer.json
+++ b/quickstart-examples/Symfony/Projection/DatabaseReadModel/composer.json
@@ -22,10 +22,10 @@
         }
     },
     "require": {
-        "ecotone/dbal": "dev-main as 1.326.1",
-        "ecotone/jms-converter": "dev-main as 1.326.1",
-        "ecotone/pdo-event-sourcing": "dev-main as 1.326.1",
-        "ecotone/symfony-bundle": "dev-main as 1.326.1",
+        "ecotone/dbal": "~1.326.1",
+        "ecotone/jms-converter": "~1.326.1",
+        "ecotone/pdo-event-sourcing": "~1.326.1",
+        "ecotone/symfony-bundle": "~1.326.1",
         "ecotone/symfony-starter": "^1.1.0",
         "ramsey/uuid": "^4.0",
         "symfony/expression-language": "^6.4|^7.0|^8.0",

--- a/quickstart-examples/Symfony/Projection/DatabaseReadModel/composer.json
+++ b/quickstart-examples/Symfony/Projection/DatabaseReadModel/composer.json
@@ -22,10 +22,10 @@
         }
     },
     "require": {
-        "ecotone/dbal": "dev-main as 1.999.999",
-        "ecotone/jms-converter": "dev-main as 1.999.999",
-        "ecotone/pdo-event-sourcing": "dev-main as 1.999.999",
-        "ecotone/symfony-bundle": "dev-main as 1.999.999",
+        "ecotone/dbal": "dev-main as 1.326.1",
+        "ecotone/jms-converter": "dev-main as 1.326.1",
+        "ecotone/pdo-event-sourcing": "dev-main as 1.326.1",
+        "ecotone/symfony-bundle": "dev-main as 1.326.1",
         "ecotone/symfony-starter": "^1.1.0",
         "ramsey/uuid": "^4.0",
         "symfony/expression-language": "^6.4|^7.0|^8.0",

--- a/quickstart-examples/Symfony/Projection/DatabaseReadModel/composer.json
+++ b/quickstart-examples/Symfony/Projection/DatabaseReadModel/composer.json
@@ -22,16 +22,13 @@
         }
     },
     "require": {
-        "ecotone/dbal": "dev-main as 1.999.999",
-        "ecotone/jms-converter": "dev-main as 1.999.999",
-        "ecotone/pdo-event-sourcing": "dev-main as 1.999.999",
-        "ecotone/symfony-bundle": "dev-main as 1.999.999",
+        "ecotone/pdo-event-sourcing": "^1.211",
         "ecotone/symfony-starter": "^1.1.0",
-        "ramsey/uuid": "^4.0",
         "symfony/expression-language": "^6.4|^7.0|^8.0",
         "symfony/framework-bundle": "^6.4|^7.0|^8.0",
         "symfony/orm-pack": "^2.4",
-        "symfony/yaml": "^6.4|^7.0|^8.0"
+        "symfony/yaml": "^6.4|^7.0|^8.0",
+        "ramsey/uuid": "^4.0"
     },
     "require-dev": {
         "doctrine/orm": "^2.11|^3.0",

--- a/quickstart-examples/Symfony/Projection/DatabaseReadModel/composer.json
+++ b/quickstart-examples/Symfony/Projection/DatabaseReadModel/composer.json
@@ -22,13 +22,16 @@
         }
     },
     "require": {
-        "ecotone/pdo-event-sourcing": "^1.211",
+        "ecotone/dbal": "dev-main as 1.999.999",
+        "ecotone/jms-converter": "dev-main as 1.999.999",
+        "ecotone/pdo-event-sourcing": "dev-main as 1.999.999",
+        "ecotone/symfony-bundle": "dev-main as 1.999.999",
         "ecotone/symfony-starter": "^1.1.0",
+        "ramsey/uuid": "^4.0",
         "symfony/expression-language": "^6.4|^7.0|^8.0",
         "symfony/framework-bundle": "^6.4|^7.0|^8.0",
         "symfony/orm-pack": "^2.4",
-        "symfony/yaml": "^6.4|^7.0|^8.0",
-        "ramsey/uuid": "^4.0"
+        "symfony/yaml": "^6.4|^7.0|^8.0"
     },
     "require-dev": {
         "doctrine/orm": "^2.11|^3.0",

--- a/quickstart-examples/Symfony/Projection/EntityReadModel/composer.json
+++ b/quickstart-examples/Symfony/Projection/EntityReadModel/composer.json
@@ -22,10 +22,10 @@
         }
     },
     "require": {
-        "ecotone/dbal": "dev-main as 1.326.1",
-        "ecotone/jms-converter": "dev-main as 1.326.1",
-        "ecotone/pdo-event-sourcing": "dev-main as 1.326.1",
-        "ecotone/symfony-bundle": "dev-main as 1.326.1",
+        "ecotone/dbal": "~1.326.1",
+        "ecotone/jms-converter": "~1.326.1",
+        "ecotone/pdo-event-sourcing": "~1.326.1",
+        "ecotone/symfony-bundle": "~1.326.1",
         "ecotone/symfony-starter": "^1.1.0",
         "ramsey/uuid": "^4.0",
         "symfony/expression-language": "^6.4|^7.0|^8.0",

--- a/quickstart-examples/Symfony/Projection/EntityReadModel/composer.json
+++ b/quickstart-examples/Symfony/Projection/EntityReadModel/composer.json
@@ -22,10 +22,10 @@
         }
     },
     "require": {
-        "ecotone/dbal": "dev-main as 1.999.999",
-        "ecotone/jms-converter": "dev-main as 1.999.999",
-        "ecotone/pdo-event-sourcing": "dev-main as 1.999.999",
-        "ecotone/symfony-bundle": "dev-main as 1.999.999",
+        "ecotone/dbal": "dev-main as 1.326.1",
+        "ecotone/jms-converter": "dev-main as 1.326.1",
+        "ecotone/pdo-event-sourcing": "dev-main as 1.326.1",
+        "ecotone/symfony-bundle": "dev-main as 1.326.1",
         "ecotone/symfony-starter": "^1.1.0",
         "ramsey/uuid": "^4.0",
         "symfony/expression-language": "^6.4|^7.0|^8.0",

--- a/quickstart-examples/Symfony/Projection/EntityReadModel/composer.json
+++ b/quickstart-examples/Symfony/Projection/EntityReadModel/composer.json
@@ -22,16 +22,13 @@
         }
     },
     "require": {
-        "ecotone/dbal": "dev-main as 1.999.999",
-        "ecotone/jms-converter": "dev-main as 1.999.999",
-        "ecotone/pdo-event-sourcing": "dev-main as 1.999.999",
-        "ecotone/symfony-bundle": "dev-main as 1.999.999",
+        "ecotone/pdo-event-sourcing": "^1.211",
         "ecotone/symfony-starter": "^1.1.0",
-        "ramsey/uuid": "^4.0",
         "symfony/expression-language": "^6.4|^7.0|^8.0",
         "symfony/framework-bundle": "^6.4|^7.0|^8.0",
         "symfony/orm-pack": "^2.4",
-        "symfony/yaml": "^6.4|^7.0|^8.0"
+        "symfony/yaml": "^6.4|^7.0|^8.0",
+        "ramsey/uuid": "^4.0"
     },
     "require-dev": {
         "doctrine/orm": "^2.11|^3.0",

--- a/quickstart-examples/Symfony/Projection/EntityReadModel/composer.json
+++ b/quickstart-examples/Symfony/Projection/EntityReadModel/composer.json
@@ -22,13 +22,16 @@
         }
     },
     "require": {
-        "ecotone/pdo-event-sourcing": "^1.211",
+        "ecotone/dbal": "dev-main as 1.999.999",
+        "ecotone/jms-converter": "dev-main as 1.999.999",
+        "ecotone/pdo-event-sourcing": "dev-main as 1.999.999",
+        "ecotone/symfony-bundle": "dev-main as 1.999.999",
         "ecotone/symfony-starter": "^1.1.0",
+        "ramsey/uuid": "^4.0",
         "symfony/expression-language": "^6.4|^7.0|^8.0",
         "symfony/framework-bundle": "^6.4|^7.0|^8.0",
         "symfony/orm-pack": "^2.4",
-        "symfony/yaml": "^6.4|^7.0|^8.0",
-        "ramsey/uuid": "^4.0"
+        "symfony/yaml": "^6.4|^7.0|^8.0"
     },
     "require-dev": {
         "doctrine/orm": "^2.11|^3.0",

--- a/quickstart-examples/Testing/composer.json
+++ b/quickstart-examples/Testing/composer.json
@@ -28,10 +28,10 @@
     },
     "require": {
         "beberlei/assert": "^3.3.2",
-        "ecotone/jms-converter": "dev-main as 1.999.999",
-        "ecotone/lite-application": "dev-main as 1.999.999",
+        "ecotone/jms-converter": "dev-main as 1.326.1",
+        "ecotone/lite-application": "dev-main as 1.326.1",
         "ecotone/lite-event-sourcing-starter": "^1.0",
-        "ecotone/pdo-event-sourcing": "dev-main as 1.999.999",
+        "ecotone/pdo-event-sourcing": "dev-main as 1.326.1",
         "ramsey/uuid": "^4.0"
     },
     "require-dev": {

--- a/quickstart-examples/Testing/composer.json
+++ b/quickstart-examples/Testing/composer.json
@@ -28,10 +28,10 @@
     },
     "require": {
         "beberlei/assert": "^3.3.2",
-        "ecotone/jms-converter": "dev-main as 1.326.1",
-        "ecotone/lite-application": "dev-main as 1.326.1",
+        "ecotone/jms-converter": "~1.326.1",
+        "ecotone/lite-application": "~1.326.1",
         "ecotone/lite-event-sourcing-starter": "^1.0",
-        "ecotone/pdo-event-sourcing": "dev-main as 1.326.1",
+        "ecotone/pdo-event-sourcing": "~1.326.1",
         "ramsey/uuid": "^4.0"
     },
     "require-dev": {

--- a/quickstart-examples/Testing/composer.json
+++ b/quickstart-examples/Testing/composer.json
@@ -28,7 +28,10 @@
     },
     "require": {
         "beberlei/assert": "^3.3.2",
+        "ecotone/jms-converter": "dev-main as 1.999.999",
+        "ecotone/lite-application": "dev-main as 1.999.999",
         "ecotone/lite-event-sourcing-starter": "^1.0",
+        "ecotone/pdo-event-sourcing": "dev-main as 1.999.999",
         "ramsey/uuid": "^4.0"
     },
     "require-dev": {

--- a/quickstart-examples/Testing/composer.json
+++ b/quickstart-examples/Testing/composer.json
@@ -28,10 +28,7 @@
     },
     "require": {
         "beberlei/assert": "^3.3.2",
-        "ecotone/jms-converter": "dev-main as 1.999.999",
-        "ecotone/lite-application": "dev-main as 1.999.999",
         "ecotone/lite-event-sourcing-starter": "^1.0",
-        "ecotone/pdo-event-sourcing": "dev-main as 1.999.999",
         "ramsey/uuid": "^4.0"
     },
     "require-dev": {

--- a/quickstart-examples/Workflows/AsynchronousStateless/composer.json
+++ b/quickstart-examples/Workflows/AsynchronousStateless/composer.json
@@ -27,6 +27,9 @@
         }
     },
     "require": {
+        "ecotone/dbal": "dev-main as 1.999.999",
+        "ecotone/jms-converter": "dev-main as 1.999.999",
+        "ecotone/lite-application": "dev-main as 1.999.999",
         "ecotone/lite-dbal-starter": "^1.0.1",
         "intervention/image": "^3.5.1"
     },

--- a/quickstart-examples/Workflows/AsynchronousStateless/composer.json
+++ b/quickstart-examples/Workflows/AsynchronousStateless/composer.json
@@ -27,9 +27,9 @@
         }
     },
     "require": {
-        "ecotone/dbal": "dev-main as 1.999.999",
-        "ecotone/jms-converter": "dev-main as 1.999.999",
-        "ecotone/lite-application": "dev-main as 1.999.999",
+        "ecotone/dbal": "dev-main as 1.326.1",
+        "ecotone/jms-converter": "dev-main as 1.326.1",
+        "ecotone/lite-application": "dev-main as 1.326.1",
         "ecotone/lite-dbal-starter": "^1.0.1",
         "intervention/image": "^3.5.1"
     },

--- a/quickstart-examples/Workflows/AsynchronousStateless/composer.json
+++ b/quickstart-examples/Workflows/AsynchronousStateless/composer.json
@@ -27,9 +27,6 @@
         }
     },
     "require": {
-        "ecotone/dbal": "dev-main as 1.999.999",
-        "ecotone/jms-converter": "dev-main as 1.999.999",
-        "ecotone/lite-application": "dev-main as 1.999.999",
         "ecotone/lite-dbal-starter": "^1.0.1",
         "intervention/image": "^3.5.1"
     },

--- a/quickstart-examples/Workflows/AsynchronousStateless/composer.json
+++ b/quickstart-examples/Workflows/AsynchronousStateless/composer.json
@@ -27,9 +27,9 @@
         }
     },
     "require": {
-        "ecotone/dbal": "dev-main as 1.326.1",
-        "ecotone/jms-converter": "dev-main as 1.326.1",
-        "ecotone/lite-application": "dev-main as 1.326.1",
+        "ecotone/dbal": "~1.326.1",
+        "ecotone/jms-converter": "~1.326.1",
+        "ecotone/lite-application": "~1.326.1",
         "ecotone/lite-dbal-starter": "^1.0.1",
         "intervention/image": "^3.5.1"
     },

--- a/quickstart-examples/Workflows/Saga/composer.json
+++ b/quickstart-examples/Workflows/Saga/composer.json
@@ -27,9 +27,9 @@
         }
     },
     "require": {
-        "ecotone/dbal": "dev-main as 1.326.1",
-        "ecotone/jms-converter": "dev-main as 1.326.1",
-        "ecotone/lite-application": "dev-main as 1.326.1",
+        "ecotone/dbal": "~1.326.1",
+        "ecotone/jms-converter": "~1.326.1",
+        "ecotone/lite-application": "~1.326.1",
         "ecotone/lite-dbal-starter": "^1.0.1",
         "intervention/image": "^3.5.1",
         "moneyphp/money": "^4.1.0",

--- a/quickstart-examples/Workflows/Saga/composer.json
+++ b/quickstart-examples/Workflows/Saga/composer.json
@@ -27,14 +27,11 @@
         }
     },
     "require": {
-        "ecotone/dbal": "dev-main as 1.999.999",
-        "ecotone/jms-converter": "dev-main as 1.999.999",
-        "ecotone/lite-application": "dev-main as 1.999.999",
         "ecotone/lite-dbal-starter": "^1.0.1",
         "intervention/image": "^3.5.1",
         "moneyphp/money": "^4.1.0",
-        "ramsey/uuid": "^4.0",
-        "webmozart/assert": "^1.11"
+        "webmozart/assert": "^1.11",
+        "ramsey/uuid": "^4.0"
     },
     "require-dev": {
         "doctrine/orm": "^2.11|^3.0",

--- a/quickstart-examples/Workflows/Saga/composer.json
+++ b/quickstart-examples/Workflows/Saga/composer.json
@@ -27,11 +27,14 @@
         }
     },
     "require": {
+        "ecotone/dbal": "dev-main as 1.999.999",
+        "ecotone/jms-converter": "dev-main as 1.999.999",
+        "ecotone/lite-application": "dev-main as 1.999.999",
         "ecotone/lite-dbal-starter": "^1.0.1",
         "intervention/image": "^3.5.1",
         "moneyphp/money": "^4.1.0",
-        "webmozart/assert": "^1.11",
-        "ramsey/uuid": "^4.0"
+        "ramsey/uuid": "^4.0",
+        "webmozart/assert": "^1.11"
     },
     "require-dev": {
         "doctrine/orm": "^2.11|^3.0",

--- a/quickstart-examples/Workflows/Saga/composer.json
+++ b/quickstart-examples/Workflows/Saga/composer.json
@@ -27,9 +27,9 @@
         }
     },
     "require": {
-        "ecotone/dbal": "dev-main as 1.999.999",
-        "ecotone/jms-converter": "dev-main as 1.999.999",
-        "ecotone/lite-application": "dev-main as 1.999.999",
+        "ecotone/dbal": "dev-main as 1.326.1",
+        "ecotone/jms-converter": "dev-main as 1.326.1",
+        "ecotone/lite-application": "dev-main as 1.326.1",
         "ecotone/lite-dbal-starter": "^1.0.1",
         "intervention/image": "^3.5.1",
         "moneyphp/money": "^4.1.0",

--- a/quickstart-examples/Workflows/SynchronousStateless/composer.json
+++ b/quickstart-examples/Workflows/SynchronousStateless/composer.json
@@ -27,6 +27,9 @@
         }
     },
     "require": {
+        "ecotone/dbal": "dev-main as 1.999.999",
+        "ecotone/jms-converter": "dev-main as 1.999.999",
+        "ecotone/lite-application": "dev-main as 1.999.999",
         "ecotone/lite-dbal-starter": "^1.0.1",
         "intervention/image": "^3.5.1"
     },

--- a/quickstart-examples/Workflows/SynchronousStateless/composer.json
+++ b/quickstart-examples/Workflows/SynchronousStateless/composer.json
@@ -27,9 +27,9 @@
         }
     },
     "require": {
-        "ecotone/dbal": "dev-main as 1.999.999",
-        "ecotone/jms-converter": "dev-main as 1.999.999",
-        "ecotone/lite-application": "dev-main as 1.999.999",
+        "ecotone/dbal": "dev-main as 1.326.1",
+        "ecotone/jms-converter": "dev-main as 1.326.1",
+        "ecotone/lite-application": "dev-main as 1.326.1",
         "ecotone/lite-dbal-starter": "^1.0.1",
         "intervention/image": "^3.5.1"
     },

--- a/quickstart-examples/Workflows/SynchronousStateless/composer.json
+++ b/quickstart-examples/Workflows/SynchronousStateless/composer.json
@@ -27,9 +27,6 @@
         }
     },
     "require": {
-        "ecotone/dbal": "dev-main as 1.999.999",
-        "ecotone/jms-converter": "dev-main as 1.999.999",
-        "ecotone/lite-application": "dev-main as 1.999.999",
         "ecotone/lite-dbal-starter": "^1.0.1",
         "intervention/image": "^3.5.1"
     },

--- a/quickstart-examples/Workflows/SynchronousStateless/composer.json
+++ b/quickstart-examples/Workflows/SynchronousStateless/composer.json
@@ -27,9 +27,9 @@
         }
     },
     "require": {
-        "ecotone/dbal": "dev-main as 1.326.1",
-        "ecotone/jms-converter": "dev-main as 1.326.1",
-        "ecotone/lite-application": "dev-main as 1.326.1",
+        "ecotone/dbal": "~1.326.1",
+        "ecotone/jms-converter": "~1.326.1",
+        "ecotone/lite-application": "~1.326.1",
         "ecotone/lite-dbal-starter": "^1.0.1",
         "intervention/image": "^3.5.1"
     },

--- a/quickstart-examples/WorkingWithAggregateDirectly/composer.json
+++ b/quickstart-examples/WorkingWithAggregateDirectly/composer.json
@@ -22,10 +22,10 @@
         }
     },
     "require": {
-        "ecotone/jms-converter": "dev-main as 1.999.999",
-        "ecotone/lite-application": "dev-main as 1.999.999",
+        "ecotone/jms-converter": "dev-main as 1.326.1",
+        "ecotone/lite-application": "dev-main as 1.326.1",
         "ecotone/lite-event-sourcing-starter": "^1.0",
-        "ecotone/pdo-event-sourcing": "dev-main as 1.999.999",
+        "ecotone/pdo-event-sourcing": "dev-main as 1.326.1",
         "ramsey/uuid": "^4.0"
     },
     "require-dev": {

--- a/quickstart-examples/WorkingWithAggregateDirectly/composer.json
+++ b/quickstart-examples/WorkingWithAggregateDirectly/composer.json
@@ -22,10 +22,10 @@
         }
     },
     "require": {
-        "ecotone/jms-converter": "dev-main as 1.326.1",
-        "ecotone/lite-application": "dev-main as 1.326.1",
+        "ecotone/jms-converter": "~1.326.1",
+        "ecotone/lite-application": "~1.326.1",
         "ecotone/lite-event-sourcing-starter": "^1.0",
-        "ecotone/pdo-event-sourcing": "dev-main as 1.326.1",
+        "ecotone/pdo-event-sourcing": "~1.326.1",
         "ramsey/uuid": "^4.0"
     },
     "require-dev": {

--- a/quickstart-examples/WorkingWithAggregateDirectly/composer.json
+++ b/quickstart-examples/WorkingWithAggregateDirectly/composer.json
@@ -22,10 +22,7 @@
         }
     },
     "require": {
-        "ecotone/jms-converter": "dev-main as 1.999.999",
-        "ecotone/lite-application": "dev-main as 1.999.999",
         "ecotone/lite-event-sourcing-starter": "^1.0",
-        "ecotone/pdo-event-sourcing": "dev-main as 1.999.999",
         "ramsey/uuid": "^4.0"
     },
     "require-dev": {

--- a/quickstart-examples/WorkingWithAggregateDirectly/composer.json
+++ b/quickstart-examples/WorkingWithAggregateDirectly/composer.json
@@ -22,7 +22,10 @@
         }
     },
     "require": {
+        "ecotone/jms-converter": "dev-main as 1.999.999",
+        "ecotone/lite-application": "dev-main as 1.999.999",
         "ecotone/lite-event-sourcing-starter": "^1.0",
+        "ecotone/pdo-event-sourcing": "dev-main as 1.999.999",
         "ramsey/uuid": "^4.0"
     },
     "require-dev": {


### PR DESCRIPTION
## Why is this change proposed?

Skips the skills marketplace publish, Discord notification, and tweet for pre-release tags. Pre-release tags validate a release candidate before it reaches users; the marketplace listing, Discord message, and tweet are public announcements meant only for finished, stable releases. Code packages and quickstart-examples still split for every tag, pre-release included.

### Before / after

| Release type | Code packages split | Skills package split | Discord + tweet |
|---|---|---|---|
| Stable (e.g. `1.327.0`) | ✅ | ✅ | ✅ |
| Pre-release (e.g. `2.0.0-beta.1`), before | ✅ | ✅ | ✅ |
| Pre-release (e.g. `2.0.0-beta.1`), after | ✅ | ❌ | ❌ |

A related problem surfaced while validating this change: quickstart-examples resolves the monorepo's own packages canonically from disk, and several examples depend on external starter packages that pin those same packages to `^1.0`. Once `main`'s declared version moved outside that range, every one of those examples became unresolvable — confirming the risk this PR addresses is real. Those examples now pin their local package requirements to a fixed alias, so resolution no longer depends on which version the monorepo currently advertises.

## Description of Changes

Gates three jobs in the release workflow behind a check for a `-` pre-release suffix in the pushed tag: the skills-package split step, the Discord notification job, and the tweet job. All other package splits (code packages, quickstart-examples) remain unconditional.

Also requires the affected local packages (`lite-application`, `jms-converter`, `amqp`, `dbal`, `pdo-event-sourcing`, `symfony-bundle`, `laravel`) directly in every quickstart example that uses a starter package, using the exact same `~$version` pattern `packages/*` already use to require each other — `update-required-packages.php` refreshes these the same way, at every release. Because these are ordinary version constraints rather than a path-repo-only workaround, they resolve correctly whether the path repository is present (in-monorepo) or not (the split, read-only repo, against real published releases) — no special-casing needed during the split.

## Pull Request Contribution Terms

- [x] I have read and agree to the contribution terms outlined in [CONTRIBUTING](https://github.com/ecotoneframework/ecotone-dev/blob/main/CONTRIBUTING.md).
